### PR TITLE
fix(extract): Class.lines always 0 for all languages

### DIFF
--- a/internal/cbm/extract_defs.c
+++ b/internal/cbm/extract_defs.c
@@ -3323,6 +3323,7 @@ static void extract_class_def(CBMExtractCtx *ctx, TSNode node, const CBMLangSpec
     def.file_path = ctx->rel_path;
     def.start_line = ts_node_start_point(node).row + TS_LINE_OFFSET;
     def.end_line = ts_node_end_point(node).row + TS_LINE_OFFSET;
+    def.lines = (int)(def.end_line - def.start_line + TS_LINE_OFFSET);
     def.is_exported = cbm_is_exported(name, ctx->language);
     def.base_classes = extract_base_classes(a, node, ctx->source, ctx->language);
     def.decorators = extract_decorators(a, node, ctx->source, ctx->language, spec);

--- a/tests/test_incremental.c
+++ b/tests/test_incremental.c
@@ -964,6 +964,19 @@ TEST(tool_qg_defines_method_more_than_10) {
     PASS();
 }
 
+TEST(tool_qg_class_lines_nonzero) {
+    double ms;
+    char *r =
+        call_tool_timed("query_graph", &ms,
+                        "{\"project\":\"%s\","
+                        "\"query\":\"MATCH (c:Class) WHERE c.lines > 0 RETURN count(c) AS n\"}",
+                        g_project);
+    TOOL_OK(r, ms);
+    ASSERT(strstr(r, "\"0\"") == NULL);
+    free(r);
+    PASS();
+}
+
 TEST(tool_list_projects_has_current) {
     double ms;
     char *r = call_tool_timed("list_projects", &ms, "{}");
@@ -3105,6 +3118,7 @@ SUITE(incremental) {
     RUN_TEST(tool_qg_handles);
     RUN_TEST(tool_qg_defines_method);
     RUN_TEST(tool_qg_defines_method_more_than_10);
+    RUN_TEST(tool_qg_class_lines_nonzero);
     RUN_TEST(tool_qg_no_limit);
     RUN_TEST(tool_qg_empty_result);
 


### PR DESCRIPTION
**Class.lines always 0 for all languages**

Discovered while trying to sort classes by size. Every class node had `lines = 0` regardless of actual length.

**Root cause**

In `extract_class_def()`, `start_line` and `end_line` are correctly set from tree-sitter node positions, but `def.lines` is never computed — it stays 0 from the `memset` that zeroes the struct. The equivalent computation exists and is correct in `push_method_def()`:

```c
// push_method_def — correct
def.lines = (int)(def.end_line - def.start_line + TS_LINE_OFFSET);

// extract_class_def — missing this line entirely
// def.lines was always 0
```

**Fix**

Add the same one-liner to `extract_class_def()` after `end_line` is set. Affects all languages — any tree-sitter grammar that produces class nodes goes through this path.

**Regression test**

`tool_qg_class_lines_nonzero` in `tests/test_incremental.c` — indexes a project in full mode and asserts that at least one class node has `lines > 0` via a `query_graph` tool call. Before the fix this assertion always failed.