### PR TITLE
Fix formatting in update message for current version

### DIFF
--- a/cmd/codebase-memory-mcp/update.go
+++ b/cmd/codebase-memory-mcp/update.go
@@ -54,7 +54,7 @@ func runUpdate(args []string) int {
 	}
 
 	if selfupdate.CompareVersions(latest, currentVersion) <= 0 {
-		fmt.Printf("Already up to date (v%s).\n", currentVersion)
+		fmt.Printf("Already up to date (%s).\n", currentVersion)
 		return 0
 	}
 


### PR DESCRIPTION
shows version with double v currently
```
codebase-memory-mcp v0.3.4 — checking for updates...
Already up to date (vv0.3.4).
```