### PR TITLE
fix poll() / getline() buffered IO desync

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -2389,7 +2389,13 @@ int cbm_mcp_server_run(cbm_mcp_server_t *srv, FILE *in, FILE *out) {
             continue;
         }
 #else
-        int has_buffered = (in->_IO_read_ptr < in->_IO_read_end);  // glibc-specific
+#ifdef __GLIBC__
+        int has_buffered = (in->_IO_read_ptr < in->_IO_read_end);
+#else
+        /* macOS / BSD: use __srget-style check.
+         * fp->_r is the count of unread bytes in the buffer. */
+        int has_buffered = (in->_r > 0);
+#endif
         if (!has_buffered) {
             struct pollfd pfd = {.fd = fd, .events = POLLIN};
             int pr = poll(&pfd, 1, STORE_IDLE_TIMEOUT_S * 1000);


### PR DESCRIPTION
fixes #78 (at least for me, on Linux Mint 21.2, glibc version 2.35)
(perhaps also relevant to #77, which I referenced here by accident first, see further down in discussion for that)

PR description generated by AI (Claude Opus 4.6), with some human commentary at the bottom.

### Problem

Some MCP clients (OpenCode specifically) that send notifications/initialized and tools/list in rapid succession after receiving the initialize response (as the @modelcontextprotocol/sdk does by default) hit a 60-second stall. The server never responds to tools/list until the STORE_IDLE_TIMEOUT_S poll timeout expires, causing the client to report "Failed to get tools".

### Root cause

cbm_mcp_server_run() mixes poll() on the raw fd with getline() on the buffered FILE*. When getline() reads the initialize request, libc may read ahead and pull subsequent messages into its internal userspace buffer. On the next iteration, poll() checks the kernel pipe buffer — which is now empty — and blocks for 60 seconds, unaware that getline() already has data ready to return.

### Fix

Before calling poll(), check whether the FILE* has buffered data available. If it does, skip poll() and go straight to getline().

Confirmed with a bidirectional wire-logging proxy: tools/list response now arrives in <1ms instead of 60s. Tested with OpenCode (which uses the MCP SDK's StdioClientTransport). Claude Code and other JSONL clients are unaffected.

### Human commentary (from me)

Related issue: #78, probably #77 as well
See [issue comment](https://github.com/DeusData/codebase-memory-mcp/issues/78#issuecomment-4105772861) on #78 for more detail on the initial error investigation and fix. (later amended here for mac)