### PR TITLE
feat: add temporal properties to FILE_CHANGES_WITH edges and File nodes

### DIFF
--- a/src/cypher/cypher.c
+++ b/src/cypher/cypher.c
@@ -2118,7 +2118,7 @@ static const char *binding_get_virtual(binding_t *b, const char *var, const char
     /* Fall through to normal lookup */
     cbm_edge_t *e = binding_get_edge(b, var);
     if (e) {
-        return prop ? edge_prop(e, prop) : "";
+        return prop ? edge_prop(e, prop) : (e->properties_json ? e->properties_json : "{}");
     }
     cbm_node_t *n = binding_get(b, var);
     if (n) {

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -1260,10 +1260,19 @@ static char *bm25_search(cbm_store_t *store, const char *project, const char *qu
     return json;
 }
 
-/* Emit the cbm_store_search results as a JSON "results" array on the doc. */
+/* Forward declaration — defined later in this file. */
+static yyjson_doc *enrich_node_properties(yyjson_mut_doc *doc, yyjson_mut_val *obj,
+                                          const char *properties_json);
+
+/* Emit the cbm_store_search results as a JSON "results" array on the doc.
+ * Populates *out_pdocs with parsed property docs that must be freed by the
+ * caller AFTER serializing doc (zero-copy strings point into these docs). */
 static void emit_search_results(yyjson_mut_doc *doc, yyjson_mut_val *root,
                                 const cbm_search_output_t *out, cbm_store_t *store,
-                                const char *relationship, bool include_connected, int offset) {
+                                const char *relationship, bool include_connected, int offset,
+                                yyjson_doc ***out_pdocs, int *out_pdoc_count) {
+    yyjson_doc **pdocs = out->count > 0 ? malloc((size_t)out->count * sizeof(yyjson_doc *)) : NULL;
+    int pdoc_count = 0;
     yyjson_mut_obj_add_int(doc, root, "total", out->total);
     yyjson_mut_val *results = yyjson_mut_arr(doc);
     for (int i = 0; i < out->count; i++) {
@@ -1280,10 +1289,14 @@ static void emit_search_results(yyjson_mut_doc *doc, yyjson_mut_val *root,
         if (include_connected && sr->node.id > 0) {
             enrich_connected(doc, item, store, sr->node.id, relationship);
         }
+        yyjson_doc *pdoc = enrich_node_properties(doc, item, sr->node.properties_json);
+        if (pdoc && pdocs) pdocs[pdoc_count++] = pdoc;
         yyjson_mut_arr_add_val(results, item);
     }
     yyjson_mut_obj_add_val(doc, root, "results", results);
     yyjson_mut_obj_add_bool(doc, root, "has_more", out->total > offset + out->count);
+    *out_pdocs = pdocs;
+    *out_pdoc_count = pdoc_count;
 }
 
 /* Extract keyword strings from a yyjson array into `keywords`.  Returns the
@@ -1426,7 +1439,10 @@ static char *handle_search_graph(cbm_mcp_server_t *srv, const char *args) {
     yyjson_mut_val *root = yyjson_mut_obj(doc);
     yyjson_mut_doc_set_root(doc, root);
 
-    emit_search_results(doc, root, &out, store, relationship, include_connected, offset);
+    yyjson_doc **props_docs = NULL;
+    int props_doc_count = 0;
+    emit_search_results(doc, root, &out, store, relationship, include_connected, offset,
+                        &props_docs, &props_doc_count);
 
     /* Add diagnostic hint when zero results */
     if (out.total == 0) {
@@ -1449,6 +1465,8 @@ static char *handle_search_graph(cbm_mcp_server_t *srv, const char *args) {
     bool sq_type_error = run_semantic_query(doc, root, args, store, project, limit);
 
     if (sq_type_error) {
+        for (int pi = 0; pi < props_doc_count; pi++) yyjson_doc_free(props_docs[pi]);
+        free(props_docs);
         yyjson_mut_doc_free(doc);
         cbm_store_search_free(&out);
         free(project);
@@ -1466,6 +1484,8 @@ static char *handle_search_graph(cbm_mcp_server_t *srv, const char *args) {
     }
 
     char *json = yy_doc_to_str(doc);
+    for (int pi = 0; pi < props_doc_count; pi++) yyjson_doc_free(props_docs[pi]);
+    free(props_docs);
     yyjson_mut_doc_free(doc);
     cbm_store_search_free(&out);
 

--- a/src/pipeline/pass_githistory.c
+++ b/src/pipeline/pass_githistory.c
@@ -87,6 +87,7 @@ typedef struct {
     char **files;
     int count;
     int cap;
+    time_t timestamp;    /* unix epoch of this commit */
 } commit_t;
 
 static void commit_add_file(commit_t *c, const char *file) {
@@ -189,6 +190,7 @@ static int parse_git_log(const char *repo_path, commit_t **out, int *out_count) 
                     cap *= PAIR_LEN;
                     commits = safe_realloc(commits, cap * sizeof(commit_t));
                 }
+                current.timestamp = (time_t)ct;
                 commits[count++] = current;
             } else {
                 commit_free(&current);
@@ -224,7 +226,7 @@ static int parse_git_log(const char *repo_path, commit_t **out, int *out_count) 
 
     char cmd[CBM_SZ_1K];
     snprintf(cmd, sizeof(cmd),
-             "cd '%s' && git log --name-only --pretty=format:COMMIT:%%H "
+             "cd '%s' && git log --name-only --pretty=format:COMMIT:%%H:%%ct "
              "--since='1 year ago' --max-count=10000 2>/dev/null",
              repo_path);
 
@@ -256,6 +258,11 @@ static int parse_git_log(const char *repo_path, commit_t **out, int *out_count) 
                 }
                 commits[count++] = current;
                 memset(&current, 0, sizeof(current));
+            }
+            /* Parse unix timestamp from COMMIT:<hash>:<ct> */
+            const char *hash_end = strchr(line + SLEN("COMMIT:"), ':');
+            if (hash_end) {
+                current.timestamp = (time_t)strtoll(hash_end + 1, NULL, 10);
             }
             continue;
         }
@@ -294,6 +301,7 @@ static void free_counter(const char *key, void *val, void *ud) {
 /* Context for collect_coupling_result callback. */
 typedef struct {
     CBMHashTable *file_counts;
+    CBMHashTable *pair_timestamps;
     cbm_change_coupling_t *out;
     int out_count;
     int max_out;
@@ -344,12 +352,15 @@ static void collect_coupling_cb(const char *pair_key, void *val, void *ud) {
     snprintf(cc->file_b, sizeof(cc->file_b), "%s", file_b);
     cc->co_change_count = co_count;
     cc->coupling_score = score;
+    time_t *ts = cbm_ht_get(cctx->pair_timestamps, pair_key);
+    cc->last_co_change = ts ? *ts : 0;
 }
 
 int cbm_compute_change_coupling(const cbm_commit_files_t *commits, int commit_count,
                                 cbm_change_coupling_t *out, int max_out) {
     CBMHashTable *file_counts = cbm_ht_create(CBM_SZ_1K);
     CBMHashTable *pair_counts = cbm_ht_create(CBM_SZ_2K);
+    CBMHashTable *pair_timestamps = cbm_ht_create(CBM_SZ_2K);
 
     for (int c = 0; c < commit_count; c++) {
         if (commits[c].count > GH_MAX_FILES) {
@@ -378,7 +389,8 @@ int cbm_compute_change_coupling(const cbm_commit_files_t *commits, int commit_co
                 }
                 size_t la = strlen(a);
                 size_t lb = strlen(b);
-                char *pk = malloc(la + SKIP_ONE + lb + SKIP_ONE);
+                size_t pk_len = la + SKIP_ONE + lb + SKIP_ONE;
+                char *pk = malloc(pk_len);
                 memcpy(pk, a, la);
                 pk[la] = '\x01';
                 memcpy(pk + la + SKIP_ONE, b, lb + SKIP_ONE);
@@ -386,11 +398,22 @@ int cbm_compute_change_coupling(const cbm_commit_files_t *commits, int commit_co
                 int *val = cbm_ht_get(pair_counts, pk);
                 if (val) {
                     (*val)++;
+                    /* Update max timestamp for existing pair */
+                    time_t *ts = cbm_ht_get(pair_timestamps, pk);
+                    if (ts && commits[c].timestamp > *ts) {
+                        *ts = commits[c].timestamp;
+                    }
                     free(pk);
                 } else {
                     int *nv = malloc(sizeof(int));
                     *nv = SKIP_ONE;
+                    /* Duplicate key for pair_timestamps since pair_counts consumes pk */
+                    char *pk2 = malloc(pk_len);
+                    memcpy(pk2, pk, pk_len);
                     cbm_ht_set(pair_counts, pk, nv);
+                    time_t *nts = malloc(sizeof(time_t));
+                    *nts = commits[c].timestamp;
+                    cbm_ht_set(pair_timestamps, pk2, nts);
                 }
             }
         }
@@ -398,6 +421,7 @@ int cbm_compute_change_coupling(const cbm_commit_files_t *commits, int commit_co
 
     collect_coupling_ctx_t cctx = {
         .file_counts = file_counts,
+        .pair_timestamps = pair_timestamps,
         .out = out,
         .out_count = 0,
         .max_out = max_out,
@@ -406,6 +430,8 @@ int cbm_compute_change_coupling(const cbm_commit_files_t *commits, int commit_co
 
     cbm_ht_foreach(pair_counts, free_counter, NULL);
     cbm_ht_free(pair_counts);
+    cbm_ht_foreach(pair_timestamps, free_counter, NULL);
+    cbm_ht_free(pair_timestamps);
     cbm_ht_foreach(file_counts, free_counter, NULL);
     cbm_ht_free(file_counts);
 
@@ -423,6 +449,8 @@ int cbm_pipeline_githistory_compute(const char *repo_path, cbm_githistory_result
     result->couplings = NULL;
     result->count = 0;
     result->commit_count = 0;
+    result->file_temporal = NULL;
+    result->file_temporal_count = 0;
 
     commit_t *commits = NULL;
     int commit_count = 0;
@@ -446,10 +474,47 @@ int cbm_pipeline_githistory_compute(const char *repo_path, cbm_githistory_result
     for (int c = 0; c < commit_count; c++) {
         cf[c].files = commits[c].files;
         cf[c].count = commits[c].count;
+        cf[c].timestamp = commits[c].timestamp;
     }
 
     cbm_change_coupling_t *couplings = malloc(MAX_COUPLINGS * sizeof(cbm_change_coupling_t));
     int coupling_count = cbm_compute_change_coupling(cf, commit_count, couplings, MAX_COUPLINGS);
+
+    /* Compute per-file temporal data: change_count and last_modified. */
+    cbm_file_temporal_t *ft_arr = malloc(MAX_FILE_TEMPORAL * sizeof(cbm_file_temporal_t));
+    int ft_count = 0;
+    if (ft_arr) {
+        /* Map file path → index in ft_arr */
+        CBMHashTable *file_idx = cbm_ht_create(CBM_SZ_1K);
+        for (int c = 0; c < commit_count; c++) {
+            if (cf[c].count > GH_MAX_FILES) {
+                continue;
+            }
+            for (int f = 0; f < cf[c].count; f++) {
+                const char *fp = cf[c].files[f];
+                int *idx = cbm_ht_get(file_idx, fp);
+                if (idx) {
+                    ft_arr[*idx].change_count++;
+                    if (cf[c].timestamp > ft_arr[*idx].last_modified) {
+                        ft_arr[*idx].last_modified = cf[c].timestamp;
+                    }
+                } else if (ft_count < MAX_FILE_TEMPORAL) {
+                    int new_idx = ft_count++;
+                    snprintf(ft_arr[new_idx].file_path, sizeof(ft_arr[new_idx].file_path),
+                             "%s", fp);
+                    ft_arr[new_idx].change_count = 1;
+                    ft_arr[new_idx].last_modified = cf[c].timestamp;
+                    int *nidx = malloc(sizeof(int));
+                    *nidx = new_idx;
+                    cbm_ht_set(file_idx, strdup(fp), nidx);
+                }
+            }
+        }
+        cbm_ht_foreach(file_idx, free_counter, NULL);
+        cbm_ht_free(file_idx);
+        result->file_temporal = ft_arr;
+        result->file_temporal_count = ft_count;
+    }
 
     free(cf);
     for (int c = 0; c < commit_count; c++) {
@@ -483,11 +548,36 @@ int cbm_pipeline_githistory_apply(cbm_pipeline_ctx_t *ctx, const cbm_githistory_
         }
 
         char props[CBM_SZ_128];
-        snprintf(props, sizeof(props), "{\"co_changes\":%d,\"coupling_score\":%.2f}",
-                 cc->co_change_count, cc->coupling_score);
+        snprintf(props, sizeof(props),
+                 "{\"co_changes\":%d,\"coupling_score\":%.2f,\"last_co_change\":%lld}",
+                 cc->co_change_count, cc->coupling_score, (long long)cc->last_co_change);
 
         cbm_gbuf_insert_edge(ctx->gbuf, node_a->id, node_b->id, "FILE_CHANGES_WITH", props);
         edge_count++;
+    }
+
+    /* Apply per-file temporal metadata to File nodes. */
+    for (int i = 0; i < result->file_temporal_count; i++) {
+        const cbm_file_temporal_t *ft = &result->file_temporal[i];
+        char *qn = cbm_pipeline_fqn_compute(ctx->project_name, ft->file_path, "__file__");
+        const cbm_gbuf_node_t *node = cbm_gbuf_find_by_qn(ctx->gbuf, qn);
+        free(qn);
+        if (!node) {
+            continue;
+        }
+
+        /* Re-derive extension to preserve it alongside new temporal fields. */
+        const char *base = strrchr(ft->file_path, '/');
+        base = base ? base + SKIP_ONE : ft->file_path;
+        const char *ext = strrchr(base, '.');
+
+        char props[CBM_SZ_256];
+        snprintf(props, sizeof(props),
+                 "{\"extension\":\"%s\",\"last_modified\":%lld,\"change_count\":%d}",
+                 ext ? ext : "", (long long)ft->last_modified, ft->change_count);
+
+        cbm_gbuf_upsert_node(ctx->gbuf, node->label, node->name, node->qualified_name,
+                             node->file_path, node->start_line, node->end_line, props);
     }
 
     return edge_count;
@@ -502,11 +592,12 @@ int cbm_pipeline_pass_githistory(cbm_pipeline_ctx_t *ctx) {
     cbm_pipeline_githistory_compute(ctx->repo_path, &result);
 
     int edge_count = 0;
-    if (result.count > 0) {
+    if (result.count > 0 || result.file_temporal_count > 0) {
         edge_count = cbm_pipeline_githistory_apply(ctx, &result);
     }
 
     free(result.couplings);
+    free(result.file_temporal);
 
     cbm_log_info("pass.done", "pass", "githistory", "commits", itoa_log(result.commit_count),
                  "edges", itoa_log(edge_count));

--- a/src/pipeline/pipeline.c
+++ b/src/pipeline/pipeline.c
@@ -733,12 +733,13 @@ static int run_githistory(cbm_pipeline_t *p, cbm_pipeline_ctx_t *ctx) {
     }
 
     int gh_edges = 0;
-    if (gh_result.count > 0) {
+    if (gh_result.count > 0 || gh_result.file_temporal_count > 0) {
         gh_edges = cbm_pipeline_githistory_apply(ctx, &gh_result);
     }
     cbm_log_info("pass.done", "pass", "githistory", "commits", itoa_buf(gh_result.commit_count),
                  "edges", itoa_buf(gh_edges));
     free(gh_result.couplings);
+    free(gh_result.file_temporal);
     return 0;
 }
 

--- a/src/pipeline/pipeline_internal.h
+++ b/src/pipeline/pipeline_internal.h
@@ -14,6 +14,7 @@
 #include "foundation/hash_table.h"
 #include "cbm.h"
 #include <stdatomic.h>
+#include <time.h>
 
 /* ── Shared pipeline constants ─────────────────────────────────── */
 
@@ -111,12 +112,14 @@ typedef struct {
     char file_b[CBM_SZ_512];
     int co_change_count;
     double coupling_score;
+    time_t last_co_change;   /* unix epoch of most recent co-change commit */
 } cbm_change_coupling_t;
 
 /* Commit data for coupling analysis */
 typedef struct {
     char **files;
     int count;
+    time_t timestamp;        /* unix epoch of this commit */
 } cbm_commit_files_t;
 
 /* Compute change coupling from commit history.
@@ -372,11 +375,23 @@ int cbm_pipeline_pass_tests(cbm_pipeline_ctx_t *ctx, const cbm_file_info_t *file
 
 int cbm_pipeline_pass_githistory(cbm_pipeline_ctx_t *ctx);
 
+/* Per-file temporal data produced by the git history pass. */
+typedef struct {
+    char file_path[CBM_SZ_512];
+    int  change_count;
+    time_t last_modified;    /* unix epoch of most recent commit touching this file */
+} cbm_file_temporal_t;
+
+/* Maximum number of files tracked for temporal metadata. */
+#define MAX_FILE_TEMPORAL 16384
+
 /* Pre-computed git history result for fused post-pass parallelism. */
 typedef struct {
     cbm_change_coupling_t *couplings;
     int count;
     int commit_count;
+    cbm_file_temporal_t *file_temporal;  /* heap-alloc'd array of per-file temporal data */
+    int file_temporal_count;
 } cbm_githistory_result_t;
 
 /* Compute change couplings without touching the graph buffer.

--- a/tests/test_pipeline.c
+++ b/tests/test_pipeline.c
@@ -528,7 +528,7 @@ TEST(githistory_compute_coupling) {
     char *files_4[] = {"d.go", "e.go"};
 
     cbm_commit_files_t commits[] = {
-        {files_0, 3}, {files_1, 2}, {files_2, 2}, {files_3, 2}, {files_4, 2},
+        {files_0, 3, 0}, {files_1, 2, 0}, {files_2, 2, 0}, {files_3, 2, 0}, {files_4, 2, 0},
     };
 
     cbm_change_coupling_t results[100];
@@ -564,7 +564,7 @@ TEST(githistory_skip_large_commits) {
         files[i] = bufs[i];
     }
 
-    cbm_commit_files_t commits[] = {{files, 25}};
+    cbm_commit_files_t commits[] = {{files, 25, 0}};
 
     cbm_change_coupling_t results[100];
     int n = cbm_compute_change_coupling(commits, 1, results, 100);
@@ -4137,7 +4137,8 @@ TEST(githistory_compute_change_coupling) {
     char *files_eee[] = {"d.go", "e.go"};
 
     cbm_commit_files_t commits[5] = {
-        {files_aaa, 3}, {files_bbb, 2}, {files_ccc, 2}, {files_ddd, 2}, {files_eee, 2},
+        {files_aaa, 3, 0}, {files_bbb, 2, 0}, {files_ccc, 2, 0}, {files_ddd, 2, 0},
+        {files_eee, 2, 0},
     };
 
     cbm_change_coupling_t out[100];
@@ -4173,7 +4174,7 @@ TEST(githistory_coupling_skips_large_commits) {
         snprintf(bufs[i], sizeof(bufs[i]), "file%d.go", i);
         files[i] = bufs[i];
     }
-    cbm_commit_files_t commits[1] = {{files, 25}};
+    cbm_commit_files_t commits[1] = {{files, 25, 0}};
 
     cbm_change_coupling_t out[100];
     int count = cbm_compute_change_coupling(commits, 1, out, 100);
@@ -5080,7 +5081,7 @@ TEST(coupling_single_file_commit) {
     /* Commits with single files → no pairs → zero couplings */
     char *f1[] = {"a.go"};
     char *f2[] = {"b.go"};
-    cbm_commit_files_t commits[] = {{f1, 1}, {f2, 1}};
+    cbm_commit_files_t commits[] = {{f1, 1, 0}, {f2, 1, 0}};
     cbm_change_coupling_t results[16];
     int n = cbm_compute_change_coupling(commits, 2, results, 16);
     ASSERT_EQ(n, 0);


### PR DESCRIPTION
- Fix search_graph (Mode A): emit_search_results now calls enrich_node_properties so node properties_json is included in results. Uses a collected-docs pattern to correctly handle yyjson zero-copy string lifetime.

- Fix query_graph bare edge return (Mode B): binding_get_virtual now returns e->properties_json instead of "" when prop is NULL, so `RETURN r` on an edge exposes the full properties object.

- Add last_co_change to FILE_CHANGES_WITH edges: commit_t and cbm_commit_files_t gain a timestamp field; cbm_compute_change_coupling maintains a parallel pair_timestamps hash table tracking the max commit timestamp per pair; cbm_change_coupling_t gains last_co_change; the edge props JSON now includes "last_co_change":<unix-epoch>. Both libgit2 and popen code paths updated consistently.

- Add last_modified and change_count to File nodes: new cbm_file_temporal_t struct and MAX_FILE_TEMPORAL=16384 constant; cbm_githistory_result_t extended with file_temporal array; cbm_pipeline_githistory_compute builds per-file change_count + last_modified via a hash table pass; cbm_pipeline_githistory_apply upserts File nodes with temporal props (re-derives extension to preserve it). Both pipeline entry points (pass_githistory and run_githistory) free file_temporal and trigger apply when file_temporal_count > 0.

- Update test_pipeline.c initializers for new cbm_commit_files_t.timestamp field (zero-initialized, backward-compatible behavior).