### PR TITLE
fix(cli): detect actual binary path at runtime in install command

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -15,6 +15,9 @@
 #include <signal.h>
 #include <unistd.h>
 #endif
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
 #include "foundation/compat_fs.h"
 
 #ifndef CBM_VERSION
@@ -2689,13 +2692,30 @@ int cbm_cmd_install(int argc, char **argv) {
     }
 #endif
 
-    /* Step 2: Binary path */
-    char self_path[1024];
+    /* Step 2: Binary path — detect actual location at runtime.
+     * install.ps1 places the binary in $LOCALAPPDATA/Programs/ but the old
+     * code hardcoded ~/.local/bin/, causing broken MCP configs on Windows.
+     * Use the same pattern as http_server.c:index_thread_fn(). */
+    char self_path[1024] = {0};
 #ifdef _WIN32
-    snprintf(self_path, sizeof(self_path), "%s/.local/bin/codebase-memory-mcp.exe", home);
+    GetModuleFileNameA(NULL, self_path, sizeof(self_path));
+    cbm_normalize_path_sep(self_path);
+#elif defined(__APPLE__)
+    uint32_t sp_sz = sizeof(self_path);
+    if (_NSGetExecutablePath(self_path, &sp_sz) != 0)
+        self_path[0] = '\0';
 #else
-    snprintf(self_path, sizeof(self_path), "%s/.local/bin/codebase-memory-mcp", home);
+    ssize_t sp_len = readlink("/proc/self/exe", self_path, sizeof(self_path) - 1);
+    if (sp_len > 0)
+        self_path[sp_len] = '\0';
 #endif
+    if (!self_path[0]) {
+#ifdef _WIN32
+        snprintf(self_path, sizeof(self_path), "%s/.local/bin/codebase-memory-mcp.exe", home);
+#else
+        snprintf(self_path, sizeof(self_path), "%s/.local/bin/codebase-memory-mcp", home);
+#endif
+    }
 
     /* Step 3: Install/refresh all agent configs */
     cbm_install_agent_configs(home, self_path, force, dry_run);


### PR DESCRIPTION
## Summary

`cbm_cmd_install()` hardcodes `~/.local/bin/codebase-memory-mcp.exe` as the binary path written into agent MCP configs. When installed via `install.ps1` (which targets `$LOCALAPPDATA/Programs/`), all agent configs point to a non-existent path — MCP fails for every agent.

Fixes #158

## Change

Single file: `src/cli/cli.c`

Use runtime binary path detection — the same pattern already in `http_server.c:index_thread_fn()` (line 594):
- Windows: `GetModuleFileNameA()` + `cbm_normalize_path_sep()`
- macOS: `_NSGetExecutablePath()`
- Linux: `readlink("/proc/self/exe")`
- Fallback: `~/.local/bin/` (preserves current behavior if detection fails)

Added `#include <mach-o/dyld.h>` for macOS.

## Testing

Runtime path detection is hard to unit-test (it depends on the actual binary location). The existing smoke tests (`smoke-test.sh`) cover `install -y` end-to-end and will verify the configs point to a valid path.

Manual verification on Windows:
```powershell
# Before fix: ~/.claude/.mcp.json → "C:/Users/<user>/.local/bin/codebase-memory-mcp.exe" (does not exist)
# After fix:  ~/.claude/.mcp.json → "C:/Users/<user>/AppData/Local/Programs/codebase-memory-mcp/codebase-memory-mcp.exe" (exists)
```