### PR TITLE
ci: deploy Pages via Actions, scoped to docs changes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+# Deploy the static site in /docs to GitHub Pages.
+#
+# Replaces the legacy "Deploy from a branch" (Jekyll) build, which ran on
+# EVERY push to main and failed because Jekyll's Liquid parser choked on the
+# planning docs under /docs (e.g. `Unknown tag 'data'` in EVALUATION_PLAN.md).
+# /docs is a hand-written static site (index.html + robots/sitemap/llms.txt),
+# so we upload it as-is — no Jekyll — and only run when the site changes.
+#
+# Requires the repo Pages source to be set to "GitHub Actions"
+# (Settings → Pages → Build and deployment → Source: GitHub Actions).
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deployment at a time; never cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: ./docs
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Problem
The **website build (`pages-build-deployment`) fails after almost every commit.** It's the legacy "Deploy from a branch" Pages setup (source: \`main\` → \`/docs\`), which runs **Jekyll on every push to main**. Jekyll's Liquid parser chokes on a planning doc:

```
Liquid Exception: Liquid syntax error (line 4253): Unknown tag 'data' in EVALUATION_PLAN.md
```

Two issues in one: (a) it fails, and (b) it runs on *every* commit even when nothing under `/docs` changed.

## Fix
`/docs` is a hand-written **static** site (`index.html` + `robots.txt`/`sitemap.xml`/`llms.txt` + a screenshot) — it never used Jekyll. So:

- Add `.github/workflows/pages.yml` that uploads `/docs` **as-is via GitHub Actions** (no Jekyll → the Liquid error is gone permanently) and triggers **only** on `paths: [docs/**]` (+ manual dispatch).
- Add `docs/.nojekyll` as a guard.
- Actions pinned by SHA (matches the repo's OpenSSF Scorecard posture).

## ⚠️ One settings change required
After merge, set **Settings → Pages → Source: GitHub Actions** (or it's switched via API). Until then the legacy build stays selected. The live site keeps serving the last good deploy throughout — no downtime.

`EVALUATION_PLAN.md`/`BENCHMARK.md` stay in `/docs` and are served as static files; they're simply no longer run through Jekyll.