### PR TITLE
docs(config): document extra_extensions values and skip behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ export CBM_CACHE_DIR=~/my-projects/cbm-data
 
 ## Custom File Extensions
 
-Map additional file extensions to supported languages via JSON config files. Useful for framework-specific extensions like `.blade.php` (Laravel) or `.mjs` (ES modules).
+The JSON config files support a single key, `extra_extensions`, which maps additional file extensions to supported languages. Useful for framework-specific extensions like `.blade.php` (Laravel) or `.mjs` (ES modules). (For other tunables, see [Environment Variables](#environment-variables) and the `config` subcommand above.)
 
 **Per-project** (in your repo root):
 ```json
@@ -467,7 +467,11 @@ Map additional file extensions to supported languages via JSON config files. Use
 {"extra_extensions": {".twig": "html", ".phtml": "php"}}
 ```
 
-Project config overrides global for conflicting extensions. Unknown language values are silently skipped. Missing config files are ignored.
+Each entry maps an extension (which **must** start with `.`) to a language name. Language names are matched **case-insensitively**. Accepted values (aliases in parentheses) are:
+
+`bash` (`sh`), `c`, `c++` (`cpp`), `c#` (`csharp`), `clojure`, `cmake`, `cobol`, `common lisp` (`commonlisp`, `lisp`), `css`, `cuda`, `dart`, `dockerfile`, `elixir`, `elm`, `emacs lisp` (`emacslisp`), `erlang`, `f#` (`fsharp`), `form`, `fortran`, `glsl`, `go`, `graphql`, `groovy`, `haskell`, `hcl` (`terraform`), `html`, `ini`, `java`, `javascript`, `json`, `julia`, `kotlin`, `lean`, `lua`, `magma`, `makefile`, `markdown`, `matlab`, `meson`, `nix`, `objective-c` (`objc`), `ocaml`, `perl`, `php`, `protobuf`, `python`, `r`, `ruby`, `rust`, `scala`, `scss`, `sql`, `svelte`, `swift`, `toml`, `tsx`, `typescript`, `verilog`, `vimscript`, `vue`, `wolfram`, `xml`, `yaml`, `zig`.
+
+Project config overrides global for conflicting extensions. An entry whose language name is unknown, or whose extension does not start with `.`, is skipped and a warning is logged to stderr (shown at the default `info` log level). Missing config files are ignored.
 
 ## Persistence
 


### PR DESCRIPTION
Closes #359.

The README's **Custom File Extensions** section previously showed a single example key and stated unknown language values are "silently skipped". #359 asks which other config-file options exist and where they're documented.

This clarifies the config-file surface and fixes an inaccuracy:

- States that `extra_extensions` is the **only** key the JSON config files (`.codebase-memory.json` / `config.json`) accept, and points to the Environment Variables table and `config` subcommand for other tunables.
- Lists the **accepted, case-insensitive language names** (and aliases) from `LANG_NAME_TABLE` in `src/discover/userconfig.c`, so users know which values are valid.
- Documents the "extension must start with `.`" rule.
- Corrects the behavior note: invalid entries are **skipped with a warning logged to stderr** (`parse_extra_extensions` calls `cbm_log_warn("userconfig.unknown_lang", …)`), not silently.

Docs only — no code changes. Verified against `main` (`e599df1`).
