### PR TITLE
Fix Windows artifact refresh in write_file_atomic

### DIFF
--- a/src/pipeline/artifact.c
+++ b/src/pipeline/artifact.c
@@ -36,6 +36,9 @@ enum {
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 /* ── Helpers ──────────────────────────────────────────────────────── */
 
@@ -98,7 +101,11 @@ static int write_file_atomic(const char *path, const char *data, size_t len) {
         cbm_unlink(tmp);
         return CBM_NOT_FOUND;
     }
+#ifdef _WIN32
+    if (!MoveFileExA(tmp, path, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+#else
     if (rename(tmp, path) != 0) {
+#endif
         cbm_unlink(tmp);
         return CBM_NOT_FOUND;
     }


### PR DESCRIPTION
## Summary

  Fixes Windows artifact persistence for `index_repository` with
  `persistence=true`.

  On Windows, `.codebase-memory/graph.db.zst` was created on the
  first run, but subsequent runs did not refresh/replace the
  artifact. The root cause was `src/pipeline/
  artifact.c::write_file_atomic()` using `rename(tmp, path)`,
  which does not reliably replace an existing destination file
  on Windows.

  This PR updates the atomic replace path so:

  - Windows uses `MoveFileExA(tmp, path,
  MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)`
  - POSIX keeps the existing `rename(tmp, path)` behavior

  ## Verification

  Built on Windows with MSYS2:

  ```powershell
  C:\msys64\usr\bin\bash.exe -lc "export HOME=/tmp; export
  PATH=/mingw64/bin:/usr/bin:$PATH; cd /c/Users/aayus/OneDrive/
  Desktop/opensource/codebase-memory-mcp; scripts/build.sh
  CC=gcc CXX=g++"

  Ran the Issue #400 reproduction twice with:

  $env:CBM_CACHE_DIR = ".\.codebase-memory"
  $env:CBM_PERSIST_EXPORTS = "true"

  Result:

  First run:
  artifact_present=true
  graph.db.zst exists=true
  size=7586364
  lastWriteUtc=2026-06-17T18:58:02.0340409Z

  Second run:
  artifact_present=true
  graph.db.zst exists=true
  size=9914129
  lastWriteUtc=2026-06-17T18:58:07.9280511Z

  timestamp_changed=True

  ## Fixes

  Fixes #400