### PR TITLE
fix: GitHub Actions shell injection in _build.yml (#247)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -52,20 +52,41 @@ jobs:
           node-version: "22"
 
       - name: Build standard binary
-        run: scripts/build.sh ${{ inputs.version && format('--version {0}', inputs.version) || '' }} CC=${{ matrix.cc }} CXX=${{ matrix.cxx }}
+        env:
+          VERSION: ${{ inputs.version }}
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
+        run: |
+          if [ -n "$VERSION" ]; then
+            scripts/build.sh --version "$VERSION" "CC=$CC" "CXX=$CXX"
+          else
+            scripts/build.sh "CC=$CC" "CXX=$CXX"
+          fi
 
       - name: Ad-hoc sign macOS binary
         if: startsWith(matrix.os, 'macos')
         run: codesign --sign - --force build/c/codebase-memory-mcp
 
       - name: Archive standard binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
         run: |
           cp LICENSE install.sh build/c/
-          tar -czf codebase-memory-mcp-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz \
+          tar -czf "codebase-memory-mcp-${GOOS}-${GOARCH}.tar.gz" \
             -C build/c codebase-memory-mcp LICENSE install.sh
 
       - name: Build UI binary
-        run: scripts/build.sh --with-ui ${{ inputs.version && format('--version {0}', inputs.version) || '' }} CC=${{ matrix.cc }} CXX=${{ matrix.cxx }}
+        env:
+          VERSION: ${{ inputs.version }}
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
+        run: |
+          if [ -n "$VERSION" ]; then
+            scripts/build.sh --with-ui --version "$VERSION" "CC=$CC" "CXX=$CXX"
+          else
+            scripts/build.sh --with-ui "CC=$CC" "CXX=$CXX"
+          fi
 
       - name: Ad-hoc sign macOS UI binary
         if: startsWith(matrix.os, 'macos')
@@ -76,9 +97,12 @@ jobs:
         run: scripts/security-ui.sh
 
       - name: Archive UI binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
         run: |
           cp LICENSE install.sh build/c/
-          tar -czf codebase-memory-mcp-ui-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz \
+          tar -czf "codebase-memory-mcp-ui-${GOOS}-${GOARCH}.tar.gz" \
             -C build/c codebase-memory-mcp LICENSE install.sh
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -108,7 +132,14 @@ jobs:
 
       - name: Build standard binary
         shell: msys2 {0}
-        run: scripts/build.sh ${{ inputs.version && format('--version {0}', inputs.version) || '' }} CC=clang CXX=clang++
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$VERSION" ]; then
+            scripts/build.sh --version "$VERSION" CC=clang CXX=clang++
+          else
+            scripts/build.sh CC=clang CXX=clang++
+          fi
 
       - name: Archive standard binary
         shell: msys2 {0}
@@ -120,7 +151,14 @@ jobs:
 
       - name: Build UI binary
         shell: msys2 {0}
-        run: scripts/build.sh --with-ui ${{ inputs.version && format('--version {0}', inputs.version) || '' }} CC=clang CXX=clang++
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$VERSION" ]; then
+            scripts/build.sh --with-ui --version "$VERSION" CC=clang CXX=clang++
+          else
+            scripts/build.sh --with-ui CC=clang CXX=clang++
+          fi
 
       - name: Archive UI binary
         shell: msys2 {0}
@@ -159,7 +197,14 @@ jobs:
           node-version: "22"
 
       - name: Build standard binary (static)
-        run: scripts/build.sh ${{ inputs.version && format('--version {0}', inputs.version) || '' }} CC=gcc CXX=g++ STATIC=1
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$VERSION" ]; then
+            scripts/build.sh --version "$VERSION" CC=gcc CXX=g++ STATIC=1
+          else
+            scripts/build.sh CC=gcc CXX=g++ STATIC=1
+          fi
 
       - name: Verify static linking
         run: |
@@ -167,18 +212,29 @@ jobs:
           ldd build/c/codebase-memory-mcp 2>&1 | grep -q "not a dynamic executable" || ldd build/c/codebase-memory-mcp 2>&1 | grep -q "statically linked"
 
       - name: Archive standard binary
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           cp LICENSE install.sh build/c/
-          tar -czf codebase-memory-mcp-linux-${{ matrix.arch }}-portable.tar.gz \
+          tar -czf "codebase-memory-mcp-linux-${ARCH}-portable.tar.gz" \
             -C build/c codebase-memory-mcp LICENSE install.sh
 
       - name: Build UI binary (static)
-        run: scripts/build.sh --with-ui ${{ inputs.version && format('--version {0}', inputs.version) || '' }} CC=gcc CXX=g++ STATIC=1
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$VERSION" ]; then
+            scripts/build.sh --with-ui --version "$VERSION" CC=gcc CXX=g++ STATIC=1
+          else
+            scripts/build.sh --with-ui CC=gcc CXX=g++ STATIC=1
+          fi
 
       - name: Archive UI binary
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           cp LICENSE install.sh build/c/
-          tar -czf codebase-memory-mcp-ui-linux-${{ matrix.arch }}-portable.tar.gz \
+          tar -czf "codebase-memory-mcp-ui-linux-${ARCH}-portable.tar.gz" \
             -C build/c codebase-memory-mcp LICENSE install.sh
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
Closes #247

## Summary

Replace direct `${{ ... }}` interpolation in `run:` steps of `.github/workflows/_build.yml` with `env:` blocks per GitHub's hardening guide. All 6 `run-shell-injection` findings from semgrep resolved.

## What changed

Every workflow input (`inputs.version`) and matrix value (`matrix.cc`, `matrix.cxx`, `matrix.goos`, `matrix.goarch`, `matrix.arch`) now flows into the shell through a named environment variable rather than being textually spliced into the script.

### Pattern applied

```yaml
# Before:
- name: Build standard binary
  run: scripts/build.sh ${{ inputs.version && format('--version {0}', inputs.version) || '' }} CC=${{ matrix.cc }} CXX=${{ matrix.cxx }}

# After:
- name: Build standard binary
  env:
    VERSION: ${{ inputs.version }}
    CC: ${{ matrix.cc }}
    CXX: ${{ matrix.cxx }}
  run: |
    if [ -n "$VERSION" ]; then
      scripts/build.sh --version "$VERSION" "CC=$CC" "CXX=$CXX"
    else
      scripts/build.sh "CC=$CC" "CXX=$CXX"
    fi
```

This is safe against injection because:

1. The `env:` block treats values as opaque strings during YAML parsing — GitHub does not interpret shell metacharacters in env values
2. `$VAR` expansion in the script uses normal shell semantics, so attacker input in `$VERSION` becomes a literal argv entry, not interpreted shell code
3. The if/else form avoids word-splitting pitfalls of conditional arg construction

## Changes

- `.github/workflows/_build.yml` — +66 / −10

Covered all 6 originally-flagged steps plus the archive steps that used `${{ matrix.* }}` in tar filenames (consistency).

## Test results

**Static verification:**
- Before: 6 `run-shell-injection` findings
- After: **0 findings** — `code-audit scan` / semgrep clean on `_build.yml`

**YAML syntax:** `yaml.safe_load(_build.yml)` parses cleanly

**Behavior preservation:**
- Same `build.sh` invocations, same artifact names, same conditional version handling
- Only functional difference: version-handling branch is now an `if/else` instead of a YAML ternary, which produces byte-identical arguments to `build.sh`

### Verification gate

```
VERIFICATION GATE — Issue #247:
  [N/A]   Build: GH Actions workflow — only runs on CI, not locally
  [N/A]   Test suite: yaml-only change, no python tests
  [PASS]  Issue scenario: scan of _build.yml — was 6 findings, now 0
  [PASS]  Edge cases: --version empty/set branches tested logically; matrix
          values moved to env; archive filenames use $GOOS/$GOARCH/$ARCH
  [PASS]  YAML syntax valid
  [N/A]   README: internal CI config, not user-facing
RESULT: PASS (3 PASS + 3 N/A)
```

Reference: https://securitylab.github.com/research/github-actions-untrusted-input/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
