### PR TITLE
feat(platform): CBM_WORKERS env override for cbm_default_worker_count

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ codebase-memory-mcp config reset auto_index              # reset to default
 | `CBM_CACHE_DIR` | `~/.cache/codebase-memory-mcp` | Override the database storage directory. All project indexes and config are stored here. |
 | `CBM_DIAGNOSTICS` | `false` | Set to `1` or `true` to enable periodic diagnostics output to `/tmp/cbm-diagnostics-<pid>.json`. |
 | `CBM_DOWNLOAD_URL` | *(GitHub releases)* | Override the download URL for updates. Used for testing or self-hosted deployments. |
+| `CBM_WORKERS` | *(detected)* | Override the parallel-indexing worker count returned by `cbm_default_worker_count`. Useful inside containers where `sysconf(_SC_NPROCESSORS_ONLN)` reports host CPUs rather than the cgroup's effective quota. Range 1–256; invalid values are ignored with a warning. |
 
 ```bash
 # Store indexes in a custom directory

--- a/src/foundation/system_info.c
+++ b/src/foundation/system_info.c
@@ -10,9 +10,11 @@
  */
 #include "foundation/constants.h"
 
-enum { DEFAULT_CORES = 1, MIN_WORKERS = 1 };
+enum { DEFAULT_CORES = 1, MIN_WORKERS = 1, CBM_WORKERS_MAX = 256 };
+#include "foundation/log.h"
 #include "foundation/platform.h"
 #include <stdint.h> // uint64_t
+#include <stdlib.h> // strtol
 #include <string.h>
 
 #ifdef _WIN32
@@ -168,6 +170,20 @@ cbm_system_info_t cbm_system_info(void) {
 }
 
 int cbm_default_worker_count(bool initial) {
+    /* CBM_WORKERS env override (clamped to [1, CBM_WORKERS_MAX]).
+     * Useful inside containers where sysconf(_SC_NPROCESSORS_ONLN)
+     * reports host CPUs rather than the cgroup's effective CPU quota.
+     * Same precedence shape as other CBM_* env overrides:
+     * explicit override > implicit detection. */
+    char buf[CBM_SZ_32];
+    if (cbm_safe_getenv("CBM_WORKERS", buf, sizeof(buf), NULL) != NULL) {
+        long n = strtol(buf, NULL, CBM_DECIMAL_BASE);
+        if (n >= MIN_WORKERS && n <= CBM_WORKERS_MAX) {
+            return (int)n;
+        }
+        cbm_log_warn("workers.env.invalid", "value", buf, "fallback", "sysconf");
+    }
+
     cbm_system_info_t info = cbm_system_info();
     if (initial) {
         /* Use all cores for initial indexing — user is waiting */

--- a/tests/test_platform.c
+++ b/tests/test_platform.c
@@ -3,6 +3,7 @@
  */
 #include "test_framework.h"
 #include "../src/foundation/platform.h"
+#include <stdlib.h> /* setenv, unsetenv */
 #include <unistd.h>
 
 TEST(platform_now_ns) {
@@ -68,6 +69,57 @@ TEST(platform_mmap_nonexistent) {
     PASS();
 }
 
+/*
+ * CBM_WORKERS env override for cbm_default_worker_count.
+ *
+ * Containers running cbm on a host with more CPUs than the cgroup's
+ * effective quota currently see ~host_cpu workers spawned because
+ * sysconf(_SC_NPROCESSORS_ONLN) is not cgroup-aware (see GitHub
+ * issue for the cgroup-detection ask). CBM_WORKERS is the smaller,
+ * explicit-override path that ships independently.
+ */
+TEST(platform_default_workers_env_override) {
+    setenv("CBM_WORKERS", "4", 1);
+    int n = cbm_default_worker_count(true);
+    ASSERT_EQ(n, 4);
+    /* initial=false should also honor the explicit override. */
+    int m = cbm_default_worker_count(false);
+    ASSERT_EQ(m, 4);
+    unsetenv("CBM_WORKERS");
+    PASS();
+}
+
+TEST(platform_default_workers_env_invalid) {
+    /* Out-of-range values (< 1 or > 256) and non-numeric strings
+     * fall back to the sysconf-derived default. */
+    int baseline = cbm_default_worker_count(true);
+    ASSERT_GT(baseline, 0);
+
+    setenv("CBM_WORKERS", "0", 1);
+    ASSERT_EQ(cbm_default_worker_count(true), baseline);
+
+    setenv("CBM_WORKERS", "-1", 1);
+    ASSERT_EQ(cbm_default_worker_count(true), baseline);
+
+    setenv("CBM_WORKERS", "9999", 1);
+    ASSERT_EQ(cbm_default_worker_count(true), baseline);
+
+    setenv("CBM_WORKERS", "not-a-number", 1);
+    ASSERT_EQ(cbm_default_worker_count(true), baseline);
+
+    unsetenv("CBM_WORKERS");
+    PASS();
+}
+
+TEST(platform_default_workers_env_unset) {
+    /* When CBM_WORKERS is unset the result matches today's behaviour
+     * (info.total_cores for initial=true, perf_cores-1 for false). */
+    unsetenv("CBM_WORKERS");
+    cbm_system_info_t info = cbm_system_info();
+    ASSERT_EQ(cbm_default_worker_count(true), info.total_cores);
+    PASS();
+}
+
 SUITE(platform) {
     RUN_TEST(platform_now_ns);
     RUN_TEST(platform_now_ms);
@@ -77,4 +129,7 @@ SUITE(platform) {
     RUN_TEST(platform_file_size);
     RUN_TEST(platform_mmap);
     RUN_TEST(platform_mmap_nonexistent);
+    RUN_TEST(platform_default_workers_env_override);
+    RUN_TEST(platform_default_workers_env_invalid);
+    RUN_TEST(platform_default_workers_env_unset);
 }


### PR DESCRIPTION
### What

Adds a single env-knob, `CBM_WORKERS`, that explicitly sets the
worker count returned by `cbm_default_worker_count()`. When unset,
behaviour is unchanged.

### Why

In containerized deployments, `cbm_default_worker_count(initial=true)`
returns `sysconf(_SC_NPROCESSORS_ONLN)` (host-CPU count, not the
container's CPU quota). On a 1-vCPU pod scheduled onto a 16-core
node cbm spawns ~16 indexing workers, each with its own per-worker
buffers — the dominant OOMKill driver in container deployments
(see companion issue #363 for the broader cgroup-awareness ask).

A small env knob solves the immediate operator pain without taking
on the scope of full cgroup detection, and it follows the same
shape as the existing `CBM_*` env overrides: explicit override >
implicit detection.

### Patch

`src/foundation/system_info.c`:

```c
int cbm_default_worker_count(bool initial) {
    /* CBM_WORKERS env override (clamped to [1, CBM_WORKERS_MAX]).
     * Useful inside containers where sysconf(_SC_NPROCESSORS_ONLN)
     * reports host CPUs rather than the cgroup's effective CPU quota.
     * Same precedence shape as other CBM_* env overrides:
     * explicit override > implicit detection. */
    char buf[CBM_SZ_32];
    if (cbm_safe_getenv("CBM_WORKERS", buf, sizeof(buf), NULL) != NULL) {
        long n = strtol(buf, NULL, CBM_DECIMAL_BASE);
        if (n >= MIN_WORKERS && n <= CBM_WORKERS_MAX) {
            return (int)n;
        }
        cbm_log_warn("workers.env.invalid", "value", buf,
                     "fallback", "sysconf");
    }

    cbm_system_info_t info = cbm_system_info();
    // ... unchanged from today ...
}
```

`CBM_WORKERS_MAX = 256` is added to the file-local `enum`; happy to
drop the upper clamp if you'd rather trust the operator, or move
the constant somewhere shared. `cbm_safe_getenv`, `CBM_DECIMAL_BASE`,
`CBM_SZ_32`, `SKIP_ONE`, `MIN_WORKERS`, and `cbm_log_warn` all
already exist (see `src/foundation/platform.h`, `constants.h`, and
`log.h`).

### Tests

`tests/test_platform.c` gains three cases inside the existing
`SUITE(platform)`:

1. `platform_default_workers_env_override` — `CBM_WORKERS=4` is honored for both `initial=true` and `initial=false`.
2. `platform_default_workers_env_invalid` — `0`, `-1`, `9999`, and `not-a-number` all fall back to the sysconf-derived default (and emit `workers.env.invalid` at WARN).
3. `platform_default_workers_env_unset` — when unset, `cbm_default_worker_count(true) == cbm_system_info().total_cores`, preserving today's contract.

### Docs

One-line addition to the **Environment Variables** table in
`README.md`:

> `CBM_WORKERS` — Override the parallel-indexing worker count
> returned by `cbm_default_worker_count`. Useful inside containers
> where `sysconf(_SC_NPROCESSORS_ONLN)` reports host CPUs rather
> than the cgroup's effective quota. Range 1–256; invalid values
> are ignored with a warning.

### Behaviour when unset

Identical to today. No deployment that doesn't set `CBM_WORKERS`
sees any difference.

### Verification on my side

I have **not** run `scripts/build.sh` / `scripts/test.sh` /
`scripts/lint.sh` locally because the full ASan + UBSan setup
isn't installed on my machine. Happy to iterate quickly on any
CI feedback (lint, clang-tidy, cppcheck, format) — the patch is
small enough that a turnaround should be fast.

### Related

- Companion issue #363 — full cgroup-aware detection (the broader
  ask this PR carves a smaller, lower-risk path out of).
- Other crash bugs that container-overspawn magnifies: #317, #334,
  #336, #340.
- Downstream context: filed while integrating CBM as a long-lived
  MCP-server process inside a 2 GiB Kubernetes pod. Backend pod's
  current workaround is a memory-limit bump from 2 GiB → 4 GiB to
  ride out the overspawn until this lands.

