### PR TITLE
Publish to the official MCP Registry from the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,6 +308,44 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: twine upload --non-interactive dist/*
 
+  # ── 8b. Publish server.json to the official MCP Registry ──────
+  # Runs after npm + PyPI so the registry can verify package ownership
+  # (npm: `mcpName` field in package.json; PyPI: `mcp-name:` marker in
+  # the package README). Authenticates with GitHub Actions OIDC — no
+  # token, no interactive device flow. server.json's version is synced
+  # from the just-published npm package so it always matches the release.
+  #
+  # Intentionally does NOT gate publish-final: the binary release is the
+  # product, the registry entry is metadata. A registry-preview outage
+  # must never block shipping. Re-run this job alone to retry — it does
+  # not touch npm/PyPI, so retries are safe.
+  publish-mcp-registry:
+    needs: [publish-registries]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # GitHub OIDC auth to the MCP Registry
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Sync server.json version to the released package
+        run: |
+          VERSION=$(jq -r '.version' pkg/npm/package.json)
+          jq --arg v "$VERSION" '.version = $v | (.packages[].version) = $v' \
+            server.json > server.tmp && mv server.tmp server.json
+          echo "server.json pinned to $VERSION"
+          cat server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server.json to MCP Registry
+        run: ./mcp-publisher publish
+
   # ── 9. Atomic un-draft (only after npm + PyPI succeed) ────────
   # The GitHub release stays in DRAFT until both registries publish.
   # If anything upstream fails, the draft can be deleted and the run

--- a/pkg/npm/package.json
+++ b/pkg/npm/package.json
@@ -2,6 +2,7 @@
   "name": "codebase-memory-mcp",
   "version": "0.7.0",
   "description": "Fast code intelligence engine for AI coding agents — single static binary MCP server",
+  "mcpName": "io.github.DeusData/codebase-memory-mcp",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/pkg/pypi/README.md
+++ b/pkg/pypi/README.md
@@ -1,5 +1,7 @@
 # codebase-memory-mcp
 
+mcp-name: io.github.DeusData/codebase-memory-mcp
+
 **Fast code intelligence engine for AI coding agents.** Indexes an average repository in milliseconds, the Linux kernel (28M LOC) in 3 minutes. Answers structural queries in under 1ms.
 
 This package installs the `codebase-memory-mcp` binary from [GitHub Releases](https://github.com/DeusData/codebase-memory-mcp/releases). The binary is downloaded on first run and cached in your OS cache directory.

--- a/server.json
+++ b/server.json
@@ -2,49 +2,28 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.DeusData/codebase-memory-mcp",
   "title": "Codebase Memory",
-  "description": "Persistent codebase knowledge graph — 159 languages, sub-ms queries, 99% fewer tokens than grep. Survives session restarts and context compaction.",
+  "description": "Codebase knowledge graph for AI agents — 159 languages, sub-ms queries, 99% fewer tokens.",
   "repository": {
     "url": "https://github.com/DeusData/codebase-memory-mcp",
     "source": "github"
   },
-  "version": "0.6.1",
+  "websiteUrl": "https://deusdata.github.io/codebase-memory-mcp/",
+  "version": "0.7.0",
   "packages": [
     {
-      "registryType": "mcpb",
-      "identifier": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.6.1/codebase-memory-mcp-darwin-arm64.tar.gz",
-      "fileSha256": "3468e5df340e53dba2d23cc30bf44210c412dfb2538d7da992465934bf4980e0",
+      "registryType": "npm",
+      "identifier": "codebase-memory-mcp",
+      "version": "0.7.0",
+      "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
       }
     },
     {
-      "registryType": "mcpb",
-      "identifier": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.6.1/codebase-memory-mcp-darwin-amd64.tar.gz",
-      "fileSha256": "a85f8313181c7ffd3a0ac494c0e2bf1b5647f15de06686f8a0728162bf4326ac",
-      "transport": {
-        "type": "stdio"
-      }
-    },
-    {
-      "registryType": "mcpb",
-      "identifier": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.6.1/codebase-memory-mcp-linux-amd64.tar.gz",
-      "fileSha256": "a24c04fd1fd61b08158e011685cf08d860e3594e4ce057ffda57d1cc2f4afdd1",
-      "transport": {
-        "type": "stdio"
-      }
-    },
-    {
-      "registryType": "mcpb",
-      "identifier": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.6.1/codebase-memory-mcp-linux-arm64.tar.gz",
-      "fileSha256": "29811aadc2aa99fb9612683af30a06d03fcb2bfefb95c12ea672671827bd111c",
-      "transport": {
-        "type": "stdio"
-      }
-    },
-    {
-      "registryType": "mcpb",
-      "identifier": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.6.1/codebase-memory-mcp-windows-amd64.zip",
-      "fileSha256": "e331f84f2ec760d179025b16b440b0f14282e83f2432318969dc69dde8ffffd0",
+      "registryType": "pypi",
+      "identifier": "codebase-memory-mcp",
+      "version": "0.7.0",
+      "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## What

Wires automatic publishing to the **official MCP Registry** (`registry.modelcontextprotocol.io`) into the existing release pipeline, and fixes `server.json` so it actually validates.

## Changes

- **`pkg/npm/package.json`** — add `"mcpName": "io.github.DeusData/codebase-memory-mcp"` (required: the registry verifies npm ownership by matching this against `server.json` `name`). No version bump — the release stage owns versions.
- **`pkg/pypi/README.md`** — add the `mcp-name:` ownership marker (PyPI's equivalent of `mcpName`).
- **`server.json`** — switch from five per-platform `mcpb` tarball entries (pinned to a stale `0.6.1` with hardcoded SHA-256s) to `npm` + `pypi` package entries. The package form needs only a version sync per release, not five new hashes. Also trims the `description` to the registry's hard **100-char** limit (the old one was ~145 and would have been rejected).
- **`.github/workflows/release.yml`** — new `publish-mcp-registry` job: downloads `mcp-publisher`, authenticates via **GitHub Actions OIDC** (no token, no interactive device flow), syncs `server.json`'s version to the just-published npm package, and runs `mcp-publisher publish`.

## Notes

- The job runs **after** npm/PyPI publish (so ownership verification passes) but **does not gate the release un-draft** — a registry-preview outage can't block shipping, and the job can be retried on its own without re-running `npm publish`.
- **This takes effect on the next release.** The current live npm `0.7.0` predates the `mcpName` field, so the registry entry is created when the next release republishes npm *with* `mcpName` and then publishes `server.json`.
- The publishing GitHub identity must have rights in the `DeusData` org for the `io.github.DeusData/*` namespace (OIDC uses the repo owner).