### PR TITLE
fix(mcp): cap search_graph default limit to 200 (was 500K)

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -290,7 +290,7 @@ static const tool_def_t TOOLS[] = {
      "that score well on ALL keywords. Requires moderate/full index mode. Results appear in the "
      "'semantic_results' field (separate from 'results').\"},\"limit\":{\"type\":"
      "\"integer\",\"description\":\"Max results. Default: "
-     "unlimited\"},\"offset\":{\"type\":\"integer\",\"default\":0}},\"required\":[\"project\"]}"},
+     "200\"},\"offset\":{\"type\":\"integer\",\"default\":0}},\"required\":[\"project\"]}"},
 
     {"query_graph",
      "Execute a Cypher query against the knowledge graph for complex multi-hop patterns, "
@@ -1341,7 +1341,8 @@ static char *handle_search_graph(cbm_mcp_server_t *srv, const char *args) {
     char *relationship = cbm_mcp_get_string_arg(args, "relationship");
     bool exclude_entry_points = cbm_mcp_get_bool_arg(args, "exclude_entry_points");
     bool include_connected = cbm_mcp_get_bool_arg(args, "include_connected");
-    int limit = cbm_mcp_get_int_arg(args, "limit", MCP_HALF_SEC_US);
+    enum { SEARCH_DEFAULT_LIMIT = 200 };
+    int limit = cbm_mcp_get_int_arg(args, "limit", SEARCH_DEFAULT_LIMIT);
     int offset = cbm_mcp_get_int_arg(args, "offset", 0);
     int min_degree = cbm_mcp_get_int_arg(args, "min_degree", CBM_NOT_FOUND);
     int max_degree = cbm_mcp_get_int_arg(args, "max_degree", CBM_NOT_FOUND);

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -2301,7 +2301,8 @@ int cbm_store_search(cbm_store_t *s, const cbm_search_params_t *params, cbm_sear
     snprintf(count_sql, sizeof(count_sql), "SELECT COUNT(*) FROM (%s)", sql);
 
     /* Add ORDER BY + LIMIT */
-    int limit = params->limit > 0 ? params->limit : ST_HALF_SEC;
+    enum { ST_DEFAULT_SEARCH_LIMIT = 200 };
+    int limit = params->limit > 0 ? params->limit : ST_DEFAULT_SEARCH_LIMIT;
     int offset = params->offset;
     const char *name_col = has_degree_filter ? "name" : "n.name";
     char order_limit[CBM_SZ_128];


### PR DESCRIPTION
## Problem

`search_graph` with a broad `file_pattern` (e.g. `**/ads/**`) returns output that exceeds LLM tool result limits. In my case, querying a 12K-node project returned **3,358,396 characters**, which Claude Code couldn't process:

```
search_graph (MCP)(project: "Users-amitbhalla-Downloads-myndintegrated", file_pattern: "**/ads/**")

Error: result (3,58,396 characters) exceeds maximum allowed tokens.
```

## Root cause

The default `limit` for the regex/file_pattern search path uses `MCP_HALF_SEC_US` (500,000), which appears to be a microsecond timeout constant that was accidentally used as a row count. When no explicit `limit` is passed, the query returns up to 500K rows, serializing all of them into the JSON response.

- `src/mcp/mcp.c:1344`: `cbm_mcp_get_int_arg(args, "limit", MCP_HALF_SEC_US)` (500,000)
- `src/store/store.c:2304`: fallback to `ST_HALF_SEC` (also 500,000)
- Tool description says "Default: unlimited"

## Fix

Changed the default limit to **200** in both the MCP handler and the store layer. Updated the tool description to reflect this.

**Before:** 1,287 matching nodes, all returned, 3.3M characters output
**After:** 1,287 total (reported in `total` field), 200 returned, 57K characters output, `has_more: true`

Pagination with `offset` and `limit` continues to work as expected for callers that need more results.

## Changes

| File | Change |
|------|--------|
| `src/mcp/mcp.c` | Default limit 500,000 -> 200 in `handle_search_graph` |
| `src/store/store.c` | Fallback limit `ST_HALF_SEC` -> 200 in `cbm_store_search` |
| `src/mcp/mcp.c` | Tool description: "Default: unlimited" -> "Default: 200" |

## Test plan

- [x] Build succeeds with `make -f Makefile.cbm cbm`
- [x] `search_graph` with broad `file_pattern` returns 200 results (57K chars) instead of all matches (3.3M chars)
- [x] Response includes `total: 1287`, `has_more: true` for pagination
- [x] `list_projects` and `--help` work correctly
- [ ] Explicit `limit` param still overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)