### PR TITLE
fix(cbm): replace O(N²) ts_node_child loop with O(N) TSTreeCursor in parse_generic_imports

### DIFF
--- a/internal/cbm/extract_imports.c
+++ b/internal/cbm/extract_imports.c
@@ -575,9 +575,18 @@ static void parse_lua_imports(CBMExtractCtx *ctx) {
 static void parse_generic_imports(CBMExtractCtx *ctx, const char *node_type) {
     CBMArena *a = ctx->arena;
 
-    uint32_t count = ts_node_child_count(ctx->root);
-    for (uint32_t i = 0; i < count; i++) {
-        TSNode node = ts_node_child(ctx->root, i);
+    /* Use TSTreeCursor for O(1)-per-step sibling traversal.
+     * ts_node_child(root, i) and ts_node_next_sibling() both call
+     * ts_node_child_with_descendant() internally, making naive iteration
+     * O(N²) on roots with thousands of children (e.g. generated .d.ts files).
+     * ts_tree_cursor_goto_next_sibling() maintains cursor state and is O(1). */
+    TSTreeCursor cursor = ts_tree_cursor_new(ctx->root);
+    if (!ts_tree_cursor_goto_first_child(&cursor)) {
+        ts_tree_cursor_delete(&cursor);
+        return;
+    }
+    do {
+        TSNode node = ts_tree_cursor_current_node(&cursor);
         if (strcmp(ts_node_type(node), node_type) != 0) {
             continue;
         }
@@ -616,7 +625,8 @@ static void parse_generic_imports(CBMExtractCtx *ctx, const char *node_type) {
                 }
             }
         }
-    }
+    } while (ts_tree_cursor_goto_next_sibling(&cursor));
+    ts_tree_cursor_delete(&cursor);
 }
 
 // --- Wolfram imports ---


### PR DESCRIPTION
Fixes #106.

## Problem

`parse_generic_imports` iterated top-level AST nodes with indexed `ts_node_child(root, i)`. This is O(i) per call internally (walks the child linked list from 0 to i via `ts_node_child_with_descendant`), making the loop O(N²) total. `ts_node_next_sibling()` has the same problem — it also calls `ts_node_child_with_descendant` internally.

On repos with generated TypeScript `.d.ts` files or large Perl files with 5,000–50,000 top-level AST nodes, this causes the indexer to spin at 100% CPU indefinitely.

## Fix

Replace with `TSTreeCursor`. `ts_tree_cursor_goto_next_sibling()` maintains traversal state and is O(1) per step. Only the iteration mechanism changes — the loop body logic is identical.

```c
// Before (O(N²))
uint32_t count = ts_node_child_count(ctx->root);
for (uint32_t i = 0; i < count; i++) {
    TSNode node = ts_node_child(ctx->root, i);
    ...
}

// After (O(N))
TSTreeCursor cursor = ts_tree_cursor_new(ctx->root);
if (ts_tree_cursor_goto_first_child(&cursor)) {
    do {
        TSNode node = ts_tree_cursor_current_node(&cursor);
        ...
    } while (ts_tree_cursor_goto_next_sibling(&cursor));
}
ts_tree_cursor_delete(&cursor);
```

## Test Results

- Unit tests: 2042/2042 passed
- Live test: a monorepo with 6 submodules (TypeScript, Perl, Java, HTML, CSS) that previously hung indefinitely now indexes in 71 seconds — 142,908 nodes, 218,685 edges