### PR TITLE
fix(discover): deploy/ directories indexed as duplicate source in full mode

### DIFF
--- a/src/discover/discover.c
+++ b/src/discover/discover.c
@@ -42,7 +42,7 @@ static const char *ALWAYS_SKIP_DIRS[] = {
     ".cargo", ".stack-work", ".dart_tool", "zig-cache", "zig-out", ".metals", ".bloop", ".bsp",
     ".ccls-cache", ".clangd", "elm-stuff", "_opam", ".cpcache", ".shadow-cljs",
     /* Deploy */
-    ".vercel", ".netlify",
+    ".vercel", ".netlify", "deploy", "deployed",
     /* Misc */
     ".qdrant_code_embeddings", ".tmp", "vendor", "vendored", NULL};
 

--- a/tests/test_discover.c
+++ b/tests/test_discover.c
@@ -605,6 +605,27 @@ TEST(discover_generic_dirs_fast_mode) {
     PASS();
 }
 
+TEST(discover_deploy_excluded_full_mode) {
+    char *base = th_mktempdir("cbm_disc_deploy");
+    ASSERT(base != NULL);
+
+    th_write_file(TH_PATH(base, "src/main.go"), "package main\n");
+    th_write_file(TH_PATH(base, "deploy/main.go"), "package deploy\n");
+    th_write_file(TH_PATH(base, "deployed/main.go"), "package deployed\n");
+
+    cbm_discover_opts_t opts = {.mode = CBM_MODE_FULL};
+    cbm_file_info_t *files = NULL;
+    int count = 0;
+
+    int rc = cbm_discover(base, &opts, &files, &count);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(count, 1);
+
+    cbm_discover_free(files, count);
+    th_cleanup(base);
+    PASS();
+}
+
 TEST(discover_cbmignore_no_git) {
     char *base = th_mktempdir("cbm_disc_nogit");
     ASSERT(base != NULL);
@@ -792,6 +813,7 @@ SUITE(discover) {
     RUN_TEST(discover_new_ignore_patterns);
     RUN_TEST(discover_generic_dirs_full_mode);
     RUN_TEST(discover_generic_dirs_fast_mode);
+    RUN_TEST(discover_deploy_excluded_full_mode);
     RUN_TEST(discover_cbmignore_no_git);
 
     /* Nested .gitignore tests (issue #178) */


### PR DESCRIPTION
**deploy/ directories indexed as duplicate source in full mode, producing stale duplicate Class/Method rows**

Discovered while querying a project that uses a `deploy/` directory for build output. Queries like `MATCH (c:Class {name:'Foo'})` returned multiple rows for the same class — one from the source file, one from the copy in `deploy/`.

**Root cause**

`deploy` and `deployed` were in `FAST_SKIP_DIRS`, which is only consulted in `fast` and `moderate` indexing modes. In the default `full` mode, `FAST_SKIP_DIRS` is not applied, so `deploy/` was walked and indexed alongside source files. Any class that existed in both locations got duplicate rows in the graph with potentially stale data from the build copy.

```c
// before: deploy/deployed only skipped in fast/moderate mode
static const char *FAST_SKIP_DIRS[] = { ..., ".vercel", ".netlify", NULL };

// after: always skipped
static const char *ALWAYS_SKIP_DIRS[] = { ..., ".vercel", ".netlify", "deploy", "deployed", NULL };
```

**Fix**

Move `deploy` and `deployed` from `FAST_SKIP_DIRS` to `ALWAYS_SKIP_DIRS` so they are excluded in all indexing modes.

**Regression test**

`discover_deploy_excluded_full_mode` in `tests/test_discover.c` — creates a temporary repo with `src/`, `deploy/`, and `deployed/` subdirectories, runs discovery in full mode, and asserts only the file under `src/` is returned (deploy and deployed are excluded).