### PR TITLE
fix: respect explicit LIMIT in Cypher query_graph

### DIFF
--- a/internal/cypher/cypher_test.go
+++ b/internal/cypher/cypher_test.go
@@ -968,6 +968,33 @@ func TestEdgePropertyFilterRegex(t *testing.T) {
 	}
 }
 
+func TestApplyLimitRespectsExplicit(t *testing.T) {
+	rows := make([]map[string]any, 300)
+	for i := range rows {
+		rows[i] = map[string]any{"i": i}
+	}
+
+	got := applyLimit(rows, 0)
+	if len(got) != 200 {
+		t.Errorf("no limit: expected 200 rows, got %d", len(got))
+	}
+
+	got = applyLimit(rows, 50)
+	if len(got) != 50 {
+		t.Errorf("limit=50: expected 50 rows, got %d", len(got))
+	}
+
+	got = applyLimit(rows, 250)
+	if len(got) != 250 {
+		t.Errorf("limit=250: expected 250 rows, got %d", len(got))
+	}
+
+	got = applyLimit(rows, 500)
+	if len(got) != 300 {
+		t.Errorf("limit=500: expected 300 rows (all), got %d", len(got))
+	}
+}
+
 func TestEdgeBuiltinPropertyFilter(t *testing.T) {
 	s := setupTestStoreMultiEdge(t)
 	defer s.Close()

--- a/internal/cypher/executor.go
+++ b/internal/cypher/executor.go
@@ -1253,9 +1253,10 @@ func resolveOrderColumn(orderBy string, items []ReturnItem, cols []string) strin
 	return orderBy
 }
 
-// applyLimit enforces the LIMIT clause on result rows.
+// applyLimit caps result rows. Explicit LIMIT values are respected;
+// when no LIMIT is specified, maxResultRows (200) is used as default.
 func applyLimit(rows []map[string]any, limit int) []map[string]any {
-	if limit <= 0 || limit > maxResultRows {
+	if limit <= 0 {
 		limit = maxResultRows
 	}
 	if len(rows) > limit {


### PR DESCRIPTION
applyLimit() silently caps all query results to maxResultRows (200), even when the
  user provides a higher explicit LIMIT clause. 

A query like MATCH (f:Function) RETURN
  f.name LIMIT 500 still returns at most 200 rows with no warning. This also causes
  COUNT() aggregations to undercount when the pre-aggregation result set exceeds 200
  rows.