### PR TITLE
fix(c-lsp): cap expression type evaluation steps

### DIFF
--- a/internal/cbm/lsp/c_lsp.c
+++ b/internal/cbm/lsp/c_lsp.c
@@ -1204,11 +1204,20 @@ static const char* type_to_qn(const CBMType* t) {
 
 static const CBMType* c_eval_expr_type_inner(CLSPContext* ctx, TSNode node);
 
+#define C_EVAL_DEPTH_LIMIT 256
+#define C_EVAL_MAX_STEPS_PER_FILE 10000
+
 const CBMType* c_eval_expr_type(CLSPContext* ctx, TSNode node) {
     if (ts_node_is_null(node)) return cbm_type_unknown();
-    /* Guard against unbounded recursion on deeply nested C++ templates.
-     * Prevents stack overflow and NULL-deref from unusual AST shapes. */
-    if (ctx->eval_depth > 256) {
+    /* Expression type evaluation is best-effort. Some recovery-mode C++ ASTs
+     * can repeatedly drive member/type lookup without increasing recursion
+     * depth. Keep a generous per-file work budget so pathological expressions
+     * degrade to unknown instead of hanging repository indexing. */
+    if (ctx->eval_depth > C_EVAL_DEPTH_LIMIT ||
+        ctx->eval_steps++ > C_EVAL_MAX_STEPS_PER_FILE) {
+        if (ctx->debug && ctx->eval_steps == C_EVAL_MAX_STEPS_PER_FILE + 2) {
+            fprintf(stderr, "  [clsp] expression eval step budget exhausted; returning unknown\n");
+        }
         return cbm_type_unknown();
     }
     ctx->eval_depth++;

--- a/internal/cbm/lsp/c_lsp.h
+++ b/internal/cbm/lsp/c_lsp.h
@@ -75,6 +75,7 @@ typedef struct {
     bool in_template;       // currently inside template declaration
     bool debug;
     int eval_depth;         // recursion depth for c_eval_expr_type (crash guard)
+    int eval_steps;         // total expression eval calls for current file (hang guard)
 } CLSPContext;
 
 // --- API ---


### PR DESCRIPTION
## Summary
- Add a per-file expression-evaluation step budget to the C/C++ LSP resolver
- Return `unknown` after the budget is exhausted instead of allowing pathological expression/type lookup loops to hang indexing
- Keep the existing recursion-depth guard, but also guard the non-stack-overflow case where evaluation repeatedly walks expensive C++ expression/type-resolution paths

## Why
While indexing a large Bitcoin-derived C++ codebase, one worker could hang indefinitely in `c_eval_expr_type()` / `c_eval_expr_type_inner()` during definition extraction. The minimal repro was a single C++ test file with many versionbits-style checks; GDB showed repeated C++ expression evaluation through member/type lookup rather than a crash.

This guard trades a small amount of precision in pathological files for keeping repository indexing bounded and useful.

## Test plan
- `make -f Makefile.cbm test -j$(nproc)`
- Fresh fast index of the large C++ repro repository completed successfully after deleting its cache DB:
  - 2179 files
  - 29,766 nodes
  - ~91k edges
  - completed in ~8.6s

## Related
Follow-up to #322, which fixes a separate C++ LSP crash path.