### PR TITLE
feat: add Kiro CLI support (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ High-quality parsing through [tree-sitter](https://tree-sitter.github.io/tree-si
 - **Plug and play** — single static binary for macOS (arm64/amd64), Linux (arm64/amd64), and Windows (amd64). No Docker, no runtime dependencies, no API keys. Download → `install` → restart agent → done.
 - **66 languages** — vendored tree-sitter grammars compiled into the binary. Nothing to install, nothing that breaks.
 - **120x fewer tokens** — 5 structural queries: ~3,400 tokens vs ~412,000 via file-by-file search. One graph query replaces dozens of grep/read cycles.
-- **10 agents, one command** — `install` auto-detects Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, and OpenClaw — configures MCP entries, instruction files, and pre-tool hooks for each.
+- **11 agents, one command** — `install` auto-detects Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, and Kiro — configures MCP entries, instruction files, and pre-tool hooks for each.
 - **Built-in graph visualization** — 3D interactive UI at `localhost:9749` (optional UI binary variant).
 - **Infrastructure-as-code indexing** — Dockerfiles, Kubernetes manifests, and Kustomize overlays indexed as graph nodes with cross-references. `Resource` nodes for K8s kinds, `Module` nodes for Kustomize overlays with `IMPORTS` edges to referenced resources.
 - **14 MCP tools** — search, trace, architecture, impact analysis, Cypher queries, dead code detection, cross-service HTTP linking, ADR management, and more.
@@ -266,6 +266,7 @@ Restart your agent. Verify with `/mcp` — you should see `codebase-memory-mcp` 
 | KiloCode | `mcp_settings.json` | `~/.kilocode/rules/` | — |
 | VS Code | `Code/User/mcp.json` | — | — |
 | OpenClaw | `openclaw.json` | — | — |
+| Kiro | `.kiro/settings/mcp.json` | — | — |
 
 **Hooks** are advisory (exit code 0) — they remind agents to prefer MCP graph tools when they reach for grep/glob/read, without blocking the tool call.
 

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -950,6 +950,12 @@ cbm_detected_agents_t cbm_detect_agents(const char *home_dir) {
         agents.openclaw = true;
     }
 
+    /* Kiro: ~/.kiro/ */
+    snprintf(path, sizeof(path), "%s/.kiro", home_dir);
+    if (stat(path, &st) == 0 && S_ISDIR(st.st_mode)) {
+        agents.kiro = true;
+    }
+
     return agents;
 }
 
@@ -2420,9 +2426,12 @@ static void cbm_install_agent_configs(const char *home, const char *binary_path,
     if (agents.openclaw) {
         printf(" OpenClaw");
     }
+    if (agents.kiro) {
+        printf(" Kiro");
+    }
     if (!agents.claude_code && !agents.codex && !agents.gemini && !agents.zed && !agents.opencode &&
         !agents.antigravity && !agents.aider && !agents.kilocode && !agents.vscode &&
-        !agents.openclaw) {
+        !agents.openclaw && !agents.kiro) {
         printf(" (none)");
     }
     printf("\n\n");
@@ -2612,6 +2621,21 @@ static void cbm_install_agent_configs(const char *home, const char *binary_path,
             cbm_install_editor_mcp(binary_path, config_path);
         }
         printf("  mcp: %s\n", config_path);
+    }
+
+    /* Kiro */
+    if (agents.kiro) {
+        char mcp_path[1024];
+        snprintf(mcp_path, sizeof(mcp_path), "%s/.kiro/settings/mcp.json", home);
+        if (!dry_run) {
+            /* Ensure ~/.kiro/settings/ directory exists */
+            char settings_dir[1024];
+            snprintf(settings_dir, sizeof(settings_dir), "%s/.kiro/settings", home);
+            cbm_mkdir_p(settings_dir, 0755);
+            cbm_install_editor_mcp(binary_path, mcp_path);
+        }
+        printf("Kiro:\n");
+        printf("  mcp: %s\n", mcp_path);
     }
 }
 
@@ -2902,6 +2926,15 @@ int cbm_cmd_uninstall(int argc, char **argv) {
             cbm_remove_editor_mcp(config_path);
         }
         printf("OpenClaw: removed MCP config entry\n");
+    }
+
+    if (agents.kiro) {
+        char mcp_path[1024];
+        snprintf(mcp_path, sizeof(mcp_path), "%s/.kiro/settings/mcp.json", home);
+        if (!dry_run) {
+            cbm_remove_editor_mcp(mcp_path);
+        }
+        printf("Kiro: removed MCP config entry\n");
     }
 
     /* Step 2: Remove indexes */

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -118,6 +118,7 @@ typedef struct {
     bool antigravity; /* ~/.gemini/antigravity/ exists */
     bool aider;       /* aider on PATH */
     bool kilocode;    /* KiloCode globalStorage dir exists */
+    bool kiro;        /* ~/.kiro/ exists */
     bool vscode;      /* VS Code User config dir exists */
     bool openclaw;    /* ~/.openclaw/ exists */
 } cbm_detected_agents_t;

--- a/src/main.c
+++ b/src/main.c
@@ -147,7 +147,7 @@ static void print_help(void) {
     printf("  --ui=false   Disable HTTP graph visualization (persisted)\n");
     printf("  --port=N     Set UI port (default 9749, persisted)\n");
     printf("\nSupported agents (auto-detected):\n");
-    printf("  Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode\n");
+    printf("  Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, Kiro\n");
     printf("\nTools: index_repository, search_graph, query_graph, trace_path,\n");
     printf("  get_code_snippet, get_graph_schema, get_architecture, search_code,\n");
     printf("  list_projects, delete_project, index_status, detect_changes,\n");

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -1493,6 +1493,23 @@ TEST(cli_detect_agents_finds_kilocode) {
     PASS();
 }
 
+TEST(cli_detect_agents_finds_kiro) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-detect-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        SKIP("cbm_mkdtemp failed");
+
+    char dir[512];
+    snprintf(dir, sizeof(dir), "%s/.kiro", tmpdir);
+    test_mkdirp(dir);
+
+    cbm_detected_agents_t agents = cbm_detect_agents(tmpdir);
+    ASSERT_TRUE(agents.kiro);
+
+    test_rmdir_r(tmpdir);
+    PASS();
+}
+
 TEST(cli_detect_agents_none_found) {
     char tmpdir[256];
     snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-detect-XXXXXX");
@@ -1509,6 +1526,7 @@ TEST(cli_detect_agents_none_found) {
     ASSERT_FALSE(agents.zed);
     ASSERT_FALSE(agents.antigravity);
     ASSERT_FALSE(agents.kilocode);
+    ASSERT_FALSE(agents.kiro);
 
     rmdir(tmpdir);
     PASS();
@@ -2423,6 +2441,7 @@ SUITE(cli) {
     RUN_TEST(cli_detect_agents_finds_zed);
     RUN_TEST(cli_detect_agents_finds_antigravity);
     RUN_TEST(cli_detect_agents_finds_kilocode);
+    RUN_TEST(cli_detect_agents_finds_kiro);
     RUN_TEST(cli_detect_agents_none_found);
 
     /* Codex MCP config upsert (3 tests — group B) */


### PR DESCRIPTION
Closes #96

## Summary

Adds Kiro CLI as a detected and auto-configured coding agent, following the existing editor integration patterns. Kiro uses `~/.kiro/settings/mcp.json` with the standard `mcpServers` format.

## Changes

- `src/cli/cli.h`: Added `bool kiro` to `cbm_detected_agents_t` struct
- `src/cli/cli.c`: Detection (`~/.kiro/` dir check), install (`cbm_install_editor_mcp` to `~/.kiro/settings/mcp.json`), uninstall, and print support
- `src/main.c`: Added "Kiro" to help text agent list
- `tests/test_cli.c`: Added `cli_detect_agents_finds_kiro` test and updated `cli_detect_agents_none_found`

## Config format

Kiro CLI uses the standard `mcpServers` format at `~/.kiro/settings/mcp.json`:
```json
{
  "mcpServers": {
    "codebase-memory-mcp": {
      "command": "/path/to/codebase-memory-mcp"
    }
  }
}
```

Source: https://kiro.dev/docs/cli/mcp/

## Test results

**Build:** Compiles cleanly on macOS (Apple Clang, arm64)

**Test suite:** 2741 passed (including new Kiro detection test), 1 pre-existing flaky timing test (`test_incremental.c:371`)

**Manual verification** (created temporary `~/.kiro/` directory, tested full lifecycle, cleaned up):

| Test | Result |
|------|--------|
| Detection (`install --dry-run`) | "Kiro" appears in detected agents list with correct path `~/.kiro/settings/mcp.json` |
| Install (actual) | `~/.kiro/settings/` directory created, `mcp.json` written with correct `mcpServers` JSON and binary path |
| Uninstall | `codebase-memory-mcp` entry removed from `mcpServers`, file preserved with empty object |
| No `~/.kiro/` present | Kiro not detected, silently skipped (no error) |

Generated with [agent-team](https://github.com/dLo999/agent-team) via /issue
