### PR TITLE
fix(pipeline): persist call-site line on CALLS edges

### DIFF
--- a/src/pipeline/pass_calls.c
+++ b/src/pipeline/pass_calls.c
@@ -240,6 +240,24 @@ static int64_t create_svc_route_node(cbm_pipeline_ctx_t *ctx, const char *url, c
     return cbm_gbuf_upsert_node(ctx->gbuf, "Route", url, route_qn, "", 0, 0, rp);
 }
 
+/* Insert an edge, splicing the call-site line (,"line":N) in before the closing
+ * brace when one was captured. Mirrors finalize_and_emit() on the parallel path
+ * so CALLS edges carry their source line regardless of resolution path. Restricted
+ * to CALLS: route/config edge props feed full-only predump passes
+ * (create_route_nodes/create_data_flows), so altering them desyncs full vs
+ * incremental indexing. */
+static void calls_emit_edge(cbm_gbuf_t *gbuf, int64_t src, int64_t tgt, const char *type,
+                            char *props, size_t cap, const CBMCall *call) {
+    if (call && call->start_line > 0 && strcmp(type, "CALLS") == 0) {
+        size_t len = strlen(props);
+        if (len >= SKIP_ONE && props[len - SKIP_ONE] == '}' && len + CBM_SZ_32 < cap) {
+            snprintf(props + len - SKIP_ONE, cap - (len - SKIP_ONE), ",\"line\":%d}",
+                     call->start_line);
+        }
+    }
+    cbm_gbuf_insert_edge(gbuf, src, tgt, type, props);
+}
+
 static void emit_http_async_edge(cbm_pipeline_ctx_t *ctx, const CBMCall *call,
                                  const cbm_gbuf_node_t *source, const cbm_gbuf_node_t *target,
                                  const cbm_resolution_t *res, cbm_svc_kind_t svc) {
@@ -256,7 +274,7 @@ static void emit_http_async_edge(cbm_pipeline_ctx_t *ctx, const CBMCall *call,
                  "{\"callee\":\"%s\",\"confidence\":%.2f,\"strategy\":\"%s\",\"candidates\":%d}",
                  esc_callee, res->confidence, res->strategy ? res->strategy : "unknown",
                  res->candidate_count);
-        cbm_gbuf_insert_edge(ctx->gbuf, source->id, target->id, "CALLS", props);
+        calls_emit_edge(ctx->gbuf, source->id, target->id, "CALLS", props, sizeof(props), call);
         return;
     }
     const char *edge_type = (svc == CBM_SVC_HTTP) ? "HTTP_CALLS" : "ASYNC_CALLS";
@@ -279,7 +297,7 @@ static void emit_http_async_edge(cbm_pipeline_ctx_t *ctx, const CBMCall *call,
             snprintf(props + plen - 1, sizeof(props) - plen + SKIP_ONE, "\"}");
         }
     }
-    cbm_gbuf_insert_edge(ctx->gbuf, source->id, route_id, edge_type, props);
+    calls_emit_edge(ctx->gbuf, source->id, route_id, edge_type, props, sizeof(props), call);
 }
 
 /* Classify a resolved call and emit the appropriate edge. */
@@ -304,7 +322,8 @@ static void emit_classified_edge(cbm_pipeline_ctx_t *ctx, const CBMCall *call,
         char props[CBM_SZ_512];
         snprintf(props, sizeof(props), "{\"callee\":\"%s\",\"key\":\"%s\",\"confidence\":%.2f}",
                  esc_c, esc_k, res->confidence);
-        cbm_gbuf_insert_edge(ctx->gbuf, source->id, target->id, "CONFIGURES", props);
+        calls_emit_edge(ctx->gbuf, source->id, target->id, "CONFIGURES", props, sizeof(props),
+                        call);
         return;
     }
     char esc_c2[CBM_SZ_256];
@@ -314,7 +333,7 @@ static void emit_classified_edge(cbm_pipeline_ctx_t *ctx, const CBMCall *call,
              "{\"callee\":\"%s\",\"confidence\":%.2f,\"strategy\":\"%s\",\"candidates\":%d}",
              esc_c2, res->confidence, res->strategy ? res->strategy : "unknown",
              res->candidate_count);
-    cbm_gbuf_insert_edge(ctx->gbuf, source->id, target->id, "CALLS", props);
+    calls_emit_edge(ctx->gbuf, source->id, target->id, "CALLS", props, sizeof(props), call);
 }
 
 /* Find source node for a call: enclosing function or file node. */

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -22,6 +22,8 @@ enum {
      * -> comma + 2 key quotes + colon + 2 value quotes (resp. brackets). */
     PP_JSON_FIELD_OVERHEAD = 6,
     PP_ARGS_MARGIN = 20,
+    /* ,"line":<int> -> comma + key (7) + colon + up to 10 digits + NUL. */
+    PP_LINE_MARGIN = 24,
     PP_LOG_THRESH = 24,
     PP_LOG_INTERVAL = 10,
     PP_TIMER_THRESH = 1000,
@@ -1181,6 +1183,13 @@ static void finalize_and_emit(cbm_gbuf_t *gbuf, int64_t src_id, int64_t tgt_id,
                               const char *edge_type, char *props, int n, const CBMCall *call) {
     if (n > 0 && (size_t)n < CBM_SZ_2K - PP_ESC_SPACE) {
         size_t pos = append_args_json(props, CBM_SZ_2K, (size_t)n, call);
+        if (call->start_line > 0 && strcmp(edge_type, "CALLS") == 0 &&
+            pos < CBM_SZ_2K - PP_LINE_MARGIN) {
+            int ln = snprintf(props + pos, CBM_SZ_2K - pos, ",\"line\":%d", call->start_line);
+            if (ln > 0) {
+                pos += (size_t)ln;
+            }
+        }
         if (pos < CBM_SZ_2K - SKIP_ONE) {
             props[pos] = '}';
             props[pos + SKIP_ONE] = '\0';

--- a/tests/test_pipeline.c
+++ b/tests/test_pipeline.c
@@ -1187,6 +1187,63 @@ TEST(usages_no_duplicate_calls) {
     PASS();
 }
 
+TEST(calls_edge_carries_call_site_line) {
+    /* Regression guard for #503: a CALLS edge must persist the source line of
+     * the call site in its JSON props as "line":N. Helper() is invoked on
+     * line 8 (1-based) of the source below. */
+    const char *go_source = "package mypkg\n"
+                            "\n"
+                            "func Helper() string {\n"
+                            "\treturn \"ok\"\n"
+                            "}\n"
+                            "\n"
+                            "func Main() {\n"
+                            "\tHelper()\n"
+                            "}\n";
+
+    if (setup_usages_repo("mypkg/main.go", go_source, "go.mod", "module testmod\ngo 1.21\n") != 0) {
+        FAIL("failed to create temp dir");
+    }
+
+    char db_path[512];
+    snprintf(db_path, sizeof(db_path), "%s/test_call_line.db", g_usages_tmpdir);
+
+    cbm_pipeline_t *p = cbm_pipeline_new(g_usages_tmpdir, db_path, CBM_MODE_FULL);
+    ASSERT_NOT_NULL(p);
+    ASSERT_EQ(cbm_pipeline_run(p), 0);
+
+    cbm_store_t *s = cbm_store_open_path(db_path);
+    ASSERT_NOT_NULL(s);
+    const char *project = cbm_pipeline_project_name(p);
+
+    cbm_edge_t *call_edges = NULL;
+    int call_count = 0;
+    cbm_store_find_edges_by_type(s, project, "CALLS", &call_edges, &call_count);
+
+    bool found_line = false;
+    for (int i = 0; i < call_count; i++) {
+        cbm_node_t src = {0}, tgt = {0};
+        if (cbm_store_find_node_by_id(s, call_edges[i].source_id, &src) == CBM_STORE_OK &&
+            cbm_store_find_node_by_id(s, call_edges[i].target_id, &tgt) == CBM_STORE_OK) {
+            if (strcmp(src.name, "Main") == 0 && strcmp(tgt.name, "Helper") == 0) {
+                ASSERT_NOT_NULL(call_edges[i].properties_json);
+                ASSERT_TRUE(strstr(call_edges[i].properties_json, "\"line\":8}") != NULL);
+                found_line = true;
+            }
+        }
+        cbm_node_free_fields(&src);
+        cbm_node_free_fields(&tgt);
+    }
+    if (call_edges)
+        cbm_store_free_edges(call_edges, call_count);
+    ASSERT_TRUE(found_line);
+
+    cbm_store_close(s);
+    cbm_pipeline_free(p);
+    teardown_usages_repo();
+    PASS();
+}
+
 TEST(usages_kotlin_creates_edges) {
     /* Port of TestPassUsagesKotlinCreatesEdges.
      * Kotlin source with callback reference → USAGE edge. */
@@ -5712,6 +5769,7 @@ SUITE(pipeline) {
     /* Usages pass (full pipeline integration) */
     RUN_TEST(usages_creates_edges);
     RUN_TEST(usages_no_duplicate_calls);
+    RUN_TEST(calls_edge_carries_call_site_line);
     RUN_TEST(usages_kotlin_creates_edges);
     RUN_TEST(usages_kotlin_no_duplicate_calls);
     /* Language integration tests */


### PR DESCRIPTION
## Summary

`CALLS` edges did not carry the source line of the call site, even though `CBMCall.start_line` is already captured during extraction. This persists it as a `line` property on `CALLS` edges in both resolution paths (`finalize_and_emit` for parallel/registry, a new `calls_emit_edge` helper for serial/LSP), so call-site lines are queryable (`MATCH ()-[r:CALLS]->() RETURN r.line`) instead of needing grep.

Fixes #503.

## Scope: CALLS only

`line` is attached to `CALLS` edges only. Route/config edge props (`HTTP_CALLS`/`ASYNC_CALLS`/`CONFIGURES`) feed the full-only predump passes (`create_route_nodes`/`create_data_flows`), which the incremental path does not re-run. Altering those props desyncs full vs incremental indexing (`tests/test_incremental.c` `incr_accuracy_vs_full`). Restricting to `CALLS` keeps those props byte-identical to baseline and preserves full/incremental parity.

## Testing

- Full ASan/UBSan suite (`scripts/test.sh`): same failure profile as unpatched `main` (only the pre-existing RSS-ceiling test differs); the previously failing `incr_accuracy_vs_full` now passes.
- `CALLS` edges carry accurate line numbers on both resolution paths; non-`CALLS` edge props are unchanged.

## Changes

- `src/pipeline/pass_parallel.c`: `finalize_and_emit` appends `,"line":N` for `CALLS`.
- `src/pipeline/pass_calls.c`: `calls_emit_edge` helper splices `,"line":N` for `CALLS` and routes the call-edge sites through it.
