### PR TITLE
fix(foundation): properly escape JSON control characters as \u00XX

### DIFF
--- a/src/foundation/str_util.c
+++ b/src/foundation/str_util.c
@@ -6,6 +6,7 @@
 #include "foundation/constants.h"
 #include <string.h>
 #include <ctype.h>
+#include <stdio.h>
 
 enum {
     JSON_ESC_LEN = 2,       /* escaped char takes 2 bytes (backslash + char) */
@@ -328,8 +329,11 @@ int cbm_json_escape(char *buf, int bufsize, const char *src) {
             buf[pos++] = '\\';
             buf[pos++] = 't';
         } else if (c < JSON_CTRL_LIMIT) {
-            /* Other control chars: skip */
-            continue;
+            /* Other control chars: escape as \u00XX */
+            if (pos + 6 > bufsize - JSON_NUL_RESERVE) {
+                break;
+            }
+            pos += snprintf(buf + pos, 7, "\\u%04x", c);
         } else {
             buf[pos++] = (char)c;
         }

--- a/src/git/git_context.c
+++ b/src/git/git_context.c
@@ -316,7 +316,7 @@ static int json_escaped_len(const char *src) {
         if (c == '"' || c == '\\' || c == '\n' || c == '\r' || c == '\t') {
             len += 2;
         } else if (c < 0x20) {
-            continue;
+            len += 6; /* \u00XX */
         } else {
             len++;
         }

--- a/tests/test_str_util.c
+++ b/tests/test_str_util.c
@@ -424,6 +424,18 @@ TEST(validate_shell_arg_spaces) {
     PASS();
 }
 
+/* ── JSON Escaping tests ──────────────────────────────────────── */
+
+TEST(json_escape_control_chars) {
+    char buf[64];
+    const char *input = "A\x01"
+                        "B\n";
+    int len = cbm_json_escape(buf, sizeof(buf), input);
+    ASSERT_STR_EQ(buf, "A\\u0001B\\n");
+    ASSERT_EQ(len, 10);
+    PASS();
+}
+
 /* ── SNPRINTF_APPEND tests ────────────────────────────────────── */
 
 TEST(snprintf_append_basic) {
@@ -533,6 +545,8 @@ SUITE(str_util) {
     RUN_TEST(validate_shell_arg_backslash);
     RUN_TEST(validate_shell_arg_empty);
     RUN_TEST(validate_shell_arg_spaces);
+    /* JSON Escaping */
+    RUN_TEST(json_escape_control_chars);
     /* SNPRINTF_APPEND */
     RUN_TEST(snprintf_append_basic);
     RUN_TEST(snprintf_append_fills_exactly);


### PR DESCRIPTION
### Describe the bug
In `src/foundation/str_util.c`, the `cbm_json_escape` function was handling control characters `< 0x20` by completely skipping them instead of properly escaping them as `\u00XX`. The `json_escaped_len` function mirrored this logic. While this avoided buffer overflows, it silently stripped control characters, resulting in an invalid JSON representation of the actual data.

### Impact
Silently stripping control characters from strings mutates the data. If a file path, git branch, or code snippet contained unusual control characters, they were silently erased from the MCP JSON response rather than safely serialized.

### Fix
- Updated `cbm_json_escape` to safely format control characters as `\u00XX` using `snprintf(buf + pos, 7, "\\u%04x", c)`.
- Added `#include <stdio.h>` to `str_util.c` for `snprintf`.
- Updated `json_escaped_len` to correctly reserve 6 bytes (`len += 6`) for unhandled control characters, aligning the buffer sizing with the formatting string.

Local tests and strict compilation (`-Wall -Werror`) pass successfully.