### PR TITLE
fix(store): set busy_timeout before journal_mode=WAL to prevent immediate SQLITE_BUSY

### DIFF
--- a/src/store/store.c
+++ b/src/store/store.c
@@ -229,15 +229,15 @@ static int configure_pragmas(cbm_store_t *s, bool in_memory) {
     if (in_memory) {
         rc = exec_sql(s, "PRAGMA synchronous = OFF;");
     } else {
+        rc = exec_sql(s, "PRAGMA busy_timeout = 10000;");
+        if (rc != CBM_STORE_OK) {
+            return rc;
+        }
         rc = exec_sql(s, "PRAGMA journal_mode = WAL;");
         if (rc != CBM_STORE_OK) {
             return rc;
         }
         rc = exec_sql(s, "PRAGMA synchronous = NORMAL;");
-        if (rc != CBM_STORE_OK) {
-            return rc;
-        }
-        rc = exec_sql(s, "PRAGMA busy_timeout = 10000;");
         if (rc != CBM_STORE_OK) {
             return rc;
         }


### PR DESCRIPTION
## Summary

- Reorders SQLite pragma execution in `configure_pragmas()` so `busy_timeout=10000` is set before `journal_mode=WAL`
- Eliminates the zero-timeout window between `sqlite3_open_v2` and the first pragma execution
- Ensures the WAL mode transition (which requires an exclusive lock) can retry for up to 10 seconds under lock contention

Fixes #116

## Root cause

`sqlite3_open_v2` returns a live connection with SQLite's default zero busy timeout. The prior ordering set `busy_timeout` as the *third* pragma — after `journal_mode=WAL`. Any lock contention during the WAL transition caused an immediate `SQLITE_BUSY` failure with no retry.

## Change

```c
// Before (store.c configure_pragmas):
exec_sql(s, "PRAGMA journal_mode = WAL;");
exec_sql(s, "PRAGMA synchronous = NORMAL;");
exec_sql(s, "PRAGMA busy_timeout = 10000;");

// After:
exec_sql(s, "PRAGMA busy_timeout = 10000;");
exec_sql(s, "PRAGMA journal_mode = WAL;");
exec_sql(s, "PRAGMA synchronous = NORMAL;");
```

## Test plan

- [ ] `scripts/test.sh` passes (all ~2040 cases)
- [ ] `scripts/lint.sh` passes (clang-tidy, cppcheck, clang-format)
- [ ] Manual: start MCP server indexing a large repo, then run a CLI query against the same project — no `SQLITE_BUSY` error