### PR TITLE
fix: add .m extension to EXT_TABLE for content-based disambiguation

### DIFF
--- a/src/discover/language.c
+++ b/src/discover/language.c
@@ -174,6 +174,7 @@ static const ext_entry_t EXT_TABLE[] = {
     {".mdx", CBM_LANG_MARKDOWN},
 
     /* MATLAB */
+    {".m", CBM_LANG_MATLAB},
     {".matlab", CBM_LANG_MATLAB},
     {".mlx", CBM_LANG_MATLAB},
 


### PR DESCRIPTION
## Problem

`.m` files (MATLAB, Objective-C, Magma) are silently ignored by the indexer. `detect_file_language` returns `CBM_LANG_COUNT` before the content-based disambiguation logic (`cbm_disambiguate_m`) can run, because `.m` is missing from `EXT_TABLE`.

## Root Cause

In `src/discover/language.c`, `EXT_TABLE` includes `.matlab` and `.mlx` but omits `.m`. The lookup in `cbm_language_for_filename` returns Unknown, causing `detect_file_language` to abort early.

## Fix

Add `{".m", CBM_LANG_MATLAB}` to `EXT_TABLE` in the MATLAB section. The initial mapping to MATLAB is safe because the subsequent `cbm_disambiguate_m` call (already in `detect_file_language`) will correctly overwrite it by reading file contents.

Fixes #296