### PR TITLE
fix(cypher): label-filtered edge traversal silently truncates at 10 results

### DIFF
--- a/src/cypher/cypher.c
+++ b/src/cypher/cypher.c
@@ -4201,7 +4201,7 @@ static int execute_single(cbm_store_t *store, cbm_query_t *q, const char *projec
     scan_pattern_nodes(store, project, max_rows, &pat0->nodes[0], &scanned, &scan_count);
 
     /* Build initial bindings with early WHERE */
-    int bind_cap = scan_count > 0 ? scan_count : SKIP_ONE;
+    int bind_cap = scan_count > max_rows ? scan_count : (max_rows > 0 ? max_rows : SKIP_ONE);
     binding_t *bindings = malloc((bind_cap + SKIP_ONE) * sizeof(binding_t));
     int bind_count = 0;
     const char *var_name = pat0->nodes[0].variable ? pat0->nodes[0].variable : "_n0";

--- a/tests/test_incremental.c
+++ b/tests/test_incremental.c
@@ -400,8 +400,8 @@ TEST(incr_modify_file) {
 
     /* Single-file incremental should be faster than full */
     if ((int)ms > (int)(g_full_index_ms * 1.5)) {
-        printf("    [PERF WARNING] incremental slower than 1.5x full: %.0fms vs %.0fms\n",
-               ms, g_full_index_ms);
+        printf("    [PERF WARNING] incremental slower than 1.5x full: %.0fms vs %.0fms\n", ms,
+               g_full_index_ms);
     }
 
     printf("    [perf] modify 1 file: %.0fms (full was %.0fms)\n", ms, g_full_index_ms);
@@ -910,12 +910,12 @@ static int resp_lacks_key(const char *resp, const char *key) {
 }
 
 /* Helper: assert tool call succeeds, warn if slow */
-#define TOOL_OK(resp, ms)                                                              \
-    do {                                                                               \
-        ASSERT((resp) != NULL);                                                        \
-        if ((int)(ms) > PERF_WARN_MS) {                                                \
+#define TOOL_OK(resp, ms)                                                                 \
+    do {                                                                                  \
+        ASSERT((resp) != NULL);                                                           \
+        if ((int)(ms) > PERF_WARN_MS) {                                                   \
             printf("    [PERF WARNING] tool call: %.0fms (>%dms)\n", (ms), PERF_WARN_MS); \
-        }                                                                              \
+        }                                                                                 \
     } while (0)
 
 /* Helper: assert response is not an error */
@@ -928,6 +928,38 @@ TEST(tool_list_projects_basic) {
     char *r = call_tool_timed("list_projects", &ms, "{}");
     TOOL_OK(r, ms);
     ASSERT(strstr(r, "projects") != NULL);
+    free(r);
+    PASS();
+}
+
+TEST(tool_qg_defines_method_more_than_10) {
+    write_file_at("fastapi/big_class.py", "class BigClass:\n"
+                                          "    def m1(self): pass\n"
+                                          "    def m2(self): pass\n"
+                                          "    def m3(self): pass\n"
+                                          "    def m4(self): pass\n"
+                                          "    def m5(self): pass\n"
+                                          "    def m6(self): pass\n"
+                                          "    def m7(self): pass\n"
+                                          "    def m8(self): pass\n"
+                                          "    def m9(self): pass\n"
+                                          "    def m10(self): pass\n"
+                                          "    def m11(self): pass\n"
+                                          "    def m12(self): pass\n"
+                                          "    def m13(self): pass\n"
+                                          "    def m14(self): pass\n"
+                                          "    def m15(self): pass\n");
+    char *idx = index_repo();
+    ASSERT(idx != NULL);
+    free(idx);
+    double ms;
+    char *r = call_tool_timed("query_graph", &ms,
+                              "{\"project\":\"%s\","
+                              "\"query\":\"MATCH (c:Class)-[:DEFINES_METHOD]->(m:Method)"
+                              " WHERE c.name = 'BigClass' RETURN count(m) AS n\"}",
+                              g_project);
+    TOOL_OK(r, ms);
+    ASSERT(strstr(r, "\"15\"") != NULL || strstr(r, "\\\"15\\\"") != NULL);
     free(r);
     PASS();
 }
@@ -3042,6 +3074,7 @@ SUITE(incremental) {
     RUN_TEST(tool_qg_configures);
     RUN_TEST(tool_qg_handles);
     RUN_TEST(tool_qg_defines_method);
+    RUN_TEST(tool_qg_defines_method_more_than_10);
     RUN_TEST(tool_qg_no_limit);
     RUN_TEST(tool_qg_empty_result);
 


### PR DESCRIPTION
**MATCH with label filters silently returns at most 10 results regardless of actual edge count**

Discovered while using codebase-memory-mcp on a production codebase. A class with 37 methods returned only 10 via `MATCH (c:Class)-[:DEFINES_METHOD]->(m:Method)`. No error, no warning, no truncation indicator — the query appeared to succeed. Querying without label filters (`MATCH (c)-[:DEFINES_METHOD]->(m)`) returned all 37.

**Root cause**

In `execute_single()`, `bind_cap` is set to `scan_count` — the number of nodes returned by the initial pattern scan. When matching a single class by name, `scan_count = 1`. The edge expansion loop then runs with `max_new = bind_cap * CYP_GROWTH_10 = 10`, and exits after collecting 10 edges.

```c
// before
int bind_cap = scan_count > 0 ? scan_count : SKIP_ONE;
// bind_cap = 1, max_new = 10 — silently drops any edge beyond the 10th

// after
int bind_cap = scan_count > max_rows ? scan_count : (max_rows > 0 ? max_rows : SKIP_ONE);
// bind_cap = max_rows (default 100k), max_new = 1,000,000 — no truncation
```

This affects any label-filtered edge traversal where the initial pattern matches few nodes but each node has many edges. A single class with >10 methods, a single module with >10 imports, etc. Language-agnostic.

**Regression test**

A Python class with 15 methods indexed in full mode must return all 15 via `MATCH (c:Class)-[:DEFINES_METHOD]->(m:Method) WHERE c.name = 'BigClass'`. Added to `tests/test_incremental.c`.

**Relation to existing issues**

This is a distinct variant of the "silent incomplete index" pattern tracked in #391. The difference: the graph is correctly built (all 37 edges exist in SQLite), but the Cypher query engine silently caps traversal at 10. `cbm_store_count_edges()` returns the correct total; the truncation only appears when querying with label-typed patterns.

Happy to add more detail to the test if useful.
