### PR TITLE
fix(sqlite_writer): skip index cells that exceed a single page

### DIFF
--- a/internal/cbm/sqlite_writer.c
+++ b/internal/cbm/sqlite_writer.c
@@ -1213,9 +1213,16 @@ static uint32_t write_index_btree(FILE *fp, uint32_t *next_page, uint8_t **cells
     pb_init(&pb, fp, *next_page, true);
 
     for (int i = 0; i < count; i++) {
-        if (!pb_cell_fits(&pb, cell_lens[i]) && pb.cell_count > 0) {
-            if (!pb_promote_and_flush(&pb, cells, cell_lens, i - SKIP_ONE)) {
-                return 0;
+        if (!pb_cell_fits(&pb, cell_lens[i])) {
+            if (pb.cell_count > 0) {
+                if (!pb_promote_and_flush(&pb, cells, cell_lens, i - SKIP_ONE)) {
+                    return 0;
+                }
+            }
+            // After flush, check if the cell still doesn't fit on an empty page.
+            // Index cells larger than a full page can never be stored; skip them.
+            if (!pb_cell_fits(&pb, cell_lens[i])) {
+                continue;
             }
         }
         pb_add_cell(&pb, cells[i], cell_lens[i]);


### PR DESCRIPTION
## Problem

`write_index_btree()` crashes with SIGBUS when indexing large repositories (observed on a Ruby codebase with ~215K nodes, specifically the HackerOne `core` monolith with ~67K functions).

The crash occurs in the page-buffer writer when an index cell's payload (qualified_name + file_path + properties) exceeds the SQLite page size. The code flushes the current page and assumes the fresh page will always accept the cell — but oversized cells still fail `pb_cell_fits()` after the flush. The subsequent `pb_add_cell()` causes a `content_offset` underflow, corrupting the page header and triggering SIGBUS on the next write.

## Reproduction

Index any repository with functions whose qualified names + file paths exceed ~4000 bytes combined (the SQLite page size minus overhead). A Ruby monolith with deeply nested namespaces and long file paths reliably triggers this.

```bash
codebase-memory-mcp index --path /path/to/large-ruby-repo
# → SIGBUS in write_index_btree at sqlite_writer.c:1218
```

## Fix

After `pb_promote_and_flush()`, re-check `pb_cell_fits()`. If the cell still doesn't fit on an empty page, `continue` past it. Index entries whose keys exceed a full page cannot be stored in a leaf and are silently dropped — the rest of the index is correctly preserved.

This is the index-btree counterpart to PR #175 (record overflow pages), which fixed the same shape of bug for the record-btree writer. The record side uses overflow pages; the index side has no overflow mechanism, so skipping is the correct behavior.

## Changes

- `internal/cbm/sqlite_writer.c`: 10 lines added, 3 removed in `write_index_btree()`.

## Testing

- Verified by indexing a 215K-node Ruby repo that previously crashed — completes successfully with all other nodes indexed.
- The skipped cells are edge cases (extremely long qualified names) that don't affect query correctness for normal usage.

## Related

- Closes the index-cell side of #139 / #187 (record-cell side was fixed in #175).
- PR #217 (growable AST traversal stacks) addresses a different SIGBUS trigger in the parser.