### PR TITLE
fix: include git2/sys/alloc.h for git_allocator on libgit2 1.8+

### DIFF
--- a/internal/cbm/cbm.c
+++ b/internal/cbm/cbm.c
@@ -20,7 +20,9 @@
 #if defined(CBM_BIND_TS_ALLOCATOR) && CBM_BIND_TS_ALLOCATOR
 #include "sqlite3.h" // sqlite3_mem_methods, sqlite3_config, SQLITE_CONFIG_MALLOC — bind sqlite to mimalloc
 #if defined(HAVE_LIBGIT2)
-#include <git2.h> // git_allocator, git_libgit2_opts, GIT_OPT_SET_ALLOCATOR — bind libgit2 to mimalloc
+#include <git2.h> // git_libgit2_opts, GIT_OPT_SET_ALLOCATOR — bind libgit2 to mimalloc
+/* git_allocator moved to sys/alloc.h in libgit2 1.8+; no longer in git2.h */
+#include <git2/sys/alloc.h>
 #endif
 #endif
 #include <stdint.h> // uint32_t, uint64_t, int64_t


### PR DESCRIPTION
## Problem

`git_allocator` was moved from the top-level `git2.h` into `git2/sys/alloc.h`
in libgit2 1.8.0. Building `codebase-memory-mcp` against libgit2 ≥ 1.8 fails:

```
internal/cbm/cbm.c:347:12: error: unknown type name 'git_allocator'
```

## Fix

Add an explicit `#include <git2/sys/alloc.h>` immediately after
`#include <git2.h>` inside the `HAVE_LIBGIT2` guard in
`internal/cbm/cbm.c`. The struct members (`gmalloc`, `grealloc`, `gfree`)
and the `GIT_OPT_SET_ALLOCATOR` option code are unchanged — the only
issue was the missing header.

## Tested against

- libgit2 1.9.4 (MacPorts, macOS / Apple Silicon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)