### PR TITLE
fix(mcp): fix use-after-free in handle_manage_adr get path

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -1897,6 +1897,7 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
     char adr_path[4096];
     snprintf(adr_path, sizeof(adr_path), "%s/adr.md", adr_dir);
 
+    char *adr_buf = NULL; /* freed after yy_doc_to_str — yyjson holds pointer, not copy */
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
     yyjson_mut_val *root_obj = yyjson_mut_obj(doc);
     yyjson_mut_doc_set_root(doc, root_obj);
@@ -1937,12 +1938,12 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
             (void)fseek(fp, 0, SEEK_END);
             long sz = ftell(fp);
             (void)fseek(fp, 0, SEEK_SET);
-            char *buf = malloc(sz + 1);
-            size_t n = fread(buf, 1, sz, fp);
-            buf[n] = '\0';
+            adr_buf = malloc(sz + 1);
+            size_t n = fread(adr_buf, 1, sz, fp);
+            adr_buf[n] = '\0';
             (void)fclose(fp);
-            yyjson_mut_obj_add_str(doc, root_obj, "content", buf);
-            free(buf);
+            yyjson_mut_obj_add_str(doc, root_obj, "content", adr_buf);
+            /* do NOT free adr_buf here: yyjson stores the pointer, not a copy */
         } else {
             yyjson_mut_obj_add_str(doc, root_obj, "content", "");
             yyjson_mut_obj_add_str(doc, root_obj, "status", "no_adr");
@@ -1959,6 +1960,7 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
 
     char *json = yy_doc_to_str(doc);
     yyjson_mut_doc_free(doc);
+    free(adr_buf); /* safe to free now — doc has been serialized */
     free(root_path);
     free(project);
     free(mode_str);

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -614,6 +614,63 @@ TEST(tool_manage_adr_no_project) {
     PASS();
 }
 
+/* Regression test for use-after-free in handle_manage_adr (get path).
+ * MUST FAIL before fix: free(buf) is called before yy_doc_to_str serializes doc,
+ * so result field is missing or contains garbage. MUST PASS after fix. */
+TEST(tool_manage_adr_get_with_existing_adr) {
+    /* Create a temp directory with .codebase-memory/adr.md */
+    char tmp_dir[256];
+    snprintf(tmp_dir, sizeof(tmp_dir), "/tmp/cbm-adr-test-XXXXXX");
+    if (!cbm_mkdtemp(tmp_dir)) {
+        PASS(); /* skip if mkdtemp fails */
+    }
+
+    char adr_dir[512];
+    snprintf(adr_dir, sizeof(adr_dir), "%s/.codebase-memory", tmp_dir);
+    cbm_mkdir(adr_dir);
+
+    char adr_path[512];
+    snprintf(adr_path, sizeof(adr_path), "%s/adr.md", adr_dir);
+    FILE *fp = fopen(adr_path, "w");
+    ASSERT_NOT_NULL(fp);
+    fputs("## PURPOSE\nTest ADR content for regression test.\n\n"
+          "## STACK\nC, SQLite.\n\n"
+          "## ARCHITECTURE\nMCP server.\n",
+          fp);
+    fclose(fp);
+
+    /* Create server and register the project */
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    cbm_store_upsert_project(st, "test-adr-uaf", tmp_dir);
+    cbm_mcp_server_set_project(srv, "test-adr-uaf");
+
+    /* Call manage_adr via full JSON-RPC path to exercise cbm_jsonrpc_format_response.
+     * The bug: free(buf) before yy_doc_to_str causes garbage JSON; format_response
+     * then fails to parse the result and omits the "result" field entirely. */
+    char *resp = cbm_mcp_server_handle(
+        srv, "{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"tools/call\","
+             "\"params\":{\"name\":\"manage_adr\","
+             "\"arguments\":{\"project\":\"test-adr-uaf\",\"mode\":\"get\"}}}");
+    ASSERT_NOT_NULL(resp);
+    /* JSON-RPC response must include a "result" field (absent when use-after-free) */
+    ASSERT_NOT_NULL(strstr(resp, "\"result\""));
+    /* ADR content must appear in response */
+    ASSERT_NOT_NULL(strstr(resp, "PURPOSE"));
+    /* Must not be an error */
+    ASSERT_NULL(strstr(resp, "isError"));
+    free(resp);
+
+    /* Clean up */
+    cbm_mcp_server_free(srv);
+    remove(adr_path);
+    rmdir(adr_dir);
+    rmdir(tmp_dir);
+    PASS();
+}
+
 TEST(tool_ingest_traces_basic) {
     cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
 
@@ -1273,6 +1330,7 @@ SUITE(mcp) {
     RUN_TEST(tool_search_code_no_project);
     RUN_TEST(tool_detect_changes_no_project);
     RUN_TEST(tool_manage_adr_no_project);
+    RUN_TEST(tool_manage_adr_get_with_existing_adr);
     RUN_TEST(tool_ingest_traces_basic);
     RUN_TEST(tool_ingest_traces_empty);
 


### PR DESCRIPTION
Fixes #125.

## Summary

- `yyjson_mut_obj_add_str` stores the raw pointer; `free(buf)` before `yy_doc_to_str` leaves a dangling pointer in the yyjson document
- `yy_doc_to_str` reads freed heap memory → garbage JSON
- `cbm_jsonrpc_format_response` fails to parse the result → `"result"` field is omitted from the JSON-RPC response
- MCP client hangs indefinitely waiting for a valid response

## Changes

- `src/mcp/mcp.c`: hoist `adr_buf` to function scope, remove premature `free`, defer `free(adr_buf)` until after `yy_doc_to_str` serializes the document (~7 lines)
- `tests/test_mcp.c`: add regression test `tool_manage_adr_get_with_existing_adr`

## Test plan

- [x] `tool_manage_adr_get_with_existing_adr` FAILS on `main` (before fix): `"result"` field absent from JSON-RPC response
- [x] `tool_manage_adr_get_with_existing_adr` PASSES after fix: response contains `"result"` with ADR content
- [x] `tool_manage_adr_no_project` (no-ADR path) still passes — unaffected code path
- [x] Full test suite: 2043 tests pass, 0 failures (ASan + UBSan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)