### PR TITLE
Add Nix flake definition for reproducible builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "codebase-memory-mcp — C11 MCP server for codebase indexing";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (pkgs: {
+        default = pkgs.stdenv.mkDerivation {
+          pname = "codebase-memory-mcp";
+          version = "0.6.0";
+
+          src = ./.;
+
+          nativeBuildInputs = [ pkgs.gnumake ];
+          buildInputs = [ pkgs.zlib ];
+
+          # scripts/build.sh verifies the compiler via `file`, which fails on Nix
+          # because CC is a bash wrapper script rather than a binary. Call make
+          # directly to bypass that check; the Nix stdenv already guarantees the
+          # correct compiler and target architecture.
+          buildPhase = ''
+            make -j$NIX_BUILD_CORES -f Makefile.cbm cbm
+          '';
+
+          installPhase = ''
+            install -Dm755 build/c/codebase-memory-mcp $out/bin/codebase-memory-mcp
+          '';
+
+          meta = {
+            description = "MCP server that builds and queries a semantic graph of your codebase";
+            homepage = "https://github.com/DeusData/codebase-memory-mcp";
+            license = nixpkgs.lib.licenses.mit;
+            mainProgram = "codebase-memory-mcp";
+            platforms = systems;
+          };
+        };
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${pkgs.system}.default ];
+          # libgit2 is an optional dependency auto-detected via pkg-config at
+          # build time. When present it accelerates git history parsing;
+          # otherwise the build falls back to shelling out to `git log`.
+          packages = [ pkgs.pkg-config pkgs.libgit2 ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
Adds `flake.nix` to define how this package should be built on systems running [nix][nix-link]. Also commit the `flake.lock` file to pin the specific dependencies at build time.

By default support aarch64 and x86_64 for macos and linux. Run the Make command directly because `cc` on Nix systems is a wrapper file and not a binary directly, so the `file` check in `scripts/build.sh` fails to identify the host architecture correctly.

Include lib2git as an optional dev shell dependency since it's detected by `pkg-config` in the build script to link to `lib2git` if it exists at build time.

[nix-link]: https://nixos.org/