### PR TITLE
fix: Surface a real error when persistence artifact export silently fails on Windows

### DIFF
--- a/src/pipeline/artifact.c
+++ b/src/pipeline/artifact.c
@@ -42,6 +42,8 @@ enum {
 /* Thread-local rotating buffers for small int→string conversions (logging).
  * Rotating allows multiple itoa_buf() calls in a single log statement. */
 enum { ART_RING = 4, ART_RING_MASK = 3 };
+static _Thread_local char g_export_error[CBM_SZ_512];
+
 static const char *itoa_buf(int v) {
     static _Thread_local char bufs[ART_RING][CBM_SZ_32];
     static _Thread_local int idx = 0;
@@ -51,9 +53,68 @@ static const char *itoa_buf(int v) {
     return bufs[i];
 }
 
+const char *cbm_artifact_export_last_error(void) {
+    return g_export_error[0] ? g_export_error : NULL;
+}
+
+static void clear_export_error(void) {
+    g_export_error[0] = '\0';
+}
+
+static int artifact_export_fail(const char *stage, const char *path, const char *err, int err_no) {
+    const char *safe_stage = stage ? stage : "unknown";
+    const char *safe_err = err ? err : "unknown";
+
+    if (path && err_no != 0) {
+        snprintf(g_export_error, sizeof(g_export_error), "%s: %s errno=%d path=%s", safe_stage,
+                 safe_err, err_no, path);
+    } else if (path) {
+        snprintf(g_export_error, sizeof(g_export_error), "%s: %s path=%s", safe_stage, safe_err,
+                 path);
+    } else if (err_no != 0) {
+        snprintf(g_export_error, sizeof(g_export_error), "%s: %s errno=%d", safe_stage, safe_err,
+                 err_no);
+    } else {
+        snprintf(g_export_error, sizeof(g_export_error), "%s: %s", safe_stage, safe_err);
+    }
+
+    if (path && err_no != 0) {
+        cbm_log_error("artifact.export", "stage", safe_stage, "err", safe_err, "errno",
+                      itoa_buf(err_no), "path", path);
+    } else if (path) {
+        cbm_log_error("artifact.export", "stage", safe_stage, "err", safe_err, "path", path);
+    } else if (err_no != 0) {
+        cbm_log_error("artifact.export", "stage", safe_stage, "err", safe_err, "errno",
+                      itoa_buf(err_no));
+    } else {
+        cbm_log_error("artifact.export", "stage", safe_stage, "err", safe_err);
+    }
+    return CBM_NOT_FOUND;
+}
+
+typedef struct {
+    const char *err;
+    int err_no;
+} artifact_file_error_t;
+
+static void file_error_clear(artifact_file_error_t *out) {
+    if (out) {
+        out->err = NULL;
+        out->err_no = 0;
+    }
+}
+
+static void file_error_set(artifact_file_error_t *out, const char *err, int err_no) {
+    if (out) {
+        out->err = err;
+        out->err_no = err_no;
+    }
+}
+
 /* Build path: <repo>/.codebase-memory/<name> into caller-owned buf. */
-static void artifact_path(char *buf, size_t bufsz, const char *repo_path, const char *name) {
-    snprintf(buf, bufsz, "%s/%s/%s", repo_path, CBM_ARTIFACT_DIR, name);
+static bool artifact_path(char *buf, size_t bufsz, const char *repo_path, const char *name) {
+    int n = snprintf(buf, bufsz, "%s/%s/%s", repo_path, CBM_ARTIFACT_DIR, name);
+    return n >= 0 && (size_t)n < bufsz;
 }
 
 /* Read entire file into malloc'd buffer. Sets *out_len. Returns NULL on error. */
@@ -85,21 +146,47 @@ static char *read_file_alloc(const char *path, size_t *out_len) {
 }
 
 /* Write buffer to file atomically (write to tmp, rename). Returns 0 on success. */
-static int write_file_atomic(const char *path, const char *data, size_t len) {
+static int write_file_atomic(const char *path, const char *data, size_t len,
+                             artifact_file_error_t *out_err) {
+    file_error_clear(out_err);
+
     char tmp[CBM_SZ_4K];
-    snprintf(tmp, sizeof(tmp), "%s.tmp", path);
+    int n = snprintf(tmp, sizeof(tmp), "%s.tmp", path);
+    if (n < 0 || (size_t)n >= sizeof(tmp)) {
+        file_error_set(out_err, "path_too_long", 0);
+        return CBM_NOT_FOUND;
+    }
+
     FILE *fp = fopen(tmp, "wb");
     if (!fp) {
+        file_error_set(out_err, "open_temp", errno);
         return CBM_NOT_FOUND;
     }
+
     size_t wr = fwrite(data, ART_NUL, len, fp);
-    (void)fclose(fp);
     if (wr != len) {
+        int saved_errno = ferror(fp) ? errno : 0;
+        (void)fclose(fp);
         cbm_unlink(tmp);
+        file_error_set(out_err, "write_temp", saved_errno);
         return CBM_NOT_FOUND;
     }
-    if (rename(tmp, path) != 0) {
+
+    if (fclose(fp) != 0) {
+        int saved_errno = errno;
         cbm_unlink(tmp);
+        file_error_set(out_err, "close_temp", saved_errno);
+        return CBM_NOT_FOUND;
+    }
+
+#ifdef _WIN32
+    /* C rename() does not reliably replace an existing destination on Windows. */
+    cbm_unlink(path);
+#endif
+    if (rename(tmp, path) != 0) {
+        int saved_errno = errno;
+        cbm_unlink(tmp);
+        file_error_set(out_err, "rename_temp", saved_errno);
         return CBM_NOT_FOUND;
     }
     return 0;
@@ -215,13 +302,20 @@ static int write_metadata(const char *repo_path, const char *project_name, int n
     char *json = yyjson_mut_write(doc, YYJSON_WRITE_PRETTY, &json_len);
     yyjson_mut_doc_free(doc);
     if (!json) {
-        return CBM_NOT_FOUND;
+        return artifact_export_fail("write_metadata", NULL, "json_encode", 0);
     }
 
     char meta_path[CBM_SZ_4K];
-    artifact_path(meta_path, sizeof(meta_path), repo_path, CBM_ARTIFACT_META);
-    int rc = write_file_atomic(meta_path, json, json_len);
+    if (!artifact_path(meta_path, sizeof(meta_path), repo_path, CBM_ARTIFACT_META)) {
+        free(json);
+        return artifact_export_fail("write_metadata", repo_path, "path_too_long", 0);
+    }
+    artifact_file_error_t ioerr;
+    int rc = write_file_atomic(meta_path, json, json_len, &ioerr);
     free(json);
+    if (rc != 0) {
+        return artifact_export_fail("write_metadata", meta_path, ioerr.err, ioerr.err_no);
+    }
     return rc;
 }
 
@@ -288,7 +382,8 @@ static char *prepare_stripped_db(const char *db_path, size_t *out_size) {
      * (which blocks ATTACH, used internally by VACUUM INTO). */
     sqlite3 *raw_db = NULL;
     if (sqlite3_open_v2(db_path, &raw_db, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK) {
-        cbm_log_error("artifact.export", "err", "open_source_db");
+        const char *err = raw_db ? sqlite3_errmsg(raw_db) : "sqlite_open";
+        artifact_export_fail("open_source_db", db_path, err, 0);
         sqlite3_close(raw_db);
         return NULL;
     }
@@ -300,7 +395,7 @@ static char *prepare_stripped_db(const char *db_path, size_t *out_size) {
     sqlite3_close(raw_db);
 
     if (vrc != SQLITE_OK) {
-        cbm_log_error("artifact.export", "err", "vacuum_into");
+        artifact_export_fail("vacuum_into", tmp_path, errmsg ? errmsg : sqlite3_errstr(vrc), 0);
         sqlite3_free(errmsg);
         cbm_unlink(tmp_path);
         return NULL;
@@ -315,6 +410,9 @@ static char *prepare_stripped_db(const char *db_path, size_t *out_size) {
     }
 
     char *data = read_file_alloc(tmp_path, out_size);
+    if (!data || *out_size == 0) {
+        artifact_export_fail("read_stripped_db", tmp_path, "empty_or_unreadable", errno);
+    }
     cbm_unlink(tmp_path);
 
     /* Clean up WAL/SHM from temp */
@@ -331,14 +429,26 @@ static char *prepare_stripped_db(const char *db_path, size_t *out_size) {
 
 int cbm_artifact_export(const char *db_path, const char *repo_path, const char *project_name,
                         int quality) {
+    clear_export_error();
+
     if (!db_path || !repo_path || !project_name) {
-        return CBM_NOT_FOUND;
+        return artifact_export_fail("validate_args", NULL, "missing_argument", 0);
     }
 
     /* Ensure .codebase-memory/ directory exists */
     char art_dir[CBM_SZ_4K];
-    snprintf(art_dir, sizeof(art_dir), "%s/%s", repo_path, CBM_ARTIFACT_DIR);
-    cbm_mkdir_p(art_dir, ART_DIR_PERMS);
+    int dir_len = snprintf(art_dir, sizeof(art_dir), "%s/%s", repo_path, CBM_ARTIFACT_DIR);
+    if (dir_len < 0 || (size_t)dir_len >= sizeof(art_dir)) {
+        return artifact_export_fail("prepare_artifact_dir", repo_path, "path_too_long", 0);
+    }
+    errno = 0;
+    if (!cbm_mkdir_p(art_dir, ART_DIR_PERMS)) {
+        return artifact_export_fail("prepare_artifact_dir", art_dir, "mkdir_or_not_directory",
+                                    errno);
+    }
+    if (!cbm_is_dir(art_dir)) {
+        return artifact_export_fail("prepare_artifact_dir", art_dir, "not_directory", 0);
+    }
 
     size_t db_size = 0;
     char *db_data = NULL;
@@ -353,8 +463,10 @@ int cbm_artifact_export(const char *db_path, const char *repo_path, const char *
 
     if (!db_data || db_size == 0) {
         free(db_data);
-        cbm_log_error("artifact.export", "err", "read_db");
-        return CBM_NOT_FOUND;
+        if (cbm_artifact_export_last_error()) {
+            return CBM_NOT_FOUND;
+        }
+        return artifact_export_fail("read_db", db_path, "empty_or_unreadable", errno);
     }
 
     /* Compress with zstd */
@@ -362,7 +474,7 @@ int cbm_artifact_export(const char *db_path, const char *repo_path, const char *
     char *compressed = malloc(bound);
     if (!compressed) {
         free(db_data);
-        return CBM_NOT_FOUND;
+        return artifact_export_fail("compress", NULL, "alloc_compressed_buffer", 0);
     }
 
     int clen = cbm_zstd_compress(db_data, (int)db_size, compressed, (int)bound, compression_level);
@@ -370,19 +482,21 @@ int cbm_artifact_export(const char *db_path, const char *repo_path, const char *
 
     if (clen <= 0) {
         free(compressed);
-        cbm_log_error("artifact.export", "err", "zstd_compress");
-        return CBM_NOT_FOUND;
+        return artifact_export_fail("compress", NULL, "zstd_compress", 0);
     }
 
     /* Write compressed artifact */
     char zst_path[CBM_SZ_4K];
-    artifact_path(zst_path, sizeof(zst_path), repo_path, CBM_ARTIFACT_FILENAME);
-    int wrc = write_file_atomic(zst_path, compressed, (size_t)clen);
+    if (!artifact_path(zst_path, sizeof(zst_path), repo_path, CBM_ARTIFACT_FILENAME)) {
+        free(compressed);
+        return artifact_export_fail("write_artifact", repo_path, "path_too_long", 0);
+    }
+    artifact_file_error_t ioerr;
+    int wrc = write_file_atomic(zst_path, compressed, (size_t)clen, &ioerr);
     free(compressed);
 
     if (wrc != 0) {
-        cbm_log_error("artifact.export", "err", "write_artifact");
-        return CBM_NOT_FOUND;
+        return artifact_export_fail("write_artifact", zst_path, ioerr.err, ioerr.err_no);
     }
 
     /* Get node/edge counts for metadata */
@@ -396,7 +510,11 @@ int cbm_artifact_export(const char *db_path, const char *repo_path, const char *
     }
 
     /* Write metadata */
-    write_metadata(repo_path, project_name, nodes, edges, db_size, (size_t)clen, compression_level);
+    if (write_metadata(repo_path, project_name, nodes, edges, db_size, (size_t)clen,
+                       compression_level) != 0) {
+        cbm_unlink(zst_path);
+        return CBM_NOT_FOUND;
+    }
 
     /* Ensure .gitattributes for merge conflict prevention */
     ensure_gitattributes(repo_path);
@@ -472,11 +590,18 @@ int cbm_artifact_import(const char *repo_path, const char *cache_db_path) {
         cbm_mkdir_p(cache_dir, ART_DIR_PERMS);
     }
 
-    int wrc = write_file_atomic(tmp_path, decompressed, (size_t)dlen);
+    artifact_file_error_t ioerr;
+    int wrc = write_file_atomic(tmp_path, decompressed, (size_t)dlen, &ioerr);
     free(decompressed);
 
     if (wrc != 0) {
-        cbm_log_error("artifact.import", "err", "write_temp_db");
+        if (ioerr.err_no != 0) {
+            cbm_log_error("artifact.import", "err", "write_temp_db", "detail", ioerr.err, "errno",
+                          itoa_buf(ioerr.err_no), "path", tmp_path);
+        } else {
+            cbm_log_error("artifact.import", "err", "write_temp_db", "detail", ioerr.err, "path",
+                          tmp_path);
+        }
         return CBM_NOT_FOUND;
     }
 

--- a/src/pipeline/artifact.c
+++ b/src/pipeline/artifact.c
@@ -36,6 +36,9 @@ enum {
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 /* ── Helpers ──────────────────────────────────────────────────────── */
 
@@ -180,15 +183,21 @@ static int write_file_atomic(const char *path, const char *data, size_t len,
     }
 
 #ifdef _WIN32
-    /* C rename() does not reliably replace an existing destination on Windows. */
-    cbm_unlink(path);
-#endif
+    /* MoveFileEx replace approach suggested by @Ayush7Ranjan in #492. */
+    if (!MoveFileExA(tmp, path, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        DWORD saved_error = GetLastError();
+        cbm_unlink(tmp);
+        file_error_set(out_err, "rename_temp", (int)saved_error);
+        return CBM_NOT_FOUND;
+    }
+#else
     if (rename(tmp, path) != 0) {
         int saved_errno = errno;
         cbm_unlink(tmp);
         file_error_set(out_err, "rename_temp", saved_errno);
         return CBM_NOT_FOUND;
     }
+#endif
     return 0;
 }
 

--- a/src/pipeline/artifact.h
+++ b/src/pipeline/artifact.h
@@ -32,6 +32,10 @@ enum {
 int cbm_artifact_export(const char *db_path, const char *repo_path, const char *project_name,
                         int quality);
 
+/* Get details for the most recent export failure on this thread.
+ * Returns NULL if no export error is recorded. */
+const char *cbm_artifact_export_last_error(void);
+
 /* Import artifact from .codebase-memory/graph.db.zst to cache_db_path.
  * Decompresses, runs integrity check, recreates indexes.
  * Returns 0 on success, -1 on error. */

--- a/src/pipeline/pipeline.c
+++ b/src/pipeline/pipeline.c
@@ -46,6 +46,8 @@ static inline void *intptr_to_ptr(intptr_t v) {
     return p;
 }
 
+const char *cbm_artifact_export_last_error(void);
+
 /* ── Global index lock ─────────────────────────────────────────── */
 /* Prevents concurrent pipeline runs on the same DB file.
  * Atomic spinlock: 0 = free, 1 = locked. */
@@ -847,7 +849,12 @@ static int dump_and_persist_hashes(cbm_pipeline_t *p, const cbm_file_info_t *fil
 
     /* Export persistent artifact if enabled */
     if (p->persistence) {
-        cbm_artifact_export(db_path, p->repo_path, p->project_name, CBM_ARTIFACT_BEST);
+        int arc = cbm_artifact_export(db_path, p->repo_path, p->project_name, CBM_ARTIFACT_BEST);
+        if (arc != 0) {
+            const char *err = cbm_artifact_export_last_error();
+            cbm_log_error("pipeline.err", "phase", "artifact_export", "err", err ? err : "unknown");
+            return arc;
+        }
     }
 
     return 0;

--- a/src/pipeline/pipeline.c
+++ b/src/pipeline/pipeline.c
@@ -46,8 +46,6 @@ static inline void *intptr_to_ptr(intptr_t v) {
     return p;
 }
 
-const char *cbm_artifact_export_last_error(void);
-
 /* ── Global index lock ─────────────────────────────────────────── */
 /* Prevents concurrent pipeline runs on the same DB file.
  * Atomic spinlock: 0 = free, 1 = locked. */
@@ -853,6 +851,7 @@ static int dump_and_persist_hashes(cbm_pipeline_t *p, const cbm_file_info_t *fil
         if (arc != 0) {
             const char *err = cbm_artifact_export_last_error();
             cbm_log_error("pipeline.err", "phase", "artifact_export", "err", err ? err : "unknown");
+            /* A failed persistence export intentionally fails the run; this used to be ignored. */
             return arc;
         }
     }

--- a/tests/test_artifact.c
+++ b/tests/test_artifact.c
@@ -4,8 +4,10 @@
 #include "test_framework.h"
 #include "store/store.h"
 #include "pipeline/artifact.h"
+#include "pipeline/pipeline.h"
 #include "foundation/compat.h"
 #include "foundation/compat_fs.h"
+#include "foundation/log.h"
 
 #include <sys/stat.h>
 #include <stdio.h>
@@ -15,6 +17,11 @@
 static char g_tmpdir[1024];
 static char g_repo[1024];
 static char g_db[1024];
+enum { ART_TEST_LOG_BUF = 32768 };
+static char g_log_capture[ART_TEST_LOG_BUF];
+static CBMLogLevel g_prev_log_level;
+
+const char *cbm_artifact_export_last_error(void);
 
 static void setup_artifact_test(void) {
     snprintf(g_tmpdir, sizeof(g_tmpdir), "%s/cbm_test_artifact_XXXXXX", cbm_tmpdir());
@@ -51,6 +58,40 @@ static void cleanup_dir(const char *path) {
     char cmd[2048];
     snprintf(cmd, sizeof(cmd), "rm -rf '%s'", path);
     (void)system(cmd);
+}
+
+static void write_text_file(const char *path, const char *text) {
+    FILE *fp = fopen(path, "w");
+    if (!fp) {
+        return;
+    }
+    fputs(text, fp);
+    fclose(fp);
+}
+
+static void capture_log_sink(const char *line) {
+    size_t used = strlen(g_log_capture);
+    size_t avail = sizeof(g_log_capture) - used;
+    if (avail <= 1) {
+        return;
+    }
+    int n = snprintf(g_log_capture + used, avail, "%s\n", line);
+    if (n < 0 || (size_t)n >= avail) {
+        g_log_capture[sizeof(g_log_capture) - 1] = '\0';
+    }
+}
+
+static void capture_logs_start(void) {
+    g_log_capture[0] = '\0';
+    g_prev_log_level = cbm_log_get_level();
+    cbm_log_set_level(CBM_LOG_DEBUG);
+    cbm_log_set_sink(capture_log_sink);
+}
+
+static const char *capture_logs_end(void) {
+    cbm_log_set_sink(NULL);
+    cbm_log_set_level(g_prev_log_level);
+    return g_log_capture;
 }
 
 /* ── Tests ───────────────────────────────────────────────────────── */
@@ -207,6 +248,68 @@ TEST(artifact_gitattributes_created) {
     PASS();
 }
 
+TEST(artifact_export_rename_failure_logs_specific_error) {
+    setup_artifact_test();
+    create_test_db(g_db);
+
+    char art_dir[1024];
+    snprintf(art_dir, sizeof(art_dir), "%s/.codebase-memory", g_repo);
+    cbm_mkdir_p(art_dir, 0755);
+
+    char zst[1024];
+    snprintf(zst, sizeof(zst), "%s/graph.db.zst", art_dir);
+    cbm_mkdir_p(zst, 0755);
+
+    capture_logs_start();
+    int rc = cbm_artifact_export(g_db, g_repo, "test-proj", CBM_ARTIFACT_FAST);
+    const char *logs = capture_logs_end();
+
+    ASSERT_NEQ(rc, 0);
+    ASSERT_FALSE(cbm_artifact_exists(g_repo));
+    ASSERT_NOT_NULL(cbm_artifact_export_last_error());
+    ASSERT(strstr(cbm_artifact_export_last_error(), "write_artifact") != NULL);
+    ASSERT(strstr(cbm_artifact_export_last_error(), "rename_temp") != NULL);
+    ASSERT(strstr(logs, "msg=artifact.export") != NULL);
+    ASSERT(strstr(logs, "stage=write_artifact") != NULL);
+    ASSERT(strstr(logs, "err=rename_temp") != NULL);
+
+    cleanup_dir(g_tmpdir);
+    PASS();
+}
+
+TEST(pipeline_persistence_export_failure_returns_error) {
+    setup_artifact_test();
+
+    char src[1024];
+    snprintf(src, sizeof(src), "%s/main.c", g_repo);
+    write_text_file(src, "int main(void) { return 0; }\n");
+
+    char art_dir[1024];
+    snprintf(art_dir, sizeof(art_dir), "%s/.codebase-memory", g_repo);
+    cbm_mkdir_p(art_dir, 0755);
+
+    char zst[1024];
+    snprintf(zst, sizeof(zst), "%s/graph.db.zst", art_dir);
+    cbm_mkdir_p(zst, 0755);
+
+    cbm_pipeline_t *p = cbm_pipeline_new(g_repo, g_db, CBM_MODE_FAST);
+    ASSERT_NOT_NULL(p);
+    cbm_pipeline_set_persistence(p, true);
+
+    capture_logs_start();
+    int rc = cbm_pipeline_run(p);
+    const char *logs = capture_logs_end();
+    cbm_pipeline_free(p);
+
+    ASSERT_NEQ(rc, 0);
+    ASSERT_FALSE(cbm_artifact_exists(g_repo));
+    ASSERT(strstr(logs, "msg=pipeline.err") != NULL);
+    ASSERT(strstr(logs, "phase=artifact_export") != NULL);
+
+    cleanup_dir(g_tmpdir);
+    PASS();
+}
+
 TEST(artifact_null_safety) {
     ASSERT_NEQ(cbm_artifact_export(NULL, "/tmp", "p", 0), 0);
     ASSERT_NEQ(cbm_artifact_export("/tmp/x.db", NULL, "p", 0), 0);
@@ -225,5 +328,7 @@ SUITE(artifact) {
     RUN_TEST(artifact_schema_version_mismatch);
     RUN_TEST(artifact_import_missing);
     RUN_TEST(artifact_gitattributes_created);
+    RUN_TEST(artifact_export_rename_failure_logs_specific_error);
+    RUN_TEST(pipeline_persistence_export_failure_returns_error);
     RUN_TEST(artifact_null_safety);
 }

--- a/tests/test_artifact.c
+++ b/tests/test_artifact.c
@@ -21,8 +21,6 @@ enum { ART_TEST_LOG_BUF = 32768 };
 static char g_log_capture[ART_TEST_LOG_BUF];
 static CBMLogLevel g_prev_log_level;
 
-const char *cbm_artifact_export_last_error(void);
-
 static void setup_artifact_test(void) {
     snprintf(g_tmpdir, sizeof(g_tmpdir), "%s/cbm_test_artifact_XXXXXX", cbm_tmpdir());
     cbm_mkdtemp(g_tmpdir);


### PR DESCRIPTION
## Summary
On Windows, index_repository with persistence:true reports status:indexed but artifact_present:false, and the <repo>/.codebase-memory directory is created with only ADR.md and no graph.db.zst, with no error surfaced. A second user (armandn) reproduced this on 2026-06-17 with a concrete index_repository response (nodes:1866, edges:5340, adr_present:true, artifact_present:false).

## Changes
The artifact export lives in src/pipeline/artifact.c (referenced by pipeline.c, which sets artifact_present in the index_repository response). Audit the Windows code path for the zstd-compressed graph.db.zst write: a failed temp-file create/rename or path-separator/long-path handling likely returns early without propagating an error, leaving artifact_present:false and no log line.

Fixes #400
