### PR TITLE
Fix build error with libgit2 -Wmissing-field-initializers

### DIFF
--- a/src/pipeline/pass_githistory.c
+++ b/src/pipeline/pass_githistory.c
@@ -168,7 +168,8 @@ static int parse_git_log(const char *repo_path, commit_t **out, int *out_count) 
 
         /* Diff parent_tree → tree to find changed files */
         git_diff *diff = NULL;
-        git_diff_options diff_opts = GIT_DIFF_OPTIONS_INIT;
+        git_diff_options diff_opts;
+        git_diff_options_init(&diff_opts, GIT_DIFF_OPTIONS_VERSION);
         if (git_diff_tree_to_tree(&diff, repo, parent_tree, tree, &diff_opts) == 0) {
             commit_t current = {0};
 


### PR DESCRIPTION
## Summary
- Build fails at `pass_githistory.c:171` with `-Werror,-Wmissing-field-initializers` because `GIT_DIFF_OPTIONS_INIT` macro doesn't list all struct fields
- Observed with libgit2 1.9.2 on macOS (Apple clang), but the macro has never listed all fields — any libgit2 version can trigger this depending on compiler warning settings
- Replace the macro with `git_diff_options_init()` runtime API, which properly initializes all fields
- `git_diff_options_init()` available since libgit2 0.28 (2019)

## Test plan
- [x] Verify `scripts/build.sh` completes without errors

Fixes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)