### PR TITLE
fix(discover): honor .git/info/exclude during file discovery

### DIFF
--- a/src/discover/discover.c
+++ b/src/discover/discover.c
@@ -541,7 +541,13 @@ int cbm_discover_ex(const char *repo_path, const cbm_discover_opts_t *opts, cbm_
         return CBM_NOT_FOUND;
     }
 
-    /* Load gitignore if .git directory exists */
+    /* Load gitignore sources when a .git directory is present.
+     * Sources merged in order (later patterns win on conflict):
+     *   1. <repo>/.gitignore        — committed exclusions
+     *   2. <repo>/.git/info/exclude — per-clone exclusions, not committed
+     * Both are folded into a single matcher so all downstream call paths
+     * remain unchanged.  Fixes issue #489: OOM on repos whose worktrees
+     * are excluded only via .git/info/exclude (e.g. Sandcastle). */
     cbm_gitignore_t *gitignore = NULL;
     char gi_path[CBM_SZ_4K];
     snprintf(gi_path, sizeof(gi_path), "%s/.git", repo_path);
@@ -549,6 +555,18 @@ int cbm_discover_ex(const char *repo_path, const cbm_discover_opts_t *opts, cbm_
     if (wide_stat(gi_path, &gi_stat) == 0 && S_ISDIR(gi_stat.st_mode)) {
         snprintf(gi_path, sizeof(gi_path), "%s/.gitignore", repo_path);
         gitignore = cbm_gitignore_load(gi_path);
+
+        char exc_path[CBM_SZ_4K];
+        snprintf(exc_path, sizeof(exc_path), "%s/.git/info/exclude", repo_path);
+        cbm_gitignore_t *git_exclude = cbm_gitignore_load(exc_path);
+        if (git_exclude) {
+            if (!gitignore) {
+                gitignore = git_exclude;
+            } else {
+                cbm_gitignore_merge(gitignore, git_exclude);
+                cbm_gitignore_free(git_exclude);
+            }
+        }
     }
 
     /* Load cbmignore if specified or exists at repo root */

--- a/src/discover/discover.h
+++ b/src/discover/discover.h
@@ -58,6 +58,11 @@ bool cbm_gitignore_matches(const cbm_gitignore_t *gi, const char *rel_path, bool
 /* Free a gitignore matcher. NULL-safe. */
 void cbm_gitignore_free(cbm_gitignore_t *gi);
 
+/* Append all patterns from src into dst. dst takes ownership of deep copies
+ * of each src pattern; src is unchanged and must still be freed by the caller.
+ * NULL-safe on either argument. */
+void cbm_gitignore_merge(cbm_gitignore_t *dst, const cbm_gitignore_t *src);
+
 /* ── Directory skip / suffix filters ─────────────────────────────── */
 
 /* Index mode controls filtering aggressiveness.

--- a/src/discover/gitignore.c
+++ b/src/discover/gitignore.c
@@ -398,10 +398,10 @@ void cbm_gitignore_merge(cbm_gitignore_t *dst, const cbm_gitignore_t *src) {
         if (!pat) {
             return;
         }
-        dst->patterns[dst->count].pattern  = pat;
-        dst->patterns[dst->count].negated  = src->patterns[i].negated;
+        dst->patterns[dst->count].pattern = pat;
+        dst->patterns[dst->count].negated = src->patterns[i].negated;
         dst->patterns[dst->count].dir_only = src->patterns[i].dir_only;
-        dst->patterns[dst->count].rooted   = src->patterns[i].rooted;
+        dst->patterns[dst->count].rooted = src->patterns[i].rooted;
         dst->count++;
     }
 }

--- a/src/discover/gitignore.c
+++ b/src/discover/gitignore.c
@@ -379,3 +379,29 @@ void cbm_gitignore_free(cbm_gitignore_t *gi) {
     free(gi->patterns);
     free(gi);
 }
+
+void cbm_gitignore_merge(cbm_gitignore_t *dst, const cbm_gitignore_t *src) {
+    if (!dst || !src || src->count == 0) {
+        return;
+    }
+    int needed = dst->count + src->count;
+    if (needed > dst->capacity) {
+        gi_pattern_t *grown = realloc(dst->patterns, (size_t)needed * sizeof(gi_pattern_t));
+        if (!grown) {
+            return;
+        }
+        dst->patterns = grown;
+        dst->capacity = needed;
+    }
+    for (int i = 0; i < src->count; i++) {
+        char *pat = strdup(src->patterns[i].pattern);
+        if (!pat) {
+            return;
+        }
+        dst->patterns[dst->count].pattern  = pat;
+        dst->patterns[dst->count].negated  = src->patterns[i].negated;
+        dst->patterns[dst->count].dir_only = src->patterns[i].dir_only;
+        dst->patterns[dst->count].rooted   = src->patterns[i].rooted;
+        dst->count++;
+    }
+}

--- a/tests/test_discover.c
+++ b/tests/test_discover.c
@@ -627,6 +627,66 @@ TEST(discover_cbmignore_no_git) {
     PASS();
 }
 
+/* ── .git/info/exclude tests (issue #489) ─────────────────────── */
+
+/* Per-clone excludes written to .git/info/exclude (not committed) must be
+ * honored the same as .gitignore.  Without this, repos that keep worktrees
+ * under a path excluded only via info/exclude hit OOM during indexing. */
+TEST(discover_git_info_exclude) {
+    char *base = th_mktempdir("cbm_disc_exc");
+    ASSERT(base != NULL);
+
+    th_mkdir_p(TH_PATH(base, ".git/info"));
+    th_write_file(TH_PATH(base, ".git/info/exclude"), "worktrees/\n");
+    th_write_file(TH_PATH(base, "src/main.go"), "package main\n");
+    th_write_file(TH_PATH(base, "worktrees/feature/app.go"), "package app\n");
+
+    cbm_discover_opts_t opts = {0};
+    cbm_file_info_t *files = NULL;
+    int count = 0;
+    int rc = cbm_discover(base, &opts, &files, &count);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(count, 1);
+    ASSERT_TRUE(strstr(files[0].rel_path, "main.go") != NULL);
+
+    cbm_discover_free(files, count);
+    th_cleanup(base);
+    PASS();
+}
+
+TEST(discover_git_info_exclude_stacks_with_gitignore) {
+    char *base = th_mktempdir("cbm_disc_exc_stack");
+    ASSERT(base != NULL);
+
+    th_mkdir_p(TH_PATH(base, ".git/info"));
+    th_write_file(TH_PATH(base, ".gitignore"), "*.log\n");
+    th_write_file(TH_PATH(base, ".git/info/exclude"), "scratch/\n");
+    th_write_file(TH_PATH(base, "main.go"), "package main\n");
+    th_write_file(TH_PATH(base, "debug.log"), "log\n");
+    th_write_file(TH_PATH(base, "scratch/tmp.go"), "package scratch\n");
+
+    cbm_discover_opts_t opts = {0};
+    cbm_file_info_t *files = NULL;
+    int count = 0;
+    int rc = cbm_discover(base, &opts, &files, &count);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(count, 1);
+
+    bool found_log = false;
+    bool found_scratch = false;
+    for (int i = 0; i < count; i++) {
+        if (strstr(files[i].rel_path, ".log"))    found_log     = true;
+        if (strstr(files[i].rel_path, "scratch")) found_scratch = true;
+    }
+    ASSERT_FALSE(found_log);
+    ASSERT_FALSE(found_scratch);
+    ASSERT_TRUE(strstr(files[0].rel_path, "main.go") != NULL);
+
+    cbm_discover_free(files, count);
+    th_cleanup(base);
+    PASS();
+}
+
 /* ── Nested .gitignore tests (issue #178) ──────────────────────── */
 
 TEST(discover_nested_gitignore) {
@@ -793,6 +853,10 @@ SUITE(discover) {
     RUN_TEST(discover_generic_dirs_full_mode);
     RUN_TEST(discover_generic_dirs_fast_mode);
     RUN_TEST(discover_cbmignore_no_git);
+
+    /* .git/info/exclude support (issue #489) */
+    RUN_TEST(discover_git_info_exclude);
+    RUN_TEST(discover_git_info_exclude_stacks_with_gitignore);
 
     /* Nested .gitignore tests (issue #178) */
     RUN_TEST(discover_nested_gitignore);

--- a/tests/test_gitignore.c
+++ b/tests/test_gitignore.c
@@ -186,6 +186,50 @@ TEST(gi_load_nonexistent) {
     PASS();
 }
 
+/* ── Merge ─────────────────────────────────────────────────────── */
+
+TEST(gi_merge_patterns) {
+    cbm_gitignore_t *base_gi = cbm_gitignore_parse("*.log\n");
+    cbm_gitignore_t *extra   = cbm_gitignore_parse("tmp/\nbuild/\n");
+    ASSERT_NOT_NULL(base_gi);
+    ASSERT_NOT_NULL(extra);
+
+    cbm_gitignore_merge(base_gi, extra);
+    cbm_gitignore_free(extra);
+
+    ASSERT_TRUE(cbm_gitignore_matches(base_gi, "error.log", false));
+    ASSERT_TRUE(cbm_gitignore_matches(base_gi, "tmp", true));
+    ASSERT_TRUE(cbm_gitignore_matches(base_gi, "build", true));
+    ASSERT_FALSE(cbm_gitignore_matches(base_gi, "main.go", false));
+
+    cbm_gitignore_free(base_gi);
+    PASS();
+}
+
+TEST(gi_merge_into_empty) {
+    cbm_gitignore_t *dst = cbm_gitignore_parse("");
+    cbm_gitignore_t *src = cbm_gitignore_parse("*.o\n");
+    ASSERT_NOT_NULL(dst);
+    ASSERT_NOT_NULL(src);
+
+    cbm_gitignore_merge(dst, src);
+    cbm_gitignore_free(src);
+
+    ASSERT_TRUE(cbm_gitignore_matches(dst, "main.o", false));
+    ASSERT_FALSE(cbm_gitignore_matches(dst, "main.c", false));
+
+    cbm_gitignore_free(dst);
+    PASS();
+}
+
+TEST(gi_merge_null_safe) {
+    cbm_gitignore_t *gi = cbm_gitignore_parse("*.log\n");
+    cbm_gitignore_merge(gi, NULL);  /* should not crash */
+    cbm_gitignore_merge(NULL, gi);  /* should not crash */
+    cbm_gitignore_free(gi);
+    PASS();
+}
+
 /* ── Suite ─────────────────────────────────────────────────────── */
 
 SUITE(gitignore) {
@@ -206,4 +250,7 @@ SUITE(gitignore) {
     RUN_TEST(gi_null_safe_free);
     RUN_TEST(gi_load_file);
     RUN_TEST(gi_load_nonexistent);
+    RUN_TEST(gi_merge_patterns);
+    RUN_TEST(gi_merge_into_empty);
+    RUN_TEST(gi_merge_null_safe);
 }


### PR DESCRIPTION
Fixes #489

## Problem

`index_repository` honored `.gitignore` but silently ignored `.git/info/exclude` — the per-clone exclude file that Git itself treats as authoritative. Any paths excluded only via `info/exclude` (e.g. Sandcastle worktrees) were walked in full.

In the reported case this caused the indexer to traverse 661,430 files / 170 GB of worktree content and OOM.

## Solution

Added `cbm_gitignore_merge()` to append patterns from one matcher into another. In `cbm_discover_ex`, after loading `.gitignore`, the code now also loads `.git/info/exclude` and merges its patterns in. If only the exclude file exists (no `.gitignore`), it is used directly. No downstream call paths change.

## Changes

- `src/discover/discover.h` — declare `cbm_gitignore_merge`
- `src/discover/gitignore.c` — implement `cbm_gitignore_merge`
- `src/discover/discover.c` — load and merge `.git/info/exclude` in `cbm_discover_ex`
- `tests/test_gitignore.c` — 3 unit tests for `cbm_gitignore_merge`
- `tests/test_discover.c` — 2 integration tests reproducing the issue scenario

## Testing

Added `discover_git_info_exclude` and `discover_git_info_exclude_stacks_with_gitignore` to the discover suite, covering the exact reproduction case from the issue report.