### PR TITLE
Add community files and strengthen the contribution terms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,121 @@
+name: Bug report
+description: Something is wrong — help us reproduce it exactly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! The single most valuable thing you can give us
+        is a **reproduction we can run ourselves**.
+
+        **Please do not paste proprietary code or logs.** If the problem
+        shows up on private code, reproduce it with a small dummy snippet or
+        point us at a **public OSS repository** (e.g. zod, django, serilog)
+        plus the file/commit where it happens — that is how we debug here.
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `codebase-memory-mcp --version`
+      placeholder: codebase-memory-mcp 0.8.1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Linux (x64)
+        - Linux (arm64)
+        - Windows (x64)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: channel
+    attributes:
+      label: Install channel
+      options:
+        - GitHub release archive / install.sh / install.ps1
+        - npm
+        - PyPI
+        - Homebrew
+        - AUR
+        - Scoop / Winget / Chocolatey
+        - go install
+        - Built from source
+    validations:
+      required: true
+
+  - type: dropdown
+    id: variant
+    attributes:
+      label: Binary variant
+      options:
+        - standard
+        - ui
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened, and what did you expect?
+      description: Actual vs. expected behavior, in a few sentences.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: |
+        The exact steps so we can reproduce it ourselves:
+        1. The code being indexed — a minimal dummy snippet pasted here, or a
+           public repo + commit + file path (e.g. `colinhacks/zod@a1b2c3d,
+           packages/zod/src/v4/core/parse.ts`).
+        2. The exact command or MCP tool call, including JSON arguments
+           (e.g. `codebase-memory-mcp cli search_graph '{"project":"...",
+           "name_pattern":"..."}'`).
+        3. What the output was vs. what it should have been.
+      placeholder: |
+        1. Code: public repo colinhacks/zod @ <commit>, file packages/...
+           — or dummy snippet:
+           ```ts
+           interface Model<T> { create(doc: Partial<T>): Promise<T>; }
+           ```
+        2. Command: codebase-memory-mcp cli index_repository '{"repo_path":"/tmp/zod"}'
+        3. Result: ... / Expected: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Relevant log output (stderr of the binary; for the UI variant also
+        `GET /api/logs`). Will be auto-formatted as code — no backticks needed.
+        Please check for private paths/strings before pasting.
+      render: text
+
+  - type: input
+    id: scale
+    attributes:
+      label: Project scale (if relevant)
+      description: Approximate nodes/edges/files from the indexing summary
+      placeholder: "5,656 nodes / 14,517 edges / 475 files"
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: My reproduction uses shareable code (a dummy snippet or a public OSS repository), not proprietary code.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/DeusData/codebase-memory-mcp/security/advisories/new
+    about: Please report security issues privately — never in a public issue. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Propose an improvement or new capability.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The situation where the current behavior falls short — concrete examples beat abstractions.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you would like to happen. For new language/LSP support, name the public OSS repos that would make good test beds.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches and why they fall short (optional).
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at martin.vogel.tech@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,8 +174,18 @@ matching the commit author.**
 git commit -s             # adds: Signed-off-by: Your Name <you@example.com>
 ```
 
-By signing off you certify (per the [DCO](DCO)) that you wrote the change
-or otherwise have the right to submit it under the MIT license.
+**Adding a `Signed-off-by` line to a commit constitutes your certification
+of the [Developer Certificate of Origin 1.1](DCO) — in full, all four
+clauses — for that contribution.** The sign-off must match the commit's
+author name and email (enforced by CI). In short: you certify that you
+wrote the change or otherwise have the right to submit it under the MIT
+license, and that you understand the contribution and your sign-off are
+public and permanent.
+
+(Independently of the DCO, submitting a contribution to this repository is
+also subject to GitHub's Terms of Service §D.6, under which contributions
+are licensed inbound = outbound — i.e., under this repository's MIT
+license.)
 
 Enforcement is strict and automated:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Platform](https://img.shields.io/badge/macOS_%7C_Linux_%7C_Windows-supported-lightgrey)](https://github.com/DeusData/codebase-memory-mcp/releases/latest)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/DeusData/codebase-memory-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/DeusData/codebase-memory-mcp)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
-[![VirusTotal](https://img.shields.io/badge/VirusTotal-0%2F72_engines-brightgreen?logo=virustotal)](https://www.virustotal.com/gui/file/8e12bb2d6ead7f20a6d3bf2be1e51f978c38acce810f0734f510d134b039d152/detection)
+[![VirusTotal](https://img.shields.io/badge/VirusTotal-scanned_every_release-brightgreen?logo=virustotal)](https://github.com/DeusData/codebase-memory-mcp/releases/latest)
 [![arXiv](https://img.shields.io/badge/arXiv-2603.27277-b31b1b?logo=arxiv)](https://arxiv.org/abs/2603.27277)
 
 **The fastest and most efficient code intelligence engine for AI coding agents.** Full-indexes an average repository in milliseconds, the Linux kernel (28M LOC, 75K files) in 3 minutes. Answers structural queries in under 1ms. Ships as a single static binary for macOS, Linux, and Windows — download, run `install`, done.


### PR DESCRIPTION
Contributor Covenant 2.1 (canonical, byte-verified), reproduction-first issue templates (shareable reproductions only — dummy code or public OSS repos), explicit full-DCO certification wording in CONTRIBUTING.md, and a VirusTotal badge that tracks the latest release.