### PR TITLE
Fix list_projects empty + trace_path qualified-name lookup

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -772,6 +772,9 @@ static cbm_store_t *resolve_store(cbm_mcp_server_t *srv, const char *project) {
     return srv->store;
 }
 
+/* Forward decl — definition lives below alongside list_projects. */
+static bool is_project_db_file(const char *name, size_t len);
+
 /* Scan cache dir for .db files, writing comma-separated quoted names into out.
  * Returns the number of projects found. */
 static int collect_db_project_names(const char *dir_path, char *out, size_t out_sz) {
@@ -785,10 +788,7 @@ static int collect_db_project_names(const char *dir_path, char *out, size_t out_
     while ((entry = cbm_readdir(d)) != NULL) {
         const char *n = entry->name;
         size_t len = strlen(n);
-        if (len < MCP_MIN_DB_NAME || strcmp(n + len - MCP_DB_EXT, ".db") != 0) {
-            continue;
-        }
-        if (strncmp(n, "tmp-", SLEN("tmp-")) == 0 || strncmp(n, "_", SLEN("_")) == 0) {
+        if (!is_project_db_file(n, len)) {
             continue;
         }
         if (count > 0 && offset < (int)out_sz - MCP_SEPARATOR) {
@@ -842,12 +842,18 @@ static char *build_project_list_error(const char *reason) {
 
 /* ── Tool handler implementations ─────────────────────────────── */
 
-/* Return true if filename is a valid project .db file (not temp/internal). */
+/* Return true if filename is a valid project .db file (not temp/internal).
+ *
+ * NOTE: project names derived from `/tmp/...` source roots legitimately
+ * begin with `tmp-` (see cbm_project_name_from_path: "/tmp/bench/..." →
+ * "tmp-bench-..."), so we must NOT exclude the entire `tmp-` prefix.  The
+ * `_` prefix is reserved for internal/hidden DBs, and `:memory:` is the
+ * SQLite in-memory marker (defensive — never appears as a real file). */
 static bool is_project_db_file(const char *name, size_t len) {
     if (len < MCP_MIN_DB_NAME || strcmp(name + len - MCP_DB_EXT, ".db") != 0) {
         return false;
     }
-    if (strncmp(name, "tmp-", SLEN("tmp-")) == 0 || strncmp(name, "_", SLEN("_")) == 0 ||
+    if (strncmp(name, "_", SLEN("_")) == 0 ||
         strncmp(name, ":memory:", SLEN(":memory:")) == 0) {
         return false;
     }
@@ -1928,10 +1934,21 @@ static char *handle_trace_call_path(cbm_mcp_server_t *srv, const char *args) {
         direction = heap_strdup("both");
     }
 
-    /* Find the node by name */
+    /* Find the node by name. If that misses (caller passed a fully-qualified
+     * name like "module.func"), fall back to qualified_name lookup so the
+     * documented "fully qualify for precise match" UX actually works. */
     cbm_node_t *nodes = NULL;
     int node_count = 0;
     cbm_store_find_nodes_by_name(store, project, func_name, &nodes, &node_count);
+
+    if (node_count == 0) {
+        cbm_node_t qn_node = {0};
+        if (cbm_store_find_node_by_qn(store, project, func_name, &qn_node) == CBM_STORE_OK) {
+            nodes = malloc(sizeof(cbm_node_t));
+            nodes[0] = qn_node;
+            node_count = 1;
+        }
+    }
 
     if (node_count == 0) {
         enum { HINT_BUF_SZ = 512 };


### PR DESCRIPTION
## Summary

Two bugs in `src/mcp/mcp.c` surfaced during a real-world MCP tool sweep against a `mode=full` index of a 12,770-node Python repo on macOS arm64.  Both have minimal, targeted fixes.

### Bug 1 — `list_projects` returns `{"projects":[]}` even when projects exist

**Symptom:** After `index_repository(...)` succeeds, the project is fully queryable via `index_status`, `search_code`, `search_graph`, `query_graph`, `get_code_snippet`, `trace_path`, etc., but `list_projects` returns an empty array.

**Root cause:** `is_project_db_file()` (mcp.c:846, also inlined inside `collect_db_project_names` at mcp.c:791) excludes any filename with a `tmp-` prefix.  But `cbm_project_name_from_path()` legitimately produces `tmp-...` project names for source roots under `/tmp/` — verified by an existing in-tree test:

```c
// tests/test_pipeline.c:1903
{"/tmp/bench/erlang/lib/stdlib/src", "tmp-bench-erlang-lib-stdlib-src"},
```

Any project rooted under `/tmp` was silently filtered from `list_projects` + the `available_projects` hint inside `build_project_list_error`.

**Fix:** drop the `tmp-` prefix exclusion entirely.  SQLite's actual journal/WAL sidecar files end with `-journal`, `-wal`, `-shm` (not `.db`) and never collide with the `.db` suffix `is_project_db_file` already requires, so removing the prefix filter is safe.  While here, refactor `collect_db_project_names()` to call `is_project_db_file()` so the filter lives in one place.

### Bug 2 — `trace_path` returns `function not found` for fully-qualified names

**Symptom:** Calling `trace_path` with a fully-qualified function name (`"<project>.module.submodule.func"`) returns `{"error":"function not found", ...}` even when the node exists.  The tool's own error hint instructs callers to "fully qualify" the name, but doing so causes the lookup to miss every time — the documented "fully qualify for precise match" UX inverts what actually works.

**Root cause:** `handle_trace_call_path()` (mcp.c:1887) only calls `cbm_store_find_nodes_by_name()`, which queries `WHERE project = ?1 AND name = ?2` against the bare `name` column.  The qualified name is never tried.

**Fix:** when the bare-name lookup returns 0 nodes, fall back to `cbm_store_find_node_by_qn()` (already exists in store.c, used elsewhere).  If that resolves, wrap the single result into the same `nodes[]` array the downstream BFS expects, so the rest of the function is unchanged.

## Verification

Built locally with `make -f Makefile.cbm cbm`, replaced the cached binary at `~/Library/Caches/codebase-memory-mcp/0.6.0/codebase-memory-mcp` on macOS arm64, restarted the host service, and verified against a real `Users-jwiley-dev-orca` index (12,770 nodes / 36,859 edges) plus a synthetic `tmp-cbm_sandbox` project rooted at `/tmp/cbm_sandbox`:

- **Pre-patch:** `list_projects` returned `{"projects":[]}`.
  **Post-patch:** returns both `tmp-cbm_sandbox` and `Users-jwiley-dev-orca`.

- **Pre-patch:** `trace_path(function_name="Users-jwiley-dev-orca.src.services.session_enricher.enrichment_service.run_enrichment")` returned `function not found`.
  **Post-patch:** returns identical `callees` (29 nodes across hops 1+2) and `callers` (2 nodes) to the bare-name lookup `trace_path(function_name="run_enrichment")`.

Existing tests untouched.

## Test plan

- [x] Verified patched binary builds cleanly with `-O2 -Wall -Wextra -Werror` on macOS arm64
- [x] Verified `list_projects` now surfaces a `tmp-cbm_sandbox` project (was previously filtered)
- [x] Verified `trace_path` with bare name (control) still works
- [x] Verified `trace_path` with fully-qualified name returns identical traversal
- [ ] CI on this PR (Linux + Windows builds + `make -f Makefile.cbm test`)