### PR TITLE
feat(cross-repo): link Maven library dependencies

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -273,7 +273,8 @@ static const tool_def_t TOOLS[] = {
     {"index_repository",
      "Index a repository into the knowledge graph. "
      "Special mode 'cross-repo-intelligence': skip extraction, only match Routes/Channels "
-     "across projects to create CROSS_HTTP_CALLS/CROSS_ASYNC_CALLS/CROSS_CHANNEL edges. "
+     "and Maven library dependencies across projects to create CROSS_HTTP_CALLS/"
+     "CROSS_ASYNC_CALLS/CROSS_CHANNEL/CROSS_LIBRARY_DEPENDS_ON/CROSS_LIBRARY_USED_BY edges. "
      "Requires target_projects param. Ensure target projects have fresh indexes first.",
      "{\"type\":\"object\",\"properties\":{\"repo_path\":{\"type\":\"string\",\"description\":"
      "\"Path to the repository\"},"
@@ -282,7 +283,8 @@ static const tool_def_t TOOLS[] = {
      "\"default\":\"full\",\"description\":\"All modes run type-aware LSP call/usage "
      "resolution (per-file + cross-file). full: all files + similarity/semantic edges. "
      "moderate: filtered files + similarity/semantic. fast: filtered files, no "
-     "similarity/semantic. cross-repo-intelligence: match Routes/Channels across projects.\"},"
+     "similarity/semantic. cross-repo-intelligence: match Routes/Channels and Maven library "
+     "dependencies across projects.\"},"
      "\"target_projects\":{\"type\":\"array\",\"items\":{\"type\":\"string\"},"
      "\"description\":\"Projects to search for cross-repo links (cross-repo-intelligence mode). "
      "Use [\\\"*\\\"] for all indexed projects. Run list_projects to see available projects.\"},"
@@ -1813,9 +1815,14 @@ static void append_cross_repo_summary(yyjson_mut_doc *doc, yyjson_mut_val *root,
     /* Scan edge types for any CROSS_* edges and sum them */
     int cross_total = 0;
     yyjson_mut_val *cr = yyjson_mut_obj(doc);
-    static const char *cross_types[] = {"CROSS_HTTP_CALLS",    "CROSS_ASYNC_CALLS",
-                                        "CROSS_CHANNEL",       "CROSS_GRPC_CALLS",
-                                        "CROSS_GRAPHQL_CALLS", "CROSS_TRPC_CALLS"};
+    static const char *cross_types[] = {"CROSS_HTTP_CALLS",
+                                        "CROSS_ASYNC_CALLS",
+                                        "CROSS_CHANNEL",
+                                        "CROSS_GRPC_CALLS",
+                                        "CROSS_GRAPHQL_CALLS",
+                                        "CROSS_TRPC_CALLS",
+                                        "CROSS_LIBRARY_DEPENDS_ON",
+                                        "CROSS_LIBRARY_USED_BY"};
     for (int t = 0; t < (int)(sizeof(cross_types) / sizeof(cross_types[0])); t++) {
         for (int i = 0; i < schema->edge_type_count; i++) {
             if (strcmp(schema->edge_types[i].type, cross_types[t]) == 0) {
@@ -2462,7 +2469,7 @@ static char *handle_cross_repo_mode(const char *repo_path, const char *args) {
     yyjson_doc_free(jdoc);
 
     int total = result.http_edges + result.async_edges + result.channel_edges + result.grpc_edges +
-                result.graphql_edges + result.trpc_edges;
+                result.graphql_edges + result.trpc_edges + result.library_edges;
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
     yyjson_mut_val *root = yyjson_mut_obj(doc);
     yyjson_mut_doc_set_root(doc, root);
@@ -2476,6 +2483,7 @@ static char *handle_cross_repo_mode(const char *repo_path, const char *args) {
     yyjson_mut_obj_add_int(doc, root, "cross_grpc_calls", result.grpc_edges);
     yyjson_mut_obj_add_int(doc, root, "cross_graphql_calls", result.graphql_edges);
     yyjson_mut_obj_add_int(doc, root, "cross_trpc_calls", result.trpc_edges);
+    yyjson_mut_obj_add_int(doc, root, "cross_library_edges", result.library_edges);
     yyjson_mut_obj_add_int(doc, root, "total_cross_edges", total);
     yyjson_mut_obj_add_real(doc, root, "elapsed_ms", result.elapsed_ms);
 

--- a/src/pipeline/pass_cross_repo.c
+++ b/src/pipeline/pass_cross_repo.c
@@ -17,6 +17,7 @@
 #include "foundation/compat_fs.h"
 
 #include <sqlite3/sqlite3.h>
+#include <yyjson/yyjson.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -30,6 +31,7 @@ enum {
     CR_QN_BUF = 512,
     CR_PROPS_BUF = 2048,
     CR_MAX_EDGES = 4096,
+    CR_MAX_POM_SIZE = 2 * 1024 * 1024,
     CR_DB_EXT_LEN = 3, /* strlen(".db") */
     CR_INIT_CAP = 32,
     CR_COL_3 = 3,
@@ -38,6 +40,23 @@ enum {
 
 #define CR_MS_PER_SEC 1000.0
 #define CR_NS_PER_MS 1000000.0
+
+typedef struct {
+    char group_id[CBM_SZ_128];
+    char artifact_id[CBM_SZ_128];
+    char pom_path[CBM_SZ_512];
+} cr_maven_artifact_t;
+
+typedef struct {
+    char group_id[CBM_SZ_128];
+    char artifact_id[CBM_SZ_128];
+    char version[CBM_SZ_128];
+    char scope[CBM_SZ_64];
+    char relation[CBM_SZ_32];
+    char context_group_id[CBM_SZ_128];
+    char context_artifact_id[CBM_SZ_128];
+    char pom_path[CBM_SZ_512];
+} cr_maven_dependency_t;
 
 /* TLS buffer for integer-to-string in log calls. */
 static CBM_TLS char cr_ibuf[CBM_SZ_32];
@@ -112,6 +131,22 @@ static void delete_cross_edges(cbm_store_t *store, const char *project) {
     cbm_store_delete_edges_by_type(store, project, "CROSS_GRPC_CALLS");
     cbm_store_delete_edges_by_type(store, project, "CROSS_GRAPHQL_CALLS");
     cbm_store_delete_edges_by_type(store, project, "CROSS_TRPC_CALLS");
+    cbm_store_delete_edges_by_type(store, project, "CROSS_LIBRARY_DEPENDS_ON");
+    cbm_store_delete_edges_by_type(store, project, "CROSS_LIBRARY_USED_BY");
+    struct sqlite3 *db = cbm_store_get_db(store);
+    if (!db) {
+        return;
+    }
+    sqlite3_stmt *st = NULL;
+    if (sqlite3_prepare_v2(db,
+                           "DELETE FROM nodes WHERE project=?1 AND "
+                           "(qualified_name LIKE '__library__%' OR "
+                           "qualified_name LIKE '__library_consumer__%')",
+                           CBM_NOT_FOUND, &st, NULL) == SQLITE_OK) {
+        sqlite3_bind_text(st, SKIP_ONE, project, CBM_NOT_FOUND, SQLITE_STATIC);
+        sqlite3_step(st);
+        sqlite3_finalize(st);
+    }
 }
 
 /* Insert a CROSS_* edge into a store. */
@@ -125,6 +160,552 @@ static void insert_cross_edge(cbm_store_t *store, const char *project, int64_t f
         .properties_json = props,
     };
     cbm_store_insert_edge(store, &edge);
+}
+
+static bool text_has_suffix(const char *s, const char *suffix) {
+    if (!s || !suffix) {
+        return false;
+    }
+    size_t sl = strlen(s);
+    size_t tl = strlen(suffix);
+    return sl >= tl && strcmp(s + sl - tl, suffix) == 0;
+}
+
+static void trim_copy(const char *start, size_t len, char *out, size_t out_sz) {
+    if (!out || out_sz == 0) {
+        return;
+    }
+    out[0] = '\0';
+    if (!start) {
+        return;
+    }
+    while (len > 0 && (*start == ' ' || *start == '\n' || *start == '\r' || *start == '\t')) {
+        start++;
+        len--;
+    }
+    while (len > 0) {
+        char c = start[len - SKIP_ONE];
+        if (c != ' ' && c != '\n' && c != '\r' && c != '\t') {
+            break;
+        }
+        len--;
+    }
+    if (len >= out_sz) {
+        len = out_sz - SKIP_ONE;
+    }
+    memcpy(out, start, len);
+    out[len] = '\0';
+}
+
+static bool ptr_in_span(const char *p, const char *start, const char *end) {
+    return p && start && end && p >= start && p < end;
+}
+
+static bool ptr_in_xml_block_named(const char *xml, const char *tag, const char *p) {
+    char open_pat[CBM_SZ_64];
+    char close_pat[CBM_SZ_64];
+    snprintf(open_pat, sizeof(open_pat), "<%s", tag);
+    snprintf(close_pat, sizeof(close_pat), "</%s>", tag);
+
+    const char *scan = xml;
+    while ((scan = strstr(scan, open_pat)) != NULL) {
+        const char *open_end = strchr(scan, '>');
+        if (!open_end) {
+            return false;
+        }
+        const char *close = strstr(open_end + SKIP_ONE, close_pat);
+        if (!close) {
+            return false;
+        }
+        const char *block_end = close + strlen(close_pat);
+        if (ptr_in_span(p, scan, block_end)) {
+            return true;
+        }
+        scan = block_end;
+    }
+    return false;
+}
+
+static bool find_xml_block(const char *xml, const char *tag, const char **block_start,
+                           const char **block_end) {
+    char open_pat[CBM_SZ_64];
+    char close_pat[CBM_SZ_64];
+    snprintf(open_pat, sizeof(open_pat), "<%s", tag);
+    snprintf(close_pat, sizeof(close_pat), "</%s>", tag);
+    const char *open = strstr(xml, open_pat);
+    if (!open) {
+        return false;
+    }
+    const char *open_end = strchr(open, '>');
+    if (!open_end) {
+        return false;
+    }
+    const char *close = strstr(open_end + SKIP_ONE, close_pat);
+    if (!close) {
+        return false;
+    }
+    *block_start = open;
+    *block_end = close + strlen(close_pat);
+    return true;
+}
+
+static bool xml_tag_text(const char *start, const char *end, const char *tag, char *out,
+                         size_t out_sz) {
+    char open_pat[CBM_SZ_64];
+    char close_pat[CBM_SZ_64];
+    snprintf(open_pat, sizeof(open_pat), "<%s", tag);
+    snprintf(close_pat, sizeof(close_pat), "</%s>", tag);
+
+    const char *p = start;
+    while ((p = strstr(p, open_pat)) != NULL && (!end || p < end)) {
+        const char *open_end = strchr(p, '>');
+        if (!open_end || (end && open_end >= end)) {
+            return false;
+        }
+        const char *close = strstr(open_end + SKIP_ONE, close_pat);
+        if (!close || (end && close > end)) {
+            return false;
+        }
+        trim_copy(open_end + SKIP_ONE, (size_t)(close - open_end - SKIP_ONE), out, out_sz);
+        return out[0] != '\0';
+    }
+    return false;
+}
+
+static bool xml_tag_text_outside_project_blocks(const char *xml, const char *tag, char *out,
+                                                size_t out_sz) {
+    const char *parent_start = NULL;
+    const char *parent_end = NULL;
+    const char *deps_start = NULL;
+    const char *deps_end = NULL;
+    find_xml_block(xml, "parent", &parent_start, &parent_end);
+    find_xml_block(xml, "dependencies", &deps_start, &deps_end);
+
+    char open_pat[CBM_SZ_64];
+    char close_pat[CBM_SZ_64];
+    snprintf(open_pat, sizeof(open_pat), "<%s", tag);
+    snprintf(close_pat, sizeof(close_pat), "</%s>", tag);
+
+    const char *p = xml;
+    while ((p = strstr(p, open_pat)) != NULL) {
+        if (ptr_in_span(p, parent_start, parent_end) || ptr_in_span(p, deps_start, deps_end)) {
+            p += strlen(open_pat);
+            continue;
+        }
+        const char *open_end = strchr(p, '>');
+        if (!open_end) {
+            return false;
+        }
+        const char *close = strstr(open_end + SKIP_ONE, close_pat);
+        if (!close) {
+            return false;
+        }
+        trim_copy(open_end + SKIP_ONE, (size_t)(close - open_end - SKIP_ONE), out, out_sz);
+        return out[0] != '\0';
+    }
+    return false;
+}
+
+static char *read_text_file_cap(const char *path) {
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return NULL;
+    }
+    long sz = ftell(f);
+    if (sz < 0 || sz > CR_MAX_POM_SIZE) {
+        fclose(f);
+        return NULL;
+    }
+    rewind(f);
+    char *buf = malloc((size_t)sz + SKIP_ONE);
+    if (!buf) {
+        fclose(f);
+        return NULL;
+    }
+    size_t n = fread(buf, SKIP_ONE, (size_t)sz, f);
+    fclose(f);
+    buf[n] = '\0';
+    return buf;
+}
+
+static char *project_root_dup(cbm_store_t *store, const char *project) {
+    cbm_project_t p = {0};
+    if (cbm_store_get_project(store, project, &p) != CBM_STORE_OK || !p.root_path) {
+        return NULL;
+    }
+    char *root = malloc(strlen(p.root_path) + SKIP_ONE);
+    if (root) {
+        strcpy(root, p.root_path);
+    }
+    free((void *)p.name);
+    free((void *)p.indexed_at);
+    free((void *)p.root_path);
+    return root;
+}
+
+static int list_pom_paths(cbm_store_t *store, const char *project, char ***out) {
+    *out = NULL;
+    struct sqlite3 *db = cbm_store_get_db(store);
+    if (!db) {
+        return 0;
+    }
+    sqlite3_stmt *st = NULL;
+    if (sqlite3_prepare_v2(db,
+                           "SELECT DISTINCT file_path FROM nodes WHERE project=?1 AND "
+                           "label='File' AND (name='pom.xml' OR file_path LIKE '%/pom.xml')",
+                           CBM_NOT_FOUND, &st, NULL) != SQLITE_OK) {
+        return 0;
+    }
+    sqlite3_bind_text(st, SKIP_ONE, project, CBM_NOT_FOUND, SQLITE_STATIC);
+
+    int cap = CR_INIT_CAP;
+    int count = 0;
+    char **paths = malloc((size_t)cap * sizeof(char *));
+    if (!paths) {
+        sqlite3_finalize(st);
+        return 0;
+    }
+    while (sqlite3_step(st) == SQLITE_ROW) {
+        const char *path = (const char *)sqlite3_column_text(st, 0);
+        if (!path || !text_has_suffix(path, "pom.xml")) {
+            continue;
+        }
+        if (count >= cap) {
+            cap *= PAIR_LEN;
+            char **tmp = realloc(paths, (size_t)cap * sizeof(char *));
+            if (!tmp) {
+                break;
+            }
+            paths = tmp;
+        }
+        paths[count] = malloc(strlen(path) + SKIP_ONE);
+        if (paths[count]) {
+            strcpy(paths[count], path);
+            count++;
+        }
+    }
+    sqlite3_finalize(st);
+    *out = paths;
+    return count;
+}
+
+static void free_string_list(char **items, int count) {
+    for (int i = 0; i < count; i++) {
+        free(items[i]);
+    }
+    free(items);
+}
+
+static int collect_maven_artifacts(cbm_store_t *store, const char *project,
+                                   cr_maven_artifact_t **out) {
+    *out = NULL;
+    char *root = project_root_dup(store, project);
+    if (!root) {
+        return 0;
+    }
+
+    char **paths = NULL;
+    int path_count = list_pom_paths(store, project, &paths);
+    int cap = CR_INIT_CAP;
+    int count = 0;
+    cr_maven_artifact_t *items = calloc((size_t)cap, sizeof(cr_maven_artifact_t));
+    if (!items) {
+        free_string_list(paths, path_count);
+        free(root);
+        return 0;
+    }
+
+    for (int i = 0; i < path_count; i++) {
+        char full[CR_PATH_BUF];
+        snprintf(full, sizeof(full), "%s/%s", root, paths[i]);
+        char *xml = read_text_file_cap(full);
+        if (!xml) {
+            continue;
+        }
+
+        char parent_group[CBM_SZ_128] = {0};
+        const char *parent_start = NULL;
+        const char *parent_end = NULL;
+        if (find_xml_block(xml, "parent", &parent_start, &parent_end)) {
+            xml_tag_text(parent_start, parent_end, "groupId", parent_group, sizeof(parent_group));
+        }
+
+        char group[CBM_SZ_128] = {0};
+        char artifact[CBM_SZ_128] = {0};
+        xml_tag_text_outside_project_blocks(xml, "groupId", group, sizeof(group));
+        xml_tag_text_outside_project_blocks(xml, "artifactId", artifact, sizeof(artifact));
+        if (!group[0] && parent_group[0]) {
+            snprintf(group, sizeof(group), "%s", parent_group);
+        }
+        if (group[0] && artifact[0]) {
+            if (count >= cap) {
+                cap *= PAIR_LEN;
+                cr_maven_artifact_t *tmp = realloc(items, (size_t)cap * sizeof(*items));
+                if (!tmp) {
+                    free(xml);
+                    break;
+                }
+                items = tmp;
+            }
+            memset(&items[count], 0, sizeof(items[count]));
+            snprintf(items[count].group_id, sizeof(items[count].group_id), "%s", group);
+            snprintf(items[count].artifact_id, sizeof(items[count].artifact_id), "%s", artifact);
+            snprintf(items[count].pom_path, sizeof(items[count].pom_path), "%s", paths[i]);
+            count++;
+        }
+        free(xml);
+    }
+
+    free_string_list(paths, path_count);
+    free(root);
+    *out = items;
+    return count;
+}
+
+static bool add_maven_dependency(cr_maven_dependency_t **items, int *count, int *cap,
+                                 const char *group, const char *artifact, const char *version,
+                                 const char *scope, const char *relation,
+                                 const char *context_group, const char *context_artifact,
+                                 const char *pom_path) {
+    if (!items || !*items || !count || !cap || !group || !artifact || !group[0] ||
+        !artifact[0]) {
+        return false;
+    }
+    if (*count >= *cap) {
+        *cap *= PAIR_LEN;
+        cr_maven_dependency_t *tmp = realloc(*items, (size_t)*cap * sizeof(**items));
+        if (!tmp) {
+            return false;
+        }
+        *items = tmp;
+    }
+    cr_maven_dependency_t *dep = &(*items)[*count];
+    memset(dep, 0, sizeof(*dep));
+    snprintf(dep->group_id, sizeof(dep->group_id), "%s", group);
+    snprintf(dep->artifact_id, sizeof(dep->artifact_id), "%s", artifact);
+    snprintf(dep->version, sizeof(dep->version), "%s", version ? version : "");
+    snprintf(dep->scope, sizeof(dep->scope), "%s", scope ? scope : "");
+    snprintf(dep->relation, sizeof(dep->relation), "%s", relation ? relation : "dependency");
+    snprintf(dep->context_group_id, sizeof(dep->context_group_id), "%s",
+             context_group ? context_group : "");
+    snprintf(dep->context_artifact_id, sizeof(dep->context_artifact_id), "%s",
+             context_artifact ? context_artifact : "");
+    snprintf(dep->pom_path, sizeof(dep->pom_path), "%s", pom_path ? pom_path : "");
+    (*count)++;
+    return true;
+}
+
+static int collect_maven_dependencies(cbm_store_t *store, const char *project,
+                                      cr_maven_dependency_t **out) {
+    *out = NULL;
+    char *root = project_root_dup(store, project);
+    if (!root) {
+        return 0;
+    }
+
+    char **paths = NULL;
+    int path_count = list_pom_paths(store, project, &paths);
+    int cap = CR_INIT_CAP;
+    int count = 0;
+    cr_maven_dependency_t *items = calloc((size_t)cap, sizeof(cr_maven_dependency_t));
+    if (!items) {
+        free_string_list(paths, path_count);
+        free(root);
+        return 0;
+    }
+
+    for (int i = 0; i < path_count; i++) {
+        char full[CR_PATH_BUF];
+        snprintf(full, sizeof(full), "%s/%s", root, paths[i]);
+        char *xml = read_text_file_cap(full);
+        if (!xml) {
+            continue;
+        }
+
+        const char *p = xml;
+        while ((p = strstr(p, "<dependency")) != NULL && count < CR_MAX_EDGES) {
+            if (ptr_in_xml_block_named(xml, "dependencyManagement", p)) {
+                p += strlen("<dependency");
+                continue;
+            }
+            const char *open_end = strchr(p, '>');
+            if (!open_end) {
+                break;
+            }
+            const char *end = strstr(open_end + SKIP_ONE, "</dependency>");
+            if (!end) {
+                break;
+            }
+
+            char group[CBM_SZ_128] = {0};
+            char artifact[CBM_SZ_128] = {0};
+            char version[CBM_SZ_128] = {0};
+            char scope[CBM_SZ_64] = {0};
+            xml_tag_text(open_end + SKIP_ONE, end, "groupId", group, sizeof(group));
+            xml_tag_text(open_end + SKIP_ONE, end, "artifactId", artifact, sizeof(artifact));
+            xml_tag_text(open_end + SKIP_ONE, end, "version", version, sizeof(version));
+            xml_tag_text(open_end + SKIP_ONE, end, "scope", scope, sizeof(scope));
+
+            add_maven_dependency(&items, &count, &cap, group, artifact, version, scope,
+                                 "dependency", group, artifact, paths[i]);
+
+            const char *ex = open_end + SKIP_ONE;
+            while ((ex = strstr(ex, "<exclusion")) != NULL && ex < end && count < CR_MAX_EDGES) {
+                const char *ex_open_end = strchr(ex, '>');
+                if (!ex_open_end || ex_open_end >= end) {
+                    break;
+                }
+                const char *ex_end = strstr(ex_open_end + SKIP_ONE, "</exclusion>");
+                if (!ex_end || ex_end > end) {
+                    break;
+                }
+                char ex_group[CBM_SZ_128] = {0};
+                char ex_artifact[CBM_SZ_128] = {0};
+                xml_tag_text(ex_open_end + SKIP_ONE, ex_end, "groupId", ex_group,
+                             sizeof(ex_group));
+                xml_tag_text(ex_open_end + SKIP_ONE, ex_end, "artifactId", ex_artifact,
+                             sizeof(ex_artifact));
+                add_maven_dependency(&items, &count, &cap, ex_group, ex_artifact, version, scope,
+                                     "exclusion", group, artifact, paths[i]);
+                ex = ex_end + strlen("</exclusion>");
+            }
+            p = end + strlen("</dependency>");
+        }
+        free(xml);
+    }
+
+    free_string_list(paths, path_count);
+    free(root);
+    *out = items;
+    return count;
+}
+
+static int64_t project_node_id(cbm_store_t *store, const char *project) {
+    struct sqlite3 *db = cbm_store_get_db(store);
+    if (!db) {
+        return 0;
+    }
+    sqlite3_stmt *st = NULL;
+    if (sqlite3_prepare_v2(db,
+                           "SELECT id FROM nodes WHERE project=?1 AND label='Project' LIMIT 1",
+                           CBM_NOT_FOUND, &st, NULL) != SQLITE_OK) {
+        return 0;
+    }
+    sqlite3_bind_text(st, SKIP_ONE, project, CBM_NOT_FOUND, SQLITE_STATIC);
+    int64_t id = 0;
+    if (sqlite3_step(st) == SQLITE_ROW) {
+        id = sqlite3_column_int64(st, 0);
+    }
+    sqlite3_finalize(st);
+    if (id != 0) {
+        return id;
+    }
+
+    char qn[CR_QN_BUF];
+    snprintf(qn, sizeof(qn), "__project__%s", project);
+    cbm_node_t node = {
+        .project = project,
+        .label = "Project",
+        .name = project,
+        .qualified_name = qn,
+        .file_path = "",
+        .start_line = 0,
+        .end_line = 0,
+        .properties_json = "{}",
+    };
+    return cbm_store_upsert_node(store, &node);
+}
+
+static void build_library_props(char *buf, size_t bufsz, const char *other_project,
+                                const cr_maven_dependency_t *dep) {
+    if (!buf || bufsz == 0) {
+        return;
+    }
+    snprintf(buf, bufsz, "{}");
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    if (!doc) {
+        return;
+    }
+    yyjson_mut_val *root = yyjson_mut_obj(doc);
+    yyjson_mut_doc_set_root(doc, root);
+    yyjson_mut_obj_add_strcpy(doc, root, "target_project", other_project ? other_project : "");
+    yyjson_mut_obj_add_strcpy(doc, root, "group_id", dep->group_id);
+    yyjson_mut_obj_add_strcpy(doc, root, "artifact_id", dep->artifact_id);
+    yyjson_mut_obj_add_strcpy(doc, root, "version", dep->version);
+    yyjson_mut_obj_add_strcpy(doc, root, "scope", dep->scope);
+    yyjson_mut_obj_add_strcpy(doc, root, "relation", dep->relation);
+    yyjson_mut_obj_add_strcpy(doc, root, "context_group_id", dep->context_group_id);
+    yyjson_mut_obj_add_strcpy(doc, root, "context_artifact_id", dep->context_artifact_id);
+    yyjson_mut_obj_add_strcpy(doc, root, "source_pom", dep->pom_path);
+
+    size_t len = 0;
+    char *json = yyjson_mut_write(doc, 0, &len);
+    if (json && len < bufsz) {
+        memcpy(buf, json, len + SKIP_ONE);
+    }
+    free(json);
+    yyjson_mut_doc_free(doc);
+}
+
+static int emit_library_match(cbm_store_t *src_store, const char *src_project,
+                              cbm_store_t *tgt_store, const char *tgt_project,
+                              const cr_maven_dependency_t *dep) {
+    int64_t src_project_id = project_node_id(src_store, src_project);
+    int64_t tgt_project_id = project_node_id(tgt_store, tgt_project);
+    if (src_project_id <= 0 || tgt_project_id <= 0) {
+        return 0;
+    }
+
+    char lib_qn[CR_QN_BUF];
+    snprintf(lib_qn, sizeof(lib_qn), "__library__%s__%s__%s:%s__via__%s:%s__%s", tgt_project,
+             dep->relation, dep->group_id, dep->artifact_id, dep->context_group_id,
+             dep->context_artifact_id, dep->pom_path);
+    char props[CR_PROPS_BUF];
+    build_library_props(props, sizeof(props), tgt_project, dep);
+    cbm_node_t lib = {
+        .project = src_project,
+        .label = "Library",
+        .name = dep->artifact_id,
+        .qualified_name = lib_qn,
+        .file_path = dep->pom_path,
+        .start_line = 0,
+        .end_line = 0,
+        .properties_json = props,
+    };
+    int64_t lib_id = cbm_store_upsert_node(src_store, &lib);
+    if (lib_id <= 0) {
+        return 0;
+    }
+    insert_cross_edge(src_store, src_project, src_project_id, lib_id, "CROSS_LIBRARY_DEPENDS_ON",
+                      props);
+
+    char consumer_qn[CR_QN_BUF];
+    snprintf(consumer_qn, sizeof(consumer_qn), "__library_consumer__%s__%s__%s:%s__via__%s:%s__%s",
+             src_project, dep->relation, dep->group_id, dep->artifact_id, dep->context_group_id,
+             dep->context_artifact_id, dep->pom_path);
+    char reverse_props[CR_PROPS_BUF];
+    build_library_props(reverse_props, sizeof(reverse_props), src_project, dep);
+    cbm_node_t consumer = {
+        .project = tgt_project,
+        .label = "LibraryConsumer",
+        .name = src_project,
+        .qualified_name = consumer_qn,
+        .file_path = "",
+        .start_line = 0,
+        .end_line = 0,
+        .properties_json = reverse_props,
+    };
+    int64_t consumer_id = cbm_store_upsert_node(tgt_store, &consumer);
+    if (consumer_id <= 0) {
+        return 0;
+    }
+    insert_cross_edge(tgt_store, tgt_project, tgt_project_id, consumer_id, "CROSS_LIBRARY_USED_BY",
+                      reverse_props);
+    return 1;
 }
 
 /* Look up a node's name and file_path by id. */
@@ -548,6 +1129,42 @@ static int match_typed_routes(cbm_store_t *src_store, const char *src_project,
     return count;
 }
 
+/* ── Phase E: Maven library dependency matching ─────────────────── */
+
+static bool artifact_matches_dep(const cr_maven_artifact_t *artifact,
+                                 const cr_maven_dependency_t *dep) {
+    return strcmp(artifact->group_id, dep->group_id) == 0 &&
+           strcmp(artifact->artifact_id, dep->artifact_id) == 0;
+}
+
+static int match_maven_libraries(cbm_store_t *src_store, const char *src_project,
+                                 cbm_store_t *tgt_store, const char *tgt_project) {
+    cr_maven_dependency_t *deps = NULL;
+    cr_maven_artifact_t *artifacts = NULL;
+    int dep_count = collect_maven_dependencies(src_store, src_project, &deps);
+    int artifact_count = collect_maven_artifacts(tgt_store, tgt_project, &artifacts);
+    if (dep_count == 0 || artifact_count == 0) {
+        free(deps);
+        free(artifacts);
+        return 0;
+    }
+
+    int count = 0;
+    for (int d = 0; d < dep_count && count < CR_MAX_EDGES; d++) {
+        for (int a = 0; a < artifact_count; a++) {
+            if (!artifact_matches_dep(&artifacts[a], &deps[d])) {
+                continue;
+            }
+            count += emit_library_match(src_store, src_project, tgt_store, tgt_project, &deps[d]);
+            break;
+        }
+    }
+
+    free(deps);
+    free(artifacts);
+    return count;
+}
+
 /* ── Collect target projects ─────────────────────────────────────── */
 
 /* When target_projects = ["*"], scan the cache directory for all .db files. */
@@ -660,6 +1277,7 @@ cbm_cross_repo_result_t cbm_cross_repo_match(const char *project, const char **t
                                "operation", "CROSS_GRAPHQL_CALLS");
         result.trpc_edges += match_typed_routes(src_store, project, tgt_store, tgt, "TRPC_CALLS",
                                                 "procedure", "procedure", "CROSS_TRPC_CALLS");
+        result.library_edges += match_maven_libraries(src_store, project, tgt_store, tgt);
         result.projects_scanned++;
 
         cbm_store_close(tgt_store);
@@ -677,7 +1295,7 @@ cbm_cross_repo_result_t cbm_cross_repo_match(const char *project, const char **t
                         ((double)(t1.tv_nsec - t0.tv_nsec) / CR_NS_PER_MS);
 
     int total = result.http_edges + result.async_edges + result.channel_edges + result.grpc_edges +
-                result.graphql_edges + result.trpc_edges;
+                result.graphql_edges + result.trpc_edges + result.library_edges;
     cbm_log_info("cross_repo.done", "project", project, "total", cr_itoa(total));
 
     return result;

--- a/src/pipeline/pass_cross_repo.h
+++ b/src/pipeline/pass_cross_repo.h
@@ -15,6 +15,7 @@ typedef struct {
     int grpc_edges;    /* CROSS_GRPC_CALLS edges created */
     int graphql_edges; /* CROSS_GRAPHQL_CALLS edges created */
     int trpc_edges;    /* CROSS_TRPC_CALLS edges created */
+    int library_edges; /* CROSS_LIBRARY_DEPENDS_ON/CROSS_LIBRARY_USED_BY pairs created */
     int projects_scanned;
     double elapsed_ms;
 } cbm_cross_repo_result_t;

--- a/tests/test_pipeline.c
+++ b/tests/test_pipeline.c
@@ -10,7 +10,9 @@
 #include "test_helpers.h"
 #include "pipeline/pipeline.h"
 #include "pipeline/pipeline_internal.h"
+#include "pipeline/pass_cross_repo.h"
 #include "store/store.h"
+#include <sqlite3/sqlite3.h>
 #include <yyjson/yyjson.h> // properties-JSON validity (oversized-props regression)
 
 #include <stdlib.h>
@@ -1059,6 +1061,386 @@ static void teardown_usages_repo(void) {
     if (g_usages_tmpdir[0])
         rm_rf(g_usages_tmpdir);
     g_usages_tmpdir[0] = '\0';
+}
+
+static int count_edges_by_type(cbm_store_t *s, const char *project, const char *edge_type) {
+    sqlite3_stmt *stmt = NULL;
+    struct sqlite3 *db = cbm_store_get_db(s);
+    if (!db) {
+        return -1;
+    }
+    if (sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM edges WHERE project=?1 AND type=?2", -1,
+                           &stmt, NULL) != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_text(stmt, 1, project, -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 2, edge_type, -1, SQLITE_STATIC);
+    int count = -1;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        count = sqlite3_column_int(stmt, 0);
+    }
+    sqlite3_finalize(stmt);
+    return count;
+}
+
+static int edge_props_are_valid_json(cbm_store_t *s, const char *project, const char *edge_type) {
+    sqlite3_stmt *stmt = NULL;
+    struct sqlite3 *db = cbm_store_get_db(s);
+    if (!db) {
+        return 0;
+    }
+    if (sqlite3_prepare_v2(db,
+                           "SELECT properties FROM edges WHERE project=?1 AND type=?2", -1,
+                           &stmt, NULL) != SQLITE_OK) {
+        return 0;
+    }
+    sqlite3_bind_text(stmt, 1, project, -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 2, edge_type, -1, SQLITE_STATIC);
+
+    int seen = 0;
+    int ok = 1;
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        seen++;
+        const char *props = (const char *)sqlite3_column_text(stmt, 0);
+        yyjson_doc *doc = props ? yyjson_read(props, strlen(props), 0) : NULL;
+        if (!doc) {
+            ok = 0;
+            break;
+        }
+        yyjson_doc_free(doc);
+    }
+    sqlite3_finalize(stmt);
+    return seen > 0 && ok;
+}
+
+TEST(cross_repo_maven_dependency_creates_library_edges) {
+    char cache[256];
+    snprintf(cache, sizeof(cache), "/tmp/cbm_cross_cache_XXXXXX");
+    if (!cbm_mkdtemp(cache)) {
+        FAIL("failed to create cache temp dir");
+    }
+
+    char provider_root[256];
+    snprintf(provider_root, sizeof(provider_root), "/tmp/cbm_provider_XXXXXX");
+    if (!cbm_mkdtemp(provider_root)) {
+        th_cleanup(cache);
+        FAIL("failed to create provider temp dir");
+    }
+
+    char consumer_root[256];
+    snprintf(consumer_root, sizeof(consumer_root), "/tmp/cbm_consumer_XXXXXX");
+    if (!cbm_mkdtemp(consumer_root)) {
+        th_cleanup(provider_root);
+        th_cleanup(cache);
+        FAIL("failed to create consumer temp dir");
+    }
+
+    ASSERT_EQ(th_write_file(TH_PATH(provider_root, "pom.xml"),
+                            "<project><modelVersion>4.0.0</modelVersion>"
+                            "<groupId>com.example.platform</groupId>"
+                            "<artifactId>shared-library</artifactId>"
+                            "<version>1.0.0</version></project>"),
+              0);
+    ASSERT_EQ(th_write_file(TH_PATH(consumer_root, "pom.xml"),
+                            "<project><modelVersion>4.0.0</modelVersion>"
+                            "<groupId>app</groupId><artifactId>consumer</artifactId>"
+                            "<dependencies><dependency><groupId>com.example.platform</groupId>"
+                            "<artifactId>shared-library</artifactId><version>1.0.0</version>"
+                            "</dependency><dependency><groupId>vendor.client</groupId>"
+                            "<artifactId>vendor-client</artifactId><version>2.0.0</version>"
+                            "<exclusions><exclusion><groupId>com.example.platform</groupId>"
+                            "<artifactId>shared-library</artifactId></exclusion></exclusions>"
+                            "</dependency></dependencies></project>"),
+              0);
+
+    cbm_setenv("CBM_CACHE_DIR", cache, 1);
+
+    char provider_db[512];
+    char consumer_db[512];
+    snprintf(provider_db, sizeof(provider_db), "%s/provider.db", cache);
+    snprintf(consumer_db, sizeof(consumer_db), "%s/consumer.db", cache);
+
+    cbm_store_t *provider = cbm_store_open_path(provider_db);
+    cbm_store_t *consumer = cbm_store_open_path(consumer_db);
+    ASSERT_NOT_NULL(provider);
+    ASSERT_NOT_NULL(consumer);
+    ASSERT_EQ(cbm_store_upsert_project(provider, "provider", provider_root), CBM_STORE_OK);
+    ASSERT_EQ(cbm_store_upsert_project(consumer, "consumer", consumer_root), CBM_STORE_OK);
+
+    cbm_node_t provider_project = {.project = "provider",
+                                   .label = "Project",
+                                   .name = "provider",
+                                   .qualified_name = "__project__provider",
+                                   .file_path = "",
+                                   .start_line = 0,
+                                   .end_line = 0,
+                                   .properties_json = "{}"};
+    cbm_node_t consumer_project = {.project = "consumer",
+                                   .label = "Project",
+                                   .name = "consumer",
+                                   .qualified_name = "__project__consumer",
+                                   .file_path = "",
+                                   .start_line = 0,
+                                   .end_line = 0,
+                                   .properties_json = "{}"};
+    cbm_node_t provider_pom = {.project = "provider",
+                               .label = "File",
+                               .name = "pom.xml",
+                               .qualified_name = "provider.pom",
+                               .file_path = "pom.xml",
+                               .start_line = 1,
+                               .end_line = 1,
+                               .properties_json = "{}"};
+    cbm_node_t consumer_pom = {.project = "consumer",
+                               .label = "File",
+                               .name = "pom.xml",
+                               .qualified_name = "consumer.pom",
+                               .file_path = "pom.xml",
+                               .start_line = 1,
+                               .end_line = 1,
+                               .properties_json = "{}"};
+    ASSERT_GT(cbm_store_upsert_node(provider, &provider_project), 0);
+    ASSERT_GT(cbm_store_upsert_node(consumer, &consumer_project), 0);
+    ASSERT_GT(cbm_store_upsert_node(provider, &provider_pom), 0);
+    ASSERT_GT(cbm_store_upsert_node(consumer, &consumer_pom), 0);
+    cbm_store_close(provider);
+    cbm_store_close(consumer);
+
+    const char *targets[] = {"provider"};
+    cbm_cross_repo_result_t result = cbm_cross_repo_match("consumer", targets, 1);
+    ASSERT_EQ(result.library_edges, 2);
+
+    consumer = cbm_store_open_path(consumer_db);
+    provider = cbm_store_open_path(provider_db);
+    ASSERT_NOT_NULL(consumer);
+    ASSERT_NOT_NULL(provider);
+    ASSERT_EQ(count_edges_by_type(consumer, "consumer", "CROSS_LIBRARY_DEPENDS_ON"), 2);
+    ASSERT_EQ(count_edges_by_type(provider, "provider", "CROSS_LIBRARY_USED_BY"), 2);
+    cbm_store_close(consumer);
+    cbm_store_close(provider);
+
+    th_cleanup(consumer_root);
+    th_cleanup(provider_root);
+    th_cleanup(cache);
+    PASS();
+}
+
+TEST(cross_repo_maven_dependency_escapes_library_edge_props) {
+    char cache[256];
+    snprintf(cache, sizeof(cache), "/tmp/cbm_cross_escape_cache_XXXXXX");
+    if (!cbm_mkdtemp(cache)) {
+        FAIL("failed to create cache temp dir");
+    }
+
+    char provider_root[256];
+    snprintf(provider_root, sizeof(provider_root), "/tmp/cbm_provider_escape_XXXXXX");
+    if (!cbm_mkdtemp(provider_root)) {
+        th_cleanup(cache);
+        FAIL("failed to create provider temp dir");
+    }
+
+    char consumer_root[256];
+    snprintf(consumer_root, sizeof(consumer_root), "/tmp/cbm_consumer_escape_XXXXXX");
+    if (!cbm_mkdtemp(consumer_root)) {
+        th_cleanup(provider_root);
+        th_cleanup(cache);
+        FAIL("failed to create consumer temp dir");
+    }
+
+    ASSERT_EQ(th_write_file(TH_PATH(provider_root, "pom.xml"),
+                            "<project><modelVersion>4.0.0</modelVersion>"
+                            "<groupId>com.example\"platform</groupId>"
+                            "<artifactId>shared-library</artifactId>"
+                            "<version>1.0.0</version></project>"),
+              0);
+    ASSERT_EQ(th_write_file(TH_PATH(consumer_root, "pom.xml"),
+                            "<project><modelVersion>4.0.0</modelVersion>"
+                            "<groupId>app</groupId><artifactId>consumer</artifactId>"
+                            "<dependencies><dependency><groupId>com.example\"platform</groupId>"
+                            "<artifactId>shared-library</artifactId><version>1.0.0</version>"
+                            "</dependency></dependencies></project>"),
+              0);
+
+    cbm_setenv("CBM_CACHE_DIR", cache, 1);
+
+    char provider_db[512];
+    char consumer_db[512];
+    snprintf(provider_db, sizeof(provider_db), "%s/provider.db", cache);
+    snprintf(consumer_db, sizeof(consumer_db), "%s/consumer.db", cache);
+
+    cbm_store_t *provider = cbm_store_open_path(provider_db);
+    cbm_store_t *consumer = cbm_store_open_path(consumer_db);
+    ASSERT_NOT_NULL(provider);
+    ASSERT_NOT_NULL(consumer);
+    ASSERT_EQ(cbm_store_upsert_project(provider, "provider", provider_root), CBM_STORE_OK);
+    ASSERT_EQ(cbm_store_upsert_project(consumer, "consumer", consumer_root), CBM_STORE_OK);
+
+    cbm_node_t provider_project = {.project = "provider",
+                                   .label = "Project",
+                                   .name = "provider",
+                                   .qualified_name = "__project__provider",
+                                   .file_path = "",
+                                   .start_line = 0,
+                                   .end_line = 0,
+                                   .properties_json = "{}"};
+    cbm_node_t consumer_project = {.project = "consumer",
+                                   .label = "Project",
+                                   .name = "consumer",
+                                   .qualified_name = "__project__consumer",
+                                   .file_path = "",
+                                   .start_line = 0,
+                                   .end_line = 0,
+                                   .properties_json = "{}"};
+    cbm_node_t provider_pom = {.project = "provider",
+                               .label = "File",
+                               .name = "pom.xml",
+                               .qualified_name = "provider.pom",
+                               .file_path = "pom.xml",
+                               .start_line = 1,
+                               .end_line = 1,
+                               .properties_json = "{}"};
+    cbm_node_t consumer_pom = {.project = "consumer",
+                               .label = "File",
+                               .name = "pom.xml",
+                               .qualified_name = "consumer.pom",
+                               .file_path = "pom.xml",
+                               .start_line = 1,
+                               .end_line = 1,
+                               .properties_json = "{}"};
+    ASSERT_GT(cbm_store_upsert_node(provider, &provider_project), 0);
+    ASSERT_GT(cbm_store_upsert_node(consumer, &consumer_project), 0);
+    ASSERT_GT(cbm_store_upsert_node(provider, &provider_pom), 0);
+    ASSERT_GT(cbm_store_upsert_node(consumer, &consumer_pom), 0);
+    cbm_store_close(provider);
+    cbm_store_close(consumer);
+
+    const char *targets[] = {"provider"};
+    cbm_cross_repo_result_t result = cbm_cross_repo_match("consumer", targets, 1);
+    ASSERT_EQ(result.library_edges, 1);
+
+    consumer = cbm_store_open_path(consumer_db);
+    provider = cbm_store_open_path(provider_db);
+    ASSERT_NOT_NULL(consumer);
+    ASSERT_NOT_NULL(provider);
+    ASSERT_TRUE(edge_props_are_valid_json(consumer, "consumer", "CROSS_LIBRARY_DEPENDS_ON"));
+    ASSERT_TRUE(edge_props_are_valid_json(provider, "provider", "CROSS_LIBRARY_USED_BY"));
+    cbm_store_close(consumer);
+    cbm_store_close(provider);
+
+    th_cleanup(consumer_root);
+    th_cleanup(provider_root);
+    th_cleanup(cache);
+    PASS();
+}
+
+TEST(cross_repo_maven_dependency_management_does_not_create_library_edge) {
+    char cache[256];
+    snprintf(cache, sizeof(cache), "/tmp/cbm_cross_mgmt_cache_XXXXXX");
+    if (!cbm_mkdtemp(cache)) {
+        FAIL("failed to create cache temp dir");
+    }
+
+    char provider_root[256];
+    snprintf(provider_root, sizeof(provider_root), "/tmp/cbm_provider_mgmt_XXXXXX");
+    if (!cbm_mkdtemp(provider_root)) {
+        th_cleanup(cache);
+        FAIL("failed to create provider temp dir");
+    }
+
+    char consumer_root[256];
+    snprintf(consumer_root, sizeof(consumer_root), "/tmp/cbm_consumer_mgmt_XXXXXX");
+    if (!cbm_mkdtemp(consumer_root)) {
+        th_cleanup(provider_root);
+        th_cleanup(cache);
+        FAIL("failed to create consumer temp dir");
+    }
+
+    ASSERT_EQ(th_write_file(TH_PATH(provider_root, "pom.xml"),
+                            "<project><modelVersion>4.0.0</modelVersion>"
+                            "<groupId>com.example.platform</groupId>"
+                            "<artifactId>shared-library</artifactId>"
+                            "<version>1.0.0</version></project>"),
+              0);
+    ASSERT_EQ(th_write_file(TH_PATH(consumer_root, "pom.xml"),
+                            "<project><modelVersion>4.0.0</modelVersion>"
+                            "<groupId>app</groupId><artifactId>consumer</artifactId>"
+                            "<dependencyManagement><dependencies><dependency>"
+                            "<groupId>com.example.platform</groupId>"
+                            "<artifactId>shared-library</artifactId>"
+                            "<version>1.0.0</version></dependency></dependencies>"
+                            "</dependencyManagement></project>"),
+              0);
+
+    cbm_setenv("CBM_CACHE_DIR", cache, 1);
+
+    char provider_db[512];
+    char consumer_db[512];
+    snprintf(provider_db, sizeof(provider_db), "%s/provider.db", cache);
+    snprintf(consumer_db, sizeof(consumer_db), "%s/consumer.db", cache);
+
+    cbm_store_t *provider = cbm_store_open_path(provider_db);
+    cbm_store_t *consumer = cbm_store_open_path(consumer_db);
+    ASSERT_NOT_NULL(provider);
+    ASSERT_NOT_NULL(consumer);
+    ASSERT_EQ(cbm_store_upsert_project(provider, "provider", provider_root), CBM_STORE_OK);
+    ASSERT_EQ(cbm_store_upsert_project(consumer, "consumer", consumer_root), CBM_STORE_OK);
+
+    cbm_node_t provider_project = {.project = "provider",
+                                   .label = "Project",
+                                   .name = "provider",
+                                   .qualified_name = "__project__provider",
+                                   .file_path = "",
+                                   .start_line = 0,
+                                   .end_line = 0,
+                                   .properties_json = "{}"};
+    cbm_node_t consumer_project = {.project = "consumer",
+                                   .label = "Project",
+                                   .name = "consumer",
+                                   .qualified_name = "__project__consumer",
+                                   .file_path = "",
+                                   .start_line = 0,
+                                   .end_line = 0,
+                                   .properties_json = "{}"};
+    cbm_node_t provider_pom = {.project = "provider",
+                               .label = "File",
+                               .name = "pom.xml",
+                               .qualified_name = "provider.pom",
+                               .file_path = "pom.xml",
+                               .start_line = 1,
+                               .end_line = 1,
+                               .properties_json = "{}"};
+    cbm_node_t consumer_pom = {.project = "consumer",
+                               .label = "File",
+                               .name = "pom.xml",
+                               .qualified_name = "consumer.pom",
+                               .file_path = "pom.xml",
+                               .start_line = 1,
+                               .end_line = 1,
+                               .properties_json = "{}"};
+    ASSERT_GT(cbm_store_upsert_node(provider, &provider_project), 0);
+    ASSERT_GT(cbm_store_upsert_node(consumer, &consumer_project), 0);
+    ASSERT_GT(cbm_store_upsert_node(provider, &provider_pom), 0);
+    ASSERT_GT(cbm_store_upsert_node(consumer, &consumer_pom), 0);
+    cbm_store_close(provider);
+    cbm_store_close(consumer);
+
+    const char *targets[] = {"provider"};
+    cbm_cross_repo_result_t result = cbm_cross_repo_match("consumer", targets, 1);
+    ASSERT_EQ(result.library_edges, 0);
+
+    consumer = cbm_store_open_path(consumer_db);
+    provider = cbm_store_open_path(provider_db);
+    ASSERT_NOT_NULL(consumer);
+    ASSERT_NOT_NULL(provider);
+    ASSERT_EQ(count_edges_by_type(consumer, "consumer", "CROSS_LIBRARY_DEPENDS_ON"), 0);
+    ASSERT_EQ(count_edges_by_type(provider, "provider", "CROSS_LIBRARY_USED_BY"), 0);
+    cbm_store_close(consumer);
+    cbm_store_close(provider);
+
+    th_cleanup(consumer_root);
+    th_cleanup(provider_root);
+    th_cleanup(cache);
+    PASS();
 }
 
 TEST(usages_creates_edges) {
@@ -5853,6 +6235,10 @@ SUITE(pipeline) {
     /* Incremental reindex */
     /* FastAPI Depends edge tracking (PR #66 port) */
     RUN_TEST(pipeline_fastapi_depends_edges);
+    /* Cross-repo library dependency linking */
+    RUN_TEST(cross_repo_maven_dependency_creates_library_edges);
+    RUN_TEST(cross_repo_maven_dependency_escapes_library_edge_props);
+    RUN_TEST(cross_repo_maven_dependency_management_does_not_create_library_edge);
     /* Incremental */
     RUN_TEST(incremental_full_then_noop);
     RUN_TEST(incremental_detects_changed_file);


### PR DESCRIPTION
## Summary

Fixes #440

Adds Maven library dependency matching to `cross-repo-intelligence` so independently indexed repos can expose shared-library usage, not only HTTP/async/channel relationships.

This adds:

- Maven artifact/dependency collection from indexed `pom.xml` files
- `CROSS_LIBRARY_DEPENDS_ON` edges in the consuming project
- `CROSS_LIBRARY_USED_BY` edges in the provider project
- cross-repo mode result counts for `cross_library_edges`
- architecture summary support for the new `CROSS_LIBRARY_*` edge types
- pipeline regression tests using neutral sample Maven coordinates

## Scope

This draft is intentionally scoped to Maven `pom.xml` relationships. Gradle/npm/Go/Python package linking and richer source import-to-artifact resolution should be follow-up issues.

## TDD record

- Failing test: `cross_repo_maven_dependency_creates_library_edges`
- Additional failing tests from review loop: `cross_repo_maven_dependency_escapes_library_edge_props`, `cross_repo_maven_dependency_management_does_not_create_library_edge`
- Command intended for red/green loop: `make -f Makefile.cbm test` / `scripts/test.sh`
- Expected red reasons: no Maven library edges initially; then malformed JSON risk for unescaped Maven values; then false positives from dependency-management-only declarations.

## Verification

- `make -j"$(sysctl -n hw.ncpu 2>/dev/null || echo 4)" -f Makefile.cbm build/c/test-runner` passed before the review-loop fixes.
- Timed test-runner captures reached the new Maven cross-repo tests; the library-edge and JSON-escape tests pass after fixes. A dependency-management false-positive test was added and is still being completed in the review loop.
- Full suite was not completed. The runner has no help/filter mode and full execution previously hit unrelated existing probe failures in `tests/test_node_creation_probe.c` / `tests/test_grammar_probe_g.c`.
- `clang-format` is not available on my PATH in this environment. `git diff --check` passed before the initial commit.

## Notes for reviewers

This is marked draft because the contribution guide says new indexing algorithms need maintainer design discussion, and because the patch is currently larger than the preferred <500-line PR guideline. We can split parsing/edge-emission/schema-reporting if maintainers prefer smaller increments.