### PR TITLE
feat: include property definitions per label in get_graph_schema (#179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ codebase-memory-mcp cli --raw search_graph '{"label": "Function"}' | jq '.result
 | `trace_call_path` | BFS traversal — who calls a function and what it calls. Depth 1-5. |
 | `detect_changes` | Map git diff to affected symbols + blast radius with risk classification. |
 | `query_graph` | Execute Cypher-like graph queries (read-only). |
-| `get_graph_schema` | Node/edge counts, relationship patterns. Run this first. |
+| `get_graph_schema` | Node/edge counts, relationship patterns, property definitions per label. Run this first. |
 | `get_code_snippet` | Read source code for a function by qualified name. |
 | `get_architecture` | Codebase overview: languages, packages, routes, hotspots, clusters, ADR. |
 | `search_code` | Grep-like text search within indexed project files. |

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -890,6 +890,11 @@ static char *handle_get_graph_schema(cbm_mcp_server_t *srv, const char *args) {
         yyjson_mut_val *lbl = yyjson_mut_obj(doc);
         yyjson_mut_obj_add_str(doc, lbl, "label", schema.node_labels[i].label);
         yyjson_mut_obj_add_int(doc, lbl, "count", schema.node_labels[i].count);
+        yyjson_mut_val *props = yyjson_mut_arr(doc);
+        for (int j = 0; j < schema.node_labels[i].property_count; j++) {
+            yyjson_mut_arr_add_str(doc, props, schema.node_labels[i].properties[j]);
+        }
+        yyjson_mut_obj_add_val(doc, lbl, "properties", props);
         yyjson_mut_arr_add_val(labels, lbl);
     }
     yyjson_mut_obj_add_val(doc, root, "node_labels", labels);
@@ -899,6 +904,11 @@ static char *handle_get_graph_schema(cbm_mcp_server_t *srv, const char *args) {
         yyjson_mut_val *typ = yyjson_mut_obj(doc);
         yyjson_mut_obj_add_str(doc, typ, "type", schema.edge_types[i].type);
         yyjson_mut_obj_add_int(doc, typ, "count", schema.edge_types[i].count);
+        yyjson_mut_val *eprops = yyjson_mut_arr(doc);
+        for (int j = 0; j < schema.edge_types[i].property_count; j++) {
+            yyjson_mut_arr_add_str(doc, eprops, schema.edge_types[i].properties[j]);
+        }
+        yyjson_mut_obj_add_val(doc, typ, "properties", eprops);
         yyjson_mut_arr_add_val(types, typ);
     }
     yyjson_mut_obj_add_val(doc, root, "edge_types", types);

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -2480,11 +2480,55 @@ int cbm_store_get_schema(cbm_store_t *s, const char *project, cbm_schema_info_t 
             }
             arr[n].label = heap_strdup((const char *)sqlite3_column_text(stmt, 0));
             arr[n].count = sqlite3_column_int(stmt, 1);
+            arr[n].properties = NULL;
+            arr[n].property_count = 0;
             n++;
         }
         sqlite3_finalize(stmt);
         out->node_labels = arr;
         out->node_label_count = n;
+    }
+
+    /* Node label property keys: base columns + distinct JSON property keys per label */
+    {
+        /* Base columns always present on every node */
+        static const char *node_base_cols[] = {
+            "name", "qualified_name", "file_path", "start_line", "end_line"
+        };
+        static const int node_base_col_count = 5;
+
+        const char *prop_sql =
+            "SELECT DISTINCT je.key "
+            "FROM nodes, json_each(nodes.properties) AS je "
+            "WHERE nodes.project = ?1 AND nodes.label = ?2 "
+            "  AND nodes.properties != '{}' "
+            "ORDER BY je.key "
+            "LIMIT 50;";
+
+        for (int i = 0; i < out->node_label_count; i++) {
+            /* Count: base + JSON keys (up to 50) */
+            int pcap = node_base_col_count + 50;
+            char **props = malloc(pcap * sizeof(char *));
+            int pn = 0;
+
+            /* Prepend base columns */
+            for (int b = 0; b < node_base_col_count; b++) {
+                props[pn++] = heap_strdup(node_base_cols[b]);
+            }
+
+            /* Append distinct JSON property keys */
+            sqlite3_stmt *pstmt = NULL;
+            sqlite3_prepare_v2(s->db, prop_sql, -1, &pstmt, NULL);
+            bind_text(pstmt, 1, project);
+            bind_text(pstmt, 2, out->node_labels[i].label);
+            while (sqlite3_step(pstmt) == SQLITE_ROW && pn < pcap) {
+                props[pn++] = heap_strdup((const char *)sqlite3_column_text(pstmt, 0));
+            }
+            sqlite3_finalize(pstmt);
+
+            out->node_labels[i].properties = props;
+            out->node_labels[i].property_count = pn;
+        }
     }
 
     /* Edge types */
@@ -2505,11 +2549,52 @@ int cbm_store_get_schema(cbm_store_t *s, const char *project, cbm_schema_info_t 
             }
             arr[n].type = heap_strdup((const char *)sqlite3_column_text(stmt, 0));
             arr[n].count = sqlite3_column_int(stmt, 1);
+            arr[n].properties = NULL;
+            arr[n].property_count = 0;
             n++;
         }
         sqlite3_finalize(stmt);
         out->edge_types = arr;
         out->edge_type_count = n;
+    }
+
+    /* Edge type property keys: base columns + distinct JSON property keys per type */
+    {
+        /* Base columns always present on every edge */
+        static const char *edge_base_cols[] = {"source_id", "target_id"};
+        static const int edge_base_col_count = 2;
+
+        const char *prop_sql =
+            "SELECT DISTINCT je.key "
+            "FROM edges, json_each(edges.properties) AS je "
+            "WHERE edges.project = ?1 AND edges.type = ?2 "
+            "  AND edges.properties != '{}' "
+            "ORDER BY je.key "
+            "LIMIT 50;";
+
+        for (int i = 0; i < out->edge_type_count; i++) {
+            int pcap = edge_base_col_count + 50;
+            char **props = malloc(pcap * sizeof(char *));
+            int pn = 0;
+
+            /* Prepend base columns */
+            for (int b = 0; b < edge_base_col_count; b++) {
+                props[pn++] = heap_strdup(edge_base_cols[b]);
+            }
+
+            /* Append distinct JSON property keys */
+            sqlite3_stmt *pstmt = NULL;
+            sqlite3_prepare_v2(s->db, prop_sql, -1, &pstmt, NULL);
+            bind_text(pstmt, 1, project);
+            bind_text(pstmt, 2, out->edge_types[i].type);
+            while (sqlite3_step(pstmt) == SQLITE_ROW && pn < pcap) {
+                props[pn++] = heap_strdup((const char *)sqlite3_column_text(pstmt, 0));
+            }
+            sqlite3_finalize(pstmt);
+
+            out->edge_types[i].properties = props;
+            out->edge_types[i].property_count = pn;
+        }
     }
 
     return CBM_STORE_OK;
@@ -2521,11 +2606,19 @@ void cbm_store_schema_free(cbm_schema_info_t *out) {
     }
     for (int i = 0; i < out->node_label_count; i++) {
         free((void *)out->node_labels[i].label);
+        for (int j = 0; j < out->node_labels[i].property_count; j++) {
+            free(out->node_labels[i].properties[j]);
+        }
+        free(out->node_labels[i].properties);
     }
     free(out->node_labels);
 
     for (int i = 0; i < out->edge_type_count; i++) {
         free((void *)out->edge_types[i].type);
+        for (int j = 0; j < out->edge_types[i].property_count; j++) {
+            free(out->edge_types[i].properties[j]);
+        }
+        free(out->edge_types[i].properties);
     }
     free(out->edge_types);
 

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -2516,15 +2516,16 @@ int cbm_store_get_schema(cbm_store_t *s, const char *project, cbm_schema_info_t 
                 props[pn++] = heap_strdup(node_base_cols[b]);
             }
 
-            /* Append distinct JSON property keys */
+            /* Append distinct JSON property keys (capped at 50 to bound allocation) */
             sqlite3_stmt *pstmt = NULL;
-            sqlite3_prepare_v2(s->db, prop_sql, -1, &pstmt, NULL);
-            bind_text(pstmt, 1, project);
-            bind_text(pstmt, 2, out->node_labels[i].label);
-            while (sqlite3_step(pstmt) == SQLITE_ROW && pn < pcap) {
-                props[pn++] = heap_strdup((const char *)sqlite3_column_text(pstmt, 0));
+            if (sqlite3_prepare_v2(s->db, prop_sql, -1, &pstmt, NULL) == SQLITE_OK) {
+                bind_text(pstmt, 1, project);
+                bind_text(pstmt, 2, out->node_labels[i].label);
+                while (sqlite3_step(pstmt) == SQLITE_ROW && pn < pcap) {
+                    props[pn++] = heap_strdup((const char *)sqlite3_column_text(pstmt, 0));
+                }
+                sqlite3_finalize(pstmt);
             }
-            sqlite3_finalize(pstmt);
 
             out->node_labels[i].properties = props;
             out->node_labels[i].property_count = pn;
@@ -2582,15 +2583,16 @@ int cbm_store_get_schema(cbm_store_t *s, const char *project, cbm_schema_info_t 
                 props[pn++] = heap_strdup(edge_base_cols[b]);
             }
 
-            /* Append distinct JSON property keys */
+            /* Append distinct JSON property keys (capped at 50 to bound allocation) */
             sqlite3_stmt *pstmt = NULL;
-            sqlite3_prepare_v2(s->db, prop_sql, -1, &pstmt, NULL);
-            bind_text(pstmt, 1, project);
-            bind_text(pstmt, 2, out->edge_types[i].type);
-            while (sqlite3_step(pstmt) == SQLITE_ROW && pn < pcap) {
-                props[pn++] = heap_strdup((const char *)sqlite3_column_text(pstmt, 0));
+            if (sqlite3_prepare_v2(s->db, prop_sql, -1, &pstmt, NULL) == SQLITE_OK) {
+                bind_text(pstmt, 1, project);
+                bind_text(pstmt, 2, out->edge_types[i].type);
+                while (sqlite3_step(pstmt) == SQLITE_ROW && pn < pcap) {
+                    props[pn++] = heap_strdup((const char *)sqlite3_column_text(pstmt, 0));
+                }
+                sqlite3_finalize(pstmt);
             }
-            sqlite3_finalize(pstmt);
 
             out->edge_types[i].properties = props;
             out->edge_types[i].property_count = pn;

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -163,11 +163,15 @@ typedef struct {
 typedef struct {
     const char *label;
     int count;
+    char **properties;    /* distinct property keys for this label (base + JSON) */
+    int property_count;
 } cbm_label_count_t;
 
 typedef struct {
     const char *type;
     int count;
+    char **properties;    /* distinct property keys for this edge type (base + JSON) */
+    int property_count;
 } cbm_type_count_t;
 
 typedef struct {


### PR DESCRIPTION
Closes #179

## Summary

Adds property definitions per node label and edge type to `get_graph_schema` output. Users can now discover which properties are available for Cypher queries without trial and error.

## Changes

- `src/store/store.h`: Extended `cbm_label_count_t` and `cbm_type_count_t` with `properties` / `property_count` fields
- `src/store/store.c`: Added per-label/type property key queries using `json_each()` in `cbm_store_get_schema()`, with proper cleanup in `cbm_store_schema_free()`
- `src/mcp/mcp.c`: Emits `"properties"` array in JSON output for both node labels and edge types

## Output format (before → after)

**Before:**
```json
{"label": "Function", "count": 13531}
```

**After:**
```json
{"label": "Function", "count": 13531, "properties": ["name", "qualified_name", "file_path", "start_line", "end_line", "complexity", "docstring", "is_entry_point", "is_exported", "is_test", "lines", "param_names", "param_types", "return_type", "signature"]}
```

## How it works

- Base columns (`name`, `qualified_name`, `file_path`, `start_line`, `end_line`) are always listed first — these exist on every node
- JSON property keys are discovered per label via `SELECT DISTINCT je.key FROM nodes, json_each(nodes.properties) AS je WHERE label = ?` (limited to 50 keys)
- Edge types similarly list base columns (`source_id`, `target_id`) plus JSON property keys
- Existing output fields (`label`, `count`, `type`) are unchanged — fully backward compatible

## Test results

**Build:** Compiles cleanly on macOS (Apple Clang, arm64)

**Test suite:** 2741 passed, 0 failed (confirmed flake in `test_pipeline.c:2672` did not reproduce on rerun; passes on main intermittently too)

**Behavioral verification** (ran `cli get_graph_schema` against real indexed project — codebase-memory-mcp itself, 23,736 nodes, 14 labels):

| Label | Nodes | Base cols | JSON props discovered |
|-------|-------|-----------|----------------------|
| Function | 13,531 | 5 | complexity, docstring, is_entry_point, is_exported, is_test, lines, param_names, param_types, return_type, signature |
| Field | 6,444 | 5 | complexity, is_entry_point, is_exported, is_test, lines, parent_class, return_type |
| Class | 1,035 | 5 | base_classes, complexity, docstring, is_entry_point, is_exported, is_test, lines |
| File | 697 | 5 | extension |
| Folder | 194 | 5 | *(none — all properties are `{}`)* |
| Project | 1 | 5 | *(none — all properties are `{}`)* |

| Edge type | Edges | Base cols | JSON props discovered |
|-----------|-------|-----------|----------------------|
| USAGE | 15,263 | 2 | callee |
| CONFIGURES | 51 | 2 | args, callee, confidence, config_key, key, ref_path, strategy |
| DEFINES | 22,843 | 2 | *(none)* |

**Edge case: empty properties** — Labels where every node has `properties = '{}'` (Folder, Project) correctly return only the 5 base columns with 0 JSON properties. Same for edge types with no JSON properties (DEFINES, CALLS).

**Performance:** 59ms total for 23K nodes across 14 labels — negligible overhead from the `json_each()` queries.

Generated with [agent-team](https://github.com/dLo999/agent-team) via /issue
