### PR TITLE
fix(search): ignore empty-string label in search_graph name_pattern path

### DIFF
--- a/src/store/store.c
+++ b/src/store/store.c
@@ -2348,7 +2348,12 @@ static int search_where_basic(const cbm_search_params_t *params, char *where, in
         *wlen = where_append(where, where_sz, *wlen, nparams, bind_buf);
         where_bind_text(binds, bind_idx, params->project);
     }
-    if (params->label) {
+    /* Ignore an empty-string label: it is non-NULL but should behave like an
+     * omitted label (no filter), matching the BM25 query path. Without the
+     * params->label[0] guard, name_pattern/qn_pattern searches that pass
+     * label="" append `n.label = ''`, which matches no node and silently
+     * returns zero results (issue #481). */
+    if (params->label && params->label[0]) {
         snprintf(bind_buf, sizeof(bind_buf), "n.label = ?%d", *bind_idx + SKIP_ONE);
         *wlen = where_append(where, where_sz, *wlen, nparams, bind_buf);
         where_bind_text(binds, bind_idx, params->label);

--- a/tests/test_store_search.c
+++ b/tests/test_store_search.c
@@ -86,6 +86,48 @@ TEST(store_search_by_name_pattern) {
     PASS();
 }
 
+/* ── Empty-string label is ignored (issue #481) ────────────────── */
+
+/* An empty-string label must behave like an omitted label (no filter), not be
+ * applied as a literal `n.label = ''` that matches nothing. Previously a
+ * name_pattern/qn_pattern search passing label="" returned zero results, while
+ * the BM25 query path ignored the empty label — an inconsistency that made
+ * structural class/service discovery silently fail. */
+TEST(store_search_empty_label_ignored) {
+    int64_t ids[3];
+    cbm_store_t *s = setup_search_store(ids);
+
+    /* name_pattern + label="" must match the same as name_pattern alone. */
+    cbm_search_params_t empty_label = {.project = "test",
+                                       .name_pattern = ".*Submit.*",
+                                       .label = "",
+                                       .min_degree = -1,
+                                       .max_degree = -1};
+    cbm_search_output_t out = {0};
+    int rc = cbm_store_search(s, &empty_label, &out);
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_EQ(out.count, 1);
+    ASSERT_STR_EQ(out.results[0].node.name, "SubmitOrder");
+    cbm_store_search_free(&out);
+
+    /* A non-empty label still filters: ".*Order.*" matches three names but only
+     * OrderService is a Class. */
+    cbm_search_params_t cls = {.project = "test",
+                               .name_pattern = ".*Order.*",
+                               .label = "Class",
+                               .min_degree = -1,
+                               .max_degree = -1};
+    cbm_search_output_t out2 = {0};
+    rc = cbm_store_search(s, &cls, &out2);
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_EQ(out2.count, 1);
+    ASSERT_STR_EQ(out2.results[0].node.name, "OrderService");
+    cbm_store_search_free(&out2);
+
+    cbm_store_close(s);
+    PASS();
+}
+
 /* ── Search by file pattern ─────────────────────────────────────── */
 
 TEST(store_search_by_file_pattern) {
@@ -1234,6 +1276,7 @@ TEST(store_impact_summary_empty) {
 SUITE(store_search) {
     RUN_TEST(store_search_by_label);
     RUN_TEST(store_search_by_name_pattern);
+    RUN_TEST(store_search_empty_label_ignored);
     RUN_TEST(store_search_by_file_pattern);
     RUN_TEST(store_search_file_pattern_substring_issue200);
     RUN_TEST(store_search_pagination);

--- a/tests/test_store_search.c
+++ b/tests/test_store_search.c
@@ -124,6 +124,20 @@ TEST(store_search_empty_label_ignored) {
     ASSERT_STR_EQ(out2.results[0].node.name, "OrderService");
     cbm_store_search_free(&out2);
 
+    /* qn_pattern shares the same WHERE builder, so empty label must be ignored
+     * there too. */
+    cbm_search_params_t qn = {.project = "test",
+                              .qn_pattern = ".*SubmitOrder",
+                              .label = "",
+                              .min_degree = -1,
+                              .max_degree = -1};
+    cbm_search_output_t out3 = {0};
+    rc = cbm_store_search(s, &qn, &out3);
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_EQ(out3.count, 1);
+    ASSERT_STR_EQ(out3.results[0].node.name, "SubmitOrder");
+    cbm_store_search_free(&out3);
+
     cbm_store_close(s);
     PASS();
 }


### PR DESCRIPTION
Closes #481

## Problem

`search_graph` returns zero results when a request passes an empty-string `label` (`"label": ""`) together with `name_pattern` (or `qn_pattern`). The reporter saw it as "`name_pattern` misses indexed Class nodes," but the trigger is the empty label, not the regex:

| Call | result |
|---|---|
| `name_pattern=".*Foo.*"` (no `label` key) | matches ✓ |
| `name_pattern=".*Foo.*"`, `label=""` | **0** ✗ |
| `name_pattern=".*Foo.*"`, `label="Class"` | matches ✓ |
| `query="Foo"`, `label=""` (BM25) | matches ✓ |

The BM25 `query` path treats an empty label as absent; the `name_pattern` path does not — so the same `"label":""` payload works for `query` but returns nothing for `name_pattern`. Agents then fall back to grep even though the symbol is in the graph.

## Root cause

`search_where_basic` (`src/store/store.c`) guarded the label clause on NULL only:

```c
if (params->label) {                 // "" is non-NULL → still appended
    ... "n.label = ?" ...            // binds n.label = '' → matches no node
}
```

## Fix

```c
if (params->label && params->label[0]) {   // ignore empty-string label
```

An empty `label` is now a no-op, identical to an omitted label and to the BM25 path. Non-empty labels still filter exactly as before.

## Test

`store_search_empty_label_ignored` (`tests/test_store_search.c`): `name_pattern` + `label=""` returns the same match as `name_pattern` alone, and a non-empty `label` still filters (`.*Order.*` + `label="Class"` → only the Class node).

## Verification

- `scripts/build.sh` clean; `scripts/test.sh` passes (the lone `cli_hook_gate_script_no_predictable_tmp_issue384` failure is pre-existing on `main`, environment-dependent, untouched here).
- Reproduced the original symptom on a real project and confirmed the fix: with the empty label ignored, `name_pattern` matches all expected Class nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
