### PR TITLE
fix(windows): error on full index - use cmd.exe-compatible syntax (Fixes #324)

### DIFF
--- a/src/pipeline/pass_githistory.c
+++ b/src/pipeline/pass_githistory.c
@@ -223,10 +223,16 @@ static int parse_git_log(const char *repo_path, commit_t **out, int *out_count) 
     }
 
     char cmd[CBM_SZ_1K];
+#ifdef _WIN32
+    /* cmd.exe does not recognize single quotes; '/dev/null' is a POSIX path. */
+    const char *null_dev = "NUL";
+#else
+    const char *null_dev = "/dev/null";
+#endif
     snprintf(cmd, sizeof(cmd),
-             "cd '%s' && git log --name-only --pretty=format:COMMIT:%%H "
-             "--since='1 year ago' --max-count=10000 2>/dev/null",
-             repo_path);
+             "git -C \"%s\" log --name-only --pretty=format:COMMIT:%%H "
+             "--since=\"1 year ago\" --max-count=10000 2>%s",
+             repo_path, null_dev);
 
     FILE *fp = cbm_popen(cmd, "r");
     if (!fp) {


### PR DESCRIPTION
Previously on full index under Windows there is an error after step 5: `The filename, directory name, or volume label syntax is incorrect.`
This PR fixes cmd.exe syntax
```
[1/9] Building file structure
  Extracting: N/N files (100%))
[2/9] Extracting definitions
[3/9] Building registry
[4/9] Resolving calls & edges
[5/9] Detecting tests
[7/9] Analyzing git history
[8/9] Linking config files
[9/9] Writing database
```