### PR TITLE
feat(platform): cgroup-aware CPU/memory detection in detect_system_linux

### DIFF
--- a/src/foundation/system_info.c
+++ b/src/foundation/system_info.c
@@ -3,7 +3,9 @@
  *
  * macOS: sysctlbyname for core counts, hw.memsize for RAM.
  * BSD: sysconf + sysctl(HW_PHYSMEM64 / HW_PHYSMEM).
- * Linux: sysconf + sysinfo().
+ * Linux: sysconf + sysinfo(), with cgroup-aware overrides when running
+ *        inside a container so the limits reflect the cgroup's effective
+ *        CPU quota and memory cap rather than the host's totals.
  * Windows: GetSystemInfo + GlobalMemoryStatusEx.
  *
  * Results are cached after first call (immutable hardware properties).
@@ -12,6 +14,7 @@
 
 enum { DEFAULT_CORES = 1, MIN_WORKERS = 1 };
 #include "foundation/platform.h"
+#include "foundation/system_info_internal.h"
 #include <stdint.h> // uint64_t
 #include <string.h>
 
@@ -27,9 +30,12 @@ enum { DEFAULT_CORES = 1, MIN_WORKERS = 1 };
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #else /* Linux */
-#include <unistd.h>
+/* limits.h for ULLONG_MAX, stdio.h for fopen/fread, stdlib.h for strto*. */
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <sys/sysinfo.h>
-
+#include <unistd.h>
 #endif
 
 /* ── macOS detection ─────────────────────────────────────────────── */
@@ -103,18 +109,123 @@ static cbm_system_info_t detect_system_bsd(void) {
 
 #else /* Linux */
 
+/* Read up to (bufsz-1) bytes from `path` into `buf`, NUL-terminate, and strip
+ * trailing whitespace. Returns the (stripped) byte count, or -1 if the file
+ * could not be opened or read. */
+static int read_small_file(const char *path, char *buf, size_t bufsz) {
+    FILE *fp = fopen(path, "re");
+    if (fp == NULL) {
+        return -1;
+    }
+    size_t n = fread(buf, 1, bufsz - 1, fp);
+    fclose(fp);
+    while (n > 0 && (buf[n - 1] == '\n' || buf[n - 1] == ' ' || buf[n - 1] == '\t')) {
+        n--;
+    }
+    buf[n] = '\0';
+    return (int)n;
+}
+
+/* Effective CPU count from a cgroup file tree. See header for contract. */
+int cbm_detect_cgroup_cpus(const char *cgroup_root) {
+    char path[CBM_PATH_MAX];
+    char buf[CBM_SZ_64];
+
+    /* cgroup v2: "<root>/cpu.max" — "<quota> <period>" or "max <period>". */
+    snprintf(path, sizeof(path), "%s/cpu.max", cgroup_root);
+    if (read_small_file(path, buf, sizeof(buf)) > 0) {
+        if (strncmp(buf, "max", 3) == 0) {
+            return -1; /* no quota → caller falls back to sysconf */
+        }
+        long quota = 0;
+        long period = 0;
+        if (sscanf(buf, "%ld %ld", &quota, &period) == 2 && quota > 0 && period > 0) {
+            long n = (quota + period - 1) / period; /* ceil(quota/period) */
+            return n > 0 ? (int)n : MIN_WORKERS;
+        }
+        return -1;
+    }
+
+    /* cgroup v1: ".../cpu/cpu.cfs_quota_us" and ".../cpu/cpu.cfs_period_us".
+     * A quota of -1 means unlimited in cgroup v1. */
+    snprintf(path, sizeof(path), "%s/cpu/cpu.cfs_quota_us", cgroup_root);
+    if (read_small_file(path, buf, sizeof(buf)) <= 0) {
+        return -1;
+    }
+    long quota = strtol(buf, NULL, CBM_DECIMAL_BASE);
+    if (quota <= 0) {
+        return -1;
+    }
+
+    snprintf(path, sizeof(path), "%s/cpu/cpu.cfs_period_us", cgroup_root);
+    if (read_small_file(path, buf, sizeof(buf)) <= 0) {
+        return -1;
+    }
+    long period = strtol(buf, NULL, CBM_DECIMAL_BASE);
+    if (period <= 0) {
+        return -1;
+    }
+
+    long n = (quota + period - 1) / period;
+    return n > 0 ? (int)n : MIN_WORKERS;
+}
+
+/* Effective memory limit from a cgroup file tree. See header for contract. */
+size_t cbm_detect_cgroup_mem(const char *cgroup_root) {
+    char path[CBM_PATH_MAX];
+    char buf[CBM_SZ_64];
+
+    /* cgroup v2: "<root>/memory.max" — "max" or integer bytes. */
+    snprintf(path, sizeof(path), "%s/memory.max", cgroup_root);
+    if (read_small_file(path, buf, sizeof(buf)) > 0) {
+        if (strncmp(buf, "max", 3) == 0) {
+            return 0;
+        }
+        char *end = NULL;
+        unsigned long long n = strtoull(buf, &end, CBM_DECIMAL_BASE);
+        if (end == buf || n == 0) {
+            return 0;
+        }
+        return (size_t)n;
+    }
+
+    /* cgroup v1: ".../memory/memory.limit_in_bytes". The sentinel for
+     * "unlimited" is a very large value (~PAGE_COUNTER_MAX); treat anything
+     * past half of ULLONG_MAX as effectively unlimited. */
+    snprintf(path, sizeof(path), "%s/memory/memory.limit_in_bytes", cgroup_root);
+    if (read_small_file(path, buf, sizeof(buf)) <= 0) {
+        return 0;
+    }
+    char *end = NULL;
+    unsigned long long n = strtoull(buf, &end, CBM_DECIMAL_BASE);
+    if (end == buf || n == 0 || n >= (ULLONG_MAX / 2)) {
+        return 0;
+    }
+    return (size_t)n;
+}
+
 static cbm_system_info_t detect_system_linux(void) {
     cbm_system_info_t info;
     memset(&info, 0, sizeof(info));
 
+    /* Host fallbacks. */
     long nprocs = sysconf(_SC_NPROCESSORS_ONLN);
-    info.total_cores = nprocs > 0 ? (int)nprocs : 1;
-    info.perf_cores = info.total_cores; /* Linux doesn't distinguish P/E */
+    int host_cpus = nprocs > 0 ? (int)nprocs : DEFAULT_CORES;
 
+    size_t host_ram = 0;
     struct sysinfo si;
     if (sysinfo(&si) == 0) {
-        info.total_ram = (size_t)si.totalram * (size_t)si.mem_unit;
+        host_ram = (size_t)si.totalram * (size_t)si.mem_unit;
     }
+
+    /* Cgroup-aware overrides. min(cgroup, host) defends against
+     * mis-mounted cgroups that report values larger than the host. */
+    int cg_cpus = cbm_detect_cgroup_cpus("/sys/fs/cgroup");
+    info.total_cores = (cg_cpus > 0 && cg_cpus < host_cpus) ? cg_cpus : host_cpus;
+    info.perf_cores = info.total_cores; /* Linux doesn't distinguish P/E */
+
+    size_t cg_ram = cbm_detect_cgroup_mem("/sys/fs/cgroup");
+    info.total_ram = (cg_ram > 0 && (host_ram == 0 || cg_ram < host_ram)) ? cg_ram : host_ram;
 
     return info;
 }

--- a/src/foundation/system_info_internal.h
+++ b/src/foundation/system_info_internal.h
@@ -1,0 +1,44 @@
+/*
+ * system_info_internal.h — Internal helpers exposed for testing.
+ *
+ * These functions are implementation details of system_info.c; they are
+ * declared here only so that test_platform.c can drive them against a
+ * fake cgroup filesystem. Production code outside system_info.c should
+ * use the public APIs in platform.h instead.
+ */
+#ifndef CBM_FOUNDATION_SYSTEM_INFO_INTERNAL_H
+#define CBM_FOUNDATION_SYSTEM_INFO_INTERNAL_H
+
+#include <stddef.h>
+
+#ifdef __linux__
+
+/*
+ * Effective CPU count for the cgroup rooted at `cgroup_root`.
+ *
+ * Reads (in order):
+ *   1. cgroup v2: "<cgroup_root>/cpu.max"            ("<quota> <period>" or "max ...")
+ *   2. cgroup v1: "<cgroup_root>/cpu/cpu.cfs_quota_us" + ".../cpu.cfs_period_us"
+ *
+ * Returns ceil(quota / period) (>= 1) when a valid CPU quota is in place.
+ * Returns -1 when no cgroup limit is present (caller should fall back to
+ * sysconf(_SC_NPROCESSORS_ONLN)).
+ */
+int cbm_detect_cgroup_cpus(const char *cgroup_root);
+
+/*
+ * Effective memory limit (bytes) for the cgroup rooted at `cgroup_root`.
+ *
+ * Reads (in order):
+ *   1. cgroup v2: "<cgroup_root>/memory.max"             ("max" or integer bytes)
+ *   2. cgroup v1: "<cgroup_root>/memory/memory.limit_in_bytes"
+ *
+ * Returns the byte count when a finite limit is in place. Returns 0 when
+ * no cgroup limit is present, the limit is "max"/unlimited, or the value
+ * is so large it represents the cgroup-v1 "unlimited" sentinel.
+ */
+size_t cbm_detect_cgroup_mem(const char *cgroup_root);
+
+#endif /* __linux__ */
+
+#endif /* CBM_FOUNDATION_SYSTEM_INFO_INTERNAL_H */

--- a/tests/test_platform.c
+++ b/tests/test_platform.c
@@ -3,7 +3,17 @@
  */
 #include "test_framework.h"
 #include "../src/foundation/platform.h"
+#include "../src/foundation/system_info_internal.h"
 #include <unistd.h>
+
+#ifdef __linux__
+/* Linux-only cgroup tests need stdio for FILE*, stdlib for mkdtemp,
+ * string for strncpy/strchr, sys/stat for mkdir. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#endif
 
 TEST(platform_now_ns) {
     uint64_t t1 = cbm_now_ns();
@@ -68,6 +78,162 @@ TEST(platform_mmap_nonexistent) {
     PASS();
 }
 
+/* ── cgroup-aware detection (Linux only) ─────────────────────────── */
+
+#ifdef __linux__
+
+/* Create a unique tmp directory the caller will own; returns 0 on success. */
+static int cgroup_test_setup(char *root, size_t root_sz) {
+    strncpy(root, "/tmp/cbm_cgroup_test_XXXXXX", root_sz);
+    return mkdtemp(root) != NULL ? 0 : -1;
+}
+
+/* Write `content` to "<root>/<relpath>". Creates parent subdir if needed.
+ * Returns 0 on success, -1 on any failure. */
+static int cgroup_test_write(const char *root, const char *relpath, const char *content) {
+    char path[1024];
+    const char *slash = strchr(relpath, '/');
+    if (slash != NULL) {
+        char subdir[1024];
+        size_t n = (size_t)(slash - relpath);
+        if (n >= sizeof(subdir)) {
+            return -1;
+        }
+        memcpy(subdir, relpath, n);
+        subdir[n] = '\0';
+        snprintf(path, sizeof(path), "%s/%s", root, subdir);
+        (void)mkdir(path, S_IRWXU);
+    }
+    snprintf(path, sizeof(path), "%s/%s", root, relpath);
+    FILE *fp = fopen(path, "we");
+    if (fp == NULL) {
+        return -1;
+    }
+    size_t n = strlen(content);
+    int rc = (fwrite(content, 1, n, fp) == n) ? 0 : -1;
+    fclose(fp);
+    return rc;
+}
+
+/* Recursively remove a tmp dir created by cgroup_test_setup. Best-effort. */
+static void cgroup_test_teardown(const char *root) {
+    char cmd[1280];
+    snprintf(cmd, sizeof(cmd), "rm -rf -- '%s'", root);
+    (void)system(cmd);
+}
+
+TEST(cgroup_v2_cpu_quota) {
+    char root[64];
+    ASSERT_EQ(cgroup_test_setup(root, sizeof(root)), 0);
+    /* 200ms quota in a 100ms period → 2 effective CPUs. */
+    ASSERT_EQ(cgroup_test_write(root, "cpu.max", "200000 100000\n"), 0);
+    ASSERT_EQ(cbm_detect_cgroup_cpus(root), 2);
+    cgroup_test_teardown(root);
+    PASS();
+}
+
+TEST(cgroup_v2_cpu_quota_rounds_up) {
+    char root[64];
+    ASSERT_EQ(cgroup_test_setup(root, sizeof(root)), 0);
+    /* 150ms quota / 100ms period = 1.5 → ceil = 2. */
+    ASSERT_EQ(cgroup_test_write(root, "cpu.max", "150000 100000\n"), 0);
+    ASSERT_EQ(cbm_detect_cgroup_cpus(root), 2);
+    cgroup_test_teardown(root);
+    PASS();
+}
+
+TEST(cgroup_v2_cpu_unlimited) {
+    char root[64];
+    ASSERT_EQ(cgroup_test_setup(root, sizeof(root)), 0);
+    ASSERT_EQ(cgroup_test_write(root, "cpu.max", "max 100000\n"), 0);
+    ASSERT_EQ(cbm_detect_cgroup_cpus(root), -1);
+    cgroup_test_teardown(root);
+    PASS();
+}
+
+TEST(cgroup_v1_cpu_quota) {
+    char root[64];
+    ASSERT_EQ(cgroup_test_setup(root, sizeof(root)), 0);
+    ASSERT_EQ(cgroup_test_write(root, "cpu/cpu.cfs_quota_us", "200000"), 0);
+    ASSERT_EQ(cgroup_test_write(root, "cpu/cpu.cfs_period_us", "100000"), 0);
+    ASSERT_EQ(cbm_detect_cgroup_cpus(root), 2);
+    cgroup_test_teardown(root);
+    PASS();
+}
+
+TEST(cgroup_v1_cpu_unlimited) {
+    char root[64];
+    ASSERT_EQ(cgroup_test_setup(root, sizeof(root)), 0);
+    /* quota=-1 is the cgroup-v1 sentinel for "no quota". */
+    ASSERT_EQ(cgroup_test_write(root, "cpu/cpu.cfs_quota_us", "-1"), 0);
+    ASSERT_EQ(cgroup_test_write(root, "cpu/cpu.cfs_period_us", "100000"), 0);
+    ASSERT_EQ(cbm_detect_cgroup_cpus(root), -1);
+    cgroup_test_teardown(root);
+    PASS();
+}
+
+TEST(cgroup_no_cpu_files) {
+    char root[64];
+    ASSERT_EQ(cgroup_test_setup(root, sizeof(root)), 0);
+    /* Empty tmp dir: no v2 file, no v1 file → fall through to sysconf. */
+    ASSERT_EQ(cbm_detect_cgroup_cpus(root), -1);
+    cgroup_test_teardown(root);
+    PASS();
+}
+
+TEST(cgroup_v2_mem) {
+    char root[64];
+    ASSERT_EQ(cgroup_test_setup(root, sizeof(root)), 0);
+    /* 2 GiB. */
+    ASSERT_EQ(cgroup_test_write(root, "memory.max", "2147483648\n"), 0);
+    ASSERT_EQ(cbm_detect_cgroup_mem(root), (size_t)2147483648UL);
+    cgroup_test_teardown(root);
+    PASS();
+}
+
+TEST(cgroup_v2_mem_unlimited) {
+    char root[64];
+    ASSERT_EQ(cgroup_test_setup(root, sizeof(root)), 0);
+    ASSERT_EQ(cgroup_test_write(root, "memory.max", "max\n"), 0);
+    ASSERT_EQ(cbm_detect_cgroup_mem(root), (size_t)0);
+    cgroup_test_teardown(root);
+    PASS();
+}
+
+TEST(cgroup_v1_mem) {
+    char root[64];
+    ASSERT_EQ(cgroup_test_setup(root, sizeof(root)), 0);
+    /* 1 GiB. */
+    ASSERT_EQ(cgroup_test_write(root, "memory/memory.limit_in_bytes", "1073741824"), 0);
+    ASSERT_EQ(cbm_detect_cgroup_mem(root), (size_t)1073741824UL);
+    cgroup_test_teardown(root);
+    PASS();
+}
+
+TEST(cgroup_v1_mem_unlimited_sentinel) {
+    char root[64];
+    ASSERT_EQ(cgroup_test_setup(root, sizeof(root)), 0);
+    /* cgroup v1 reports a huge near-ULLONG_MAX value when unlimited
+     * (PAGE_COUNTER_MAX). Our parser treats anything >= ULLONG_MAX/2
+     * as effectively unlimited. */
+    ASSERT_EQ(cgroup_test_write(root, "memory/memory.limit_in_bytes",
+                                "9223372036854775807"),
+              0);
+    ASSERT_EQ(cbm_detect_cgroup_mem(root), (size_t)0);
+    cgroup_test_teardown(root);
+    PASS();
+}
+
+TEST(cgroup_no_mem_files) {
+    char root[64];
+    ASSERT_EQ(cgroup_test_setup(root, sizeof(root)), 0);
+    ASSERT_EQ(cbm_detect_cgroup_mem(root), (size_t)0);
+    cgroup_test_teardown(root);
+    PASS();
+}
+
+#endif /* __linux__ */
+
 SUITE(platform) {
     RUN_TEST(platform_now_ns);
     RUN_TEST(platform_now_ms);
@@ -77,4 +243,17 @@ SUITE(platform) {
     RUN_TEST(platform_file_size);
     RUN_TEST(platform_mmap);
     RUN_TEST(platform_mmap_nonexistent);
+#ifdef __linux__
+    RUN_TEST(cgroup_v2_cpu_quota);
+    RUN_TEST(cgroup_v2_cpu_quota_rounds_up);
+    RUN_TEST(cgroup_v2_cpu_unlimited);
+    RUN_TEST(cgroup_v1_cpu_quota);
+    RUN_TEST(cgroup_v1_cpu_unlimited);
+    RUN_TEST(cgroup_no_cpu_files);
+    RUN_TEST(cgroup_v2_mem);
+    RUN_TEST(cgroup_v2_mem_unlimited);
+    RUN_TEST(cgroup_v1_mem);
+    RUN_TEST(cgroup_v1_mem_unlimited_sentinel);
+    RUN_TEST(cgroup_no_mem_files);
+#endif
 }


### PR DESCRIPTION
## Summary

Closes #363 in conjunction with #364: this PR is the auto-detect half of cgroup-awareness; #364 is the `CBM_WORKERS` env-override escape hatch. They're independent and can land in either order.

Today `detect_system_linux()` reports host CPU count via `sysconf(_SC_NPROCESSORS_ONLN)` and host RAM via `sysinfo()`. Inside a container, neither reflects the cgroup's effective quota, so `cbm_default_worker_count` over-provisions workers and the SQLite mmap budget can exceed the cgroup memory cap — see #363 for the OOMKill story.

This PR makes the Linux detection path cgroup-aware:

1. **CPUs**: read `<root>/cpu.max` (v2) or `<root>/cpu/cpu.cfs_quota_us` + `cpu.cfs_period_us` (v1), compute `ceil(quota / period)`. `"max"` and `-1` quotas mean "no limit, fall back to sysconf".
2. **Memory**: read `<root>/memory.max` (v2) or `<root>/memory/memory.limit_in_bytes` (v1). `"max"` is unlimited; cgroup v1's near-`ULLONG_MAX` sentinel (`PAGE_COUNTER_MAX`) is also treated as unlimited.
3. **Safety clamp**: both axes take `min(cgroup, host)`, so a mis-mounted cgroup that reports something bigger than the host can't push us above true hardware.
4. **Fallback**: missing cgroup files → host values, exactly as before. Bare-metal hosts and non-Linux platforms are unchanged.

The helpers live in a new internal header `src/foundation/system_info_internal.h` (same pattern as the existing `pipeline_internal.h`) so tests can drive them against a fake `/sys/fs/cgroup` tree without depending on the runtime environment.

## Why this matters

Symptoms in the downstream consumer (sast-ai-app) before the workaround landed:

- Pod with `limits.memory: 2Gi` on a 32-core node spawned 32 indexing workers.
- Each worker's mmap window scaled with host RAM rather than the cgroup cap.
- Result: `OOMKilled` mid-index, watcher restart loop, 20Gi PVC grew anyway.

Operationally this was patched downstream by quadrupling pod memory and pre-creating PVCs at 4× the size CBM "thought" it needed. With this PR, the cgroup limits flow through `cbm_default_worker_count` naturally and the over-provisioning disappears.

## Test plan

11 new Linux-only tests in `tests/test_platform.c`, each creating a fresh `mkdtemp` tree and exercising one detection path:

- `cgroup_v2_cpu_quota` — `cpu.max = "200000 100000"` → 2
- `cgroup_v2_cpu_quota_rounds_up` — `cpu.max = "150000 100000"` → ceil(1.5) = 2
- `cgroup_v2_cpu_unlimited` — `cpu.max = "max 100000"` → -1
- `cgroup_v1_cpu_quota` — cfs_quota_us/cfs_period_us = 200000/100000 → 2
- `cgroup_v1_cpu_unlimited` — cfs_quota_us = -1 → -1
- `cgroup_no_cpu_files` — empty tmp dir → -1
- `cgroup_v2_mem` — `memory.max = "2147483648"` → 2 GiB
- `cgroup_v2_mem_unlimited` — `memory.max = "max"` → 0
- `cgroup_v1_mem` — `memory.limit_in_bytes = "1073741824"` → 1 GiB
- `cgroup_v1_mem_unlimited_sentinel` — `memory.limit_in_bytes = "9223372036854775807"` → 0
- `cgroup_no_mem_files` — empty tmp dir → 0

### Local verification

Verified on macOS (Apple Silicon, clang 17). The 11 Linux tests are `#ifdef __linux__`-guarded and skipped on macOS, so end-to-end Linux validation lives in upstream CI.

- **Build** (`scripts/build.sh`, `-Wall -Wextra -Werror`): clean, 47s.
- **Test** (`scripts/test.sh`): `3553 passed, 1 failed`. The single failure is `search_code_multi_word` in `tests/test_mcp.c:694` — already failing on plain `upstream/main` at the same SHA, unrelated to this PR, also showing up on recent nightly soak failures.
- **Lint** (`clang-format` + `cppcheck`): clean on all three touched files. (The remaining `clang-format` diff at `system_info.c:97/99` is in BSD code I didn't touch; it reflects an Apple clang-format 17 vs. CI clang-format disagreement that exists on `upstream/main` already.)

## Files

- `src/foundation/system_info.c` — new cgroup helpers; `detect_system_linux` rewritten with the safety clamps. macOS/BSD/Windows paths untouched. (+117/-6)
- `src/foundation/system_info_internal.h` — new internal header declaring the cgroup helpers for tests. (+44)
- `tests/test_platform.c` — 11 new Linux-only tests + small tmp-dir/fixture helpers. (+179)

## Relationship to #364

These two are deliberately independent:

- This PR (#363) gives CBM the **right default** in containers.
- #364 (`CBM_WORKERS` env override) lets operators **force a specific value** when they want to leave additional headroom below the cgroup cap (or above it, on bare metal).

If both land, the precedence is: `CBM_WORKERS` env > cgroup auto-detect > host fallback, which matches the precedence shape we use for other `CBM_*` knobs.
