### PR TITLE
fix(discover): skip .worktrees directory during indexing

### DIFF
--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -21,7 +21,7 @@ var IGNORE_PATTERNS = map[string]bool{
 	".npm": true, ".nyc_output": true, ".pnpm-store": true,
 	".pytest_cache": true, ".qdrant_code_embeddings": true,
 	".ruff_cache": true, ".svn": true, ".tmp": true, ".tox": true,
-	".venv": true, ".vs": true, ".vscode": true, ".yarn": true,
+	".venv": true, ".vs": true, ".vscode": true, ".worktrees": true, ".yarn": true,
 	"__pycache__": true, "bin": true, "bower_components": true,
 	"build": true, "coverage": true, "dist": true, "env": true,
 	"htmlcov": true, "node_modules": true, "obj": true, "out": true,

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -79,6 +79,37 @@ func TestDisambiguateM(t *testing.T) {
 	}
 }
 
+func TestDiscoverSkipsWorktrees(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a Go file at the root
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a .worktrees directory with a Go file inside
+	wtDir := filepath.Join(dir, ".worktrees", "feature-branch", "src")
+	if err := os.MkdirAll(wtDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtDir, "app.go"), []byte("package app\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	files, err := Discover(ctx, dir, nil)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file (skipping .worktrees), got %d", len(files))
+	}
+	if filepath.Base(files[0].Path) != "main.go" {
+		t.Errorf("expected main.go, got %s", files[0].Path)
+	}
+}
+
 func TestDiscoverCancellation(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

- Add `.worktrees` to `IGNORE_PATTERNS` in `internal/discover/discover.go`
- Add test case verifying `.worktrees/` contents are skipped during discovery

## Problem

Git worktrees (stored in `.worktrees/`) duplicate the entire source tree. When indexing a monorepo that uses worktrees for parallel development, the knowledge graph ends up with duplicate nodes and edges for every function, class, and route. This causes:

- Route searches returning 2-3x duplicate results
- `search_graph` results pointing to worktree copies instead of the main source
- Inflated node/edge counts (we saw 12,554 nodes where many were duplicates)

## Context

Discovered while evaluating codebase-memory-mcp on a TypeScript monorepo with active worktrees. Related to #31 (`.gitignore` support would also solve this, but `.worktrees` should be unconditionally skipped like `.git`).

## Test plan

- [x] `go test ./internal/discover/ -v -run TestDiscoverSkipsWorktrees` passes
- [x] Existing `TestDiscoverBasic` still passes