### PR TITLE
ci(deusdata-codebase-memory-mcp): add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,28 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@1c30734416d9b05948ccd7f4b3cf60baada87e9e
+        with:
+          mode: validate


### PR DESCRIPTION
This PR adds a small CI workflow for skill metadata validation.

- CLI tool with `cli search_graph` subcommand for graph queries
- Single binary that persists data to `~/.cache/codebase-memory-mcp/` via SQLite
- No external infrastructure required beyond the binary itself

**Scope:** This PR adds one workflow in `.github/workflows/` that runs the HOL skill validator in validate mode. It checks schema and trust signals only, remains validate-only, and makes no changes to the runtime code.

Happy to rename the workflow file or adjust the skill directory path if you prefer a different location.