### PR TITLE
Fix binary move command in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -169,7 +169,7 @@ download_binary() {
     tar -xzf "${tmpdir}/${asset}" -C "$tmpdir"
 
     mkdir -p "$INSTALL_DIR"
-    mv "${tmpdir}/codebase-memory-mcp-${platform}" "${INSTALL_DIR}/${BINARY_NAME}"
+    mv "${tmpdir}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
     chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
 
     ok "Installed to ${INSTALL_DIR}/${BINARY_NAME}"


### PR DESCRIPTION
fixes:
```
curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/scripts/setup.sh | bash

codebase-memory-mcp installer

✓ Platform: darwin-arm64
✓ Download tool: curl

Fetching latest release...
✓ Latest release: v0.3.4
Downloading codebase-memory-mcp-darwin-arm64.tar.gz...
mv: /var/folders/bs/drf601ys62l3v5r38s0m7llw0000gq/T/tmp.w63Cy7yIrW/codebase-memory-mcp-darwin-arm64: No such file or directory
```
<img width="929" height="169" alt="image" src="https://github.com/user-attachments/assets/e36948d2-11fa-4fb7-8d78-c60f8509ccdf" />