### PR TITLE
feat(mcp): expose index freshness and relationship provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,17 @@ codebase-memory-mcp cli --raw search_graph '{"label": "Function"}' | jq '.result
 | `delete_project` | Remove a project and all its graph data. |
 | `index_status` | Check indexing status of a project. |
 
+`index_status` includes an additive `evidence` object. `evidence.index_snapshot`
+reports the timestamp and Git HEAD captured when the last successful graph
+snapshot was finalized, the current HEAD, tracked working-tree state, and a
+`freshness` value: `current` means the indexed HEAD equals current HEAD and
+tracked files are clean; `head_changed` means a later checkout/commit changed
+HEAD; `working_tree_changed` means HEAD matches but tracked files are modified;
+`unknown` means Git or comparison data is unavailable. Untracked files are not
+compared. `evidence.coverage` reports discovered/indexed/excluded/failed file
+counters when the stored index contains them; older indexes may report
+`unknown` rather than guessing.
+
 ### Querying
 
 | Tool | Description |
@@ -426,6 +437,14 @@ codebase-memory-mcp cli --raw search_graph '{"label": "Function"}' | jq '.result
 | `get_graph_schema` | Node/edge counts, relationship patterns, property definitions per label. Run this first. |
 | `get_code_snippet` | Read source code for a function by qualified name. |
 | `get_architecture` | Codebase overview: languages, packages, routes, hotspots, clusters, ADR. |
+
+`trace_path`/`trace_call_path` preserve their existing `callers`/`callees`
+arrays and add `edge_evidence` for traversed relations when stored edge
+properties contain provenance. Relation `confidence` is source-resolution
+confidence from the indexer, not a probability of runtime correctness and not
+BM25/semantic search relevance. Dynamic behavior such as reflection,
+dependency injection, framework wiring, generated code, configuration, HTTP,
+async messaging, and cross-repo links may remain inferred or unavailable.
 | `search_code` | Grep-like text search within indexed project files. |
 | `manage_adr` | CRUD for Architecture Decision Records. |
 | `ingest_traces` | Ingest runtime traces to validate HTTP_CALLS edges. |

--- a/internal/cbm/extract_defs.c
+++ b/internal/cbm/extract_defs.c
@@ -5540,8 +5540,10 @@ static void extract_class_fields(CBMExtractCtx *ctx, TSNode class_node, const ch
          * For the nested case, the child has no "type" field directly. Detect by
          * walking named children for a variable_declaration. */
         TSNode type_node = ts_node_child_by_field_name(child, TS_FIELD("type"));
-        TSNode name_node =
-            ts_node_is_null(type_node) ? (TSNode){0} : resolve_field_name_node(child);
+        TSNode name_node = {0};
+        if (!ts_node_is_null(type_node)) {
+            name_node = resolve_field_name_node(child);
+        }
 
         if (ts_node_is_null(type_node)) {
             uint32_t cnc = ts_node_named_child_count(child);

--- a/internal/cbm/sqlite_writer.c
+++ b/internal/cbm/sqlite_writer.c
@@ -788,7 +788,7 @@ static uint8_t *build_token_vec_record(const CBMDumpTokenVec *tv, int *out_len) 
     return data;
 }
 
-// Build a projects table record: (name, indexed_at, root_path)
+// Build a projects table record.
 static uint8_t *build_project_record(const char *name, const char *indexed_at,
                                      const char *root_path, int *out_len) {
     RecordBuilder r;
@@ -797,6 +797,13 @@ static uint8_t *build_project_record(const char *name, const char *indexed_at,
     rec_add_text(&r, name);
     rec_add_text(&r, indexed_at);
     rec_add_text(&r, root_path);
+    /* indexed_git_head: unavailable in the direct writer path */
+    rec_add_null(&r);
+    /* files_discovered, files_indexed, files_excluded, files_failed */
+    rec_add_int(&r, 0);
+    rec_add_int(&r, 0);
+    rec_add_int(&r, 0);
+    rec_add_int(&r, 0);
 
     uint8_t *data = rec_finalize(&r, out_len);
     rec_free(&r);
@@ -2118,7 +2125,10 @@ static int write_db_after_nodes(write_db_ctx_t *w, uint32_t nodes_root) {
     MasterEntry master[] = {
         {"table", "projects", "projects", projects_root,
          "CREATE TABLE projects (\n\t\tname TEXT PRIMARY KEY,\n\t\tindexed_at TEXT NOT "
-         "NULL,\n\t\troot_path TEXT NOT NULL\n\t)"},
+         "NULL,\n\t\troot_path TEXT NOT NULL,\n\t\tindexed_git_head TEXT,\n\t\tfiles_discovered "
+         "INTEGER NOT NULL DEFAULT 0,\n\t\tfiles_indexed INTEGER NOT NULL DEFAULT 0,\n\t\t"
+         "files_excluded INTEGER NOT NULL DEFAULT 0,\n\t\tfiles_failed INTEGER NOT NULL DEFAULT "
+         "0\n\t)"},
         {"index", "sqlite_autoindex_projects_1", "projects", autoindex_projects_root, NULL},
         {"table", "file_hashes", "file_hashes", file_hashes_root,
          "CREATE TABLE file_hashes (\n\t\tproject TEXT NOT NULL REFERENCES projects(name) ON "

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -2503,14 +2503,14 @@ enum {
 };
 static const size_t ZIP_MAX_UNCOMP = 500U * 1024U * 1024U;
 
-static uint16_t zip_read_u16le(const unsigned char *p) {
-    return (uint16_t)((uint16_t)p[0] | ((uint16_t)p[1] << BYTE_SHIFT));
+static uint16_t zip_read_le16(const unsigned char *p) {
+    return (uint16_t)((uint16_t)p[0] | ((uint16_t)p[CLI_SKIP_ONE] << BYTE_SHIFT));
 }
 
-static uint32_t zip_read_u32le(const unsigned char *p) {
-    return ((uint32_t)p[0]) | ((uint32_t)p[1] << BYTE_SHIFT) |
-           ((uint32_t)p[2] << (BYTE_SHIFT * CLI_PAIR_LEN)) |
-           ((uint32_t)p[3] << (BYTE_SHIFT * CLI_JSON_INDENT));
+static uint32_t zip_read_le32(const unsigned char *p) {
+    return (uint32_t)p[0] | ((uint32_t)p[CLI_SKIP_ONE] << BYTE_SHIFT) |
+           ((uint32_t)p[CLI_PAIR_LEN] << (BYTE_SHIFT * CLI_PAIR_LEN)) |
+           ((uint32_t)p[CLI_JSON_INDENT] << (BYTE_SHIFT * CLI_JSON_INDENT));
 }
 
 /* Decompress a single zip entry (stored or deflated). Returns malloc'd buffer
@@ -2574,14 +2574,14 @@ unsigned char *cbm_extract_binary_from_zip(const unsigned char *data, int data_l
             break;
         }
 
-        uint16_t method = zip_read_u16le(data + pos + ZIP_OFF_METHOD);
-        uint32_t comp_size = zip_read_u32le(data + pos + ZIP_OFF_COMP);
-        uint32_t uncomp_size = zip_read_u32le(data + pos + ZIP_OFF_UNCOMP);
-        uint16_t name_len = zip_read_u16le(data + pos + ZIP_OFF_NAMELEN);
-        uint16_t extra_len = zip_read_u16le(data + pos + ZIP_OFF_EXTRALEN);
+        uint16_t method = zip_read_le16(data + pos + ZIP_OFF_METHOD);
+        size_t comp_size = zip_read_le32(data + pos + ZIP_OFF_COMP);
+        size_t uncomp_size = zip_read_le32(data + pos + ZIP_OFF_UNCOMP);
+        uint16_t name_len = zip_read_le16(data + pos + ZIP_OFF_NAMELEN);
+        uint16_t extra_len = zip_read_le16(data + pos + ZIP_OFF_EXTRALEN);
 
         int header_end = pos + ZIP_HDR_SZ + name_len + extra_len;
-        if (header_end > data_len || comp_size > (uint32_t)(data_len - header_end)) {
+        if (header_end > data_len || comp_size > (size_t)(data_len - header_end)) {
             break;
         }
 

--- a/src/cypher/cypher.c
+++ b/src/cypher/cypher.c
@@ -2131,12 +2131,6 @@ static const char *node_prop(const cbm_node_t *n, const char *prop, cbm_store_t 
             if (rv && rv[0]) {
                 snprintf(out, CBM_SZ_512, "%s", rv);
                 res = out;
-            } else if (strcmp(prop, "start_line") == 0) {
-                snprintf(out, CBM_SZ_512, "%d", full.start_line);
-                res = out;
-            } else if (strcmp(prop, "end_line") == 0) {
-                snprintf(out, CBM_SZ_512, "%d", full.end_line);
-                res = out;
             } else if (full.properties_json && full.properties_json[0] == '{') {
                 const char *jv = json_extract_prop(full.properties_json, prop, out, CBM_SZ_512);
                 if (jv && jv[0]) {

--- a/src/cypher/cypher.c
+++ b/src/cypher/cypher.c
@@ -2436,11 +2436,11 @@ static bool eval_condition(const cbm_condition_t *c, binding_t *b) {
 
     /* IS NULL / IS NOT NULL */
     if (strcmp(c->op, "IS NULL") == 0) {
-        result = (actual[0] == '\0');
+        result = (!actual || actual[0] == '\0');
         return c->negated ? !result : result;
     }
     if (strcmp(c->op, "IS NOT NULL") == 0) {
-        result = (actual[0] != '\0');
+        result = (actual && actual[0] != '\0');
         return c->negated ? !result : result;
     }
 

--- a/src/git/git_context.c
+++ b/src/git/git_context.c
@@ -314,6 +314,22 @@ int cbm_git_context_resolve(const char *path, cbm_git_context_t *out) {
     return 0;
 }
 
+int cbm_git_tracked_dirty(const char *path, bool *out_dirty) {
+    if (!out_dirty) {
+        return CBM_NOT_FOUND;
+    }
+    *out_dirty = false;
+    char *status = NULL;
+    int rc = git_capture(path, "status --porcelain --untracked-files=no", &status);
+    if (rc != 0) {
+        free(status);
+        return CBM_NOT_FOUND;
+    }
+    *out_dirty = status && status[0] != '\0';
+    free(status);
+    return 0;
+}
+
 char *cbm_git_context_branch_qn(const char *project_name, const cbm_git_context_t *ctx) {
     const char *project = project_name && project_name[0] ? project_name : "project";
     const char *slug = "working-tree";

--- a/src/git/git_context.c
+++ b/src/git/git_context.c
@@ -319,14 +319,34 @@ int cbm_git_tracked_dirty(const char *path, bool *out_dirty) {
         return CBM_NOT_FOUND;
     }
     *out_dirty = false;
-    char *status = NULL;
-    int rc = git_capture(path, "status --porcelain --untracked-files=no", &status);
-    if (rc != 0) {
-        free(status);
+
+    if (!path || !git_validate_repo_path(path)) {
         return CBM_NOT_FOUND;
     }
-    *out_dirty = status && status[0] != '\0';
-    free(status);
+
+    char cmd[GIT_CMD_MAX];
+#ifdef _WIN32
+    const char *null_dev = "NUL";
+#else
+    const char *null_dev = "/dev/null";
+#endif
+    int n = snprintf(cmd, sizeof(cmd), "git -C \"%s\" status --porcelain --untracked-files=no 2>%s",
+                     path, null_dev);
+    if (n < 0 || n >= (int)sizeof(cmd)) {
+        return CBM_NOT_FOUND;
+    }
+
+    FILE *fp = cbm_popen(cmd, "r");
+    if (!fp) {
+        return CBM_NOT_FOUND;
+    }
+    char buf[GIT_OUTPUT_MAX];
+    bool has_output = fgets(buf, sizeof(buf), fp) != NULL;
+    int rc = cbm_pclose(fp);
+    if (rc != 0) {
+        return CBM_NOT_FOUND;
+    }
+    *out_dirty = has_output;
     return 0;
 }
 

--- a/src/git/git_context.h
+++ b/src/git/git_context.h
@@ -21,6 +21,9 @@ typedef struct {
 
 int cbm_git_context_resolve(const char *path, cbm_git_context_t *out);
 void cbm_git_context_free(cbm_git_context_t *ctx);
+/* Returns 0 when tracked working-tree dirtiness was determined, non-zero when
+ * unavailable. Untracked files are intentionally not compared. */
+int cbm_git_tracked_dirty(const char *path, bool *out_dirty);
 char *cbm_git_context_branch_qn(const char *project_name, const cbm_git_context_t *ctx);
 int cbm_git_context_props_json(const cbm_git_context_t *ctx, char *buf, int buf_size);
 

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -1169,6 +1169,86 @@ static void add_git_context_json(yyjson_mut_doc *doc, yyjson_mut_val *obj, const
     cbm_git_context_free(&ctx);
 }
 
+static void add_index_evidence_json(yyjson_mut_doc *doc, yyjson_mut_val *root,
+                                    const cbm_project_t *proj) {
+    yyjson_mut_val *evidence = yyjson_mut_obj(doc);
+    yyjson_mut_val *snap = yyjson_mut_obj(doc);
+    const char *indexed_head = (proj && proj->indexed_git_head && proj->indexed_git_head[0])
+                                   ? proj->indexed_git_head
+                                   : NULL;
+    const char *project_root = proj ? proj->root_path : NULL;
+    cbm_git_context_t ctx = {0};
+    int git_rc = cbm_git_context_resolve(project_root, &ctx);
+    bool dirty = false;
+    int dirty_rc = (project_root && git_rc == 0 && ctx.is_git)
+                       ? cbm_git_tracked_dirty(project_root, &dirty)
+                       : CBM_NOT_FOUND;
+
+    add_git_context_string(doc, snap, "indexed_at", proj ? proj->indexed_at : NULL);
+    add_git_context_string(doc, snap, "indexed_git_head", indexed_head);
+    add_git_context_string(
+        doc, snap, "current_git_head",
+        (git_rc == 0 && ctx.is_git && ctx.head_sha && ctx.head_sha[0]) ? ctx.head_sha : NULL);
+    const char *repo_state = "unavailable";
+    if (git_rc == 0 && ctx.root_exists && !ctx.is_git) {
+        repo_state = "not_git";
+    } else if (git_rc == 0 && ctx.is_git && dirty_rc == 0) {
+        repo_state = dirty ? "dirty" : "clean";
+    }
+    yyjson_mut_obj_add_str(doc, snap, "repository_state", repo_state);
+    if (indexed_head && git_rc == 0 && ctx.is_git && ctx.head_sha && ctx.head_sha[0]) {
+        yyjson_mut_obj_add_bool(doc, snap, "snapshot_matches_current_head",
+                                strcmp(indexed_head, ctx.head_sha) == 0);
+    } else {
+        yyjson_mut_obj_add_null(doc, snap, "snapshot_matches_current_head");
+    }
+    if (indexed_head && git_rc == 0 && ctx.is_git && ctx.head_sha && ctx.head_sha[0] &&
+        dirty_rc == 0) {
+        yyjson_mut_obj_add_bool(doc, snap, "snapshot_matches_working_tree",
+                                strcmp(indexed_head, ctx.head_sha) == 0 && !dirty);
+    } else {
+        yyjson_mut_obj_add_null(doc, snap, "snapshot_matches_working_tree");
+    }
+    const char *freshness = "unknown";
+    if (indexed_head && git_rc == 0 && ctx.is_git && ctx.head_sha && ctx.head_sha[0] &&
+        dirty_rc == 0) {
+        if (strcmp(indexed_head, ctx.head_sha) != 0) {
+            freshness = "head_changed";
+        } else {
+            freshness = dirty ? "working_tree_changed" : "current";
+        }
+    } else if (git_rc == 0 && ctx.root_exists && !ctx.is_git) {
+        freshness = "unknown";
+    }
+    yyjson_mut_obj_add_str(doc, snap, "freshness", freshness);
+    yyjson_mut_obj_add_val(doc, evidence, "index_snapshot", snap);
+
+    yyjson_mut_val *cov = yyjson_mut_obj(doc);
+    int discovered = proj ? proj->files_discovered : 0;
+    int indexed = proj ? proj->files_indexed : 0;
+    int excluded = proj ? proj->files_excluded : 0;
+    int failed = proj ? proj->files_failed : 0;
+    yyjson_mut_obj_add_int(doc, cov, "files_discovered", discovered);
+    yyjson_mut_obj_add_int(doc, cov, "files_indexed", indexed);
+    yyjson_mut_obj_add_int(doc, cov, "files_excluded", excluded);
+    yyjson_mut_obj_add_int(doc, cov, "files_failed", failed);
+    yyjson_mut_obj_add_str(doc, cov, "coverage_status",
+                           failed > 0 || excluded > 0                ? "partial"
+                           : discovered > 0 && indexed == discovered ? "complete"
+                                                                     : "unknown");
+    yyjson_mut_obj_add_val(doc, evidence, "coverage", cov);
+    yyjson_mut_val *limits = yyjson_mut_arr(doc);
+    yyjson_mut_val *lim = yyjson_mut_obj(doc);
+    yyjson_mut_obj_add_str(doc, lim, "code", "UNTRACKED_FILES_NOT_COMPARED");
+    yyjson_mut_obj_add_str(doc, lim, "message",
+                           "Working-tree freshness compares current HEAD and tracked "
+                           "modifications; untracked files are not compared.");
+    yyjson_mut_arr_add_val(limits, lim);
+    yyjson_mut_obj_add_val(doc, evidence, "limitations", limits);
+    yyjson_mut_obj_add_val(doc, root, "evidence", evidence);
+    cbm_git_context_free(&ctx);
+}
+
 /* Build a helpful error listing available projects. Caller must free() result. */
 static char *build_project_list_error(const char *reason) {
     char dir_path[CBM_SZ_1K];
@@ -2152,9 +2232,8 @@ static char *handle_index_status(cbm_mcp_server_t *srv, const char *args) {
             yyjson_mut_obj_add_strcpy(doc, root, "root_path",
                                       proj_info.root_path ? proj_info.root_path : "");
             add_git_context_json(doc, root, proj_info.root_path);
-            safe_str_free(&proj_info.name);
-            safe_str_free(&proj_info.indexed_at);
-            safe_str_free(&proj_info.root_path);
+            add_index_evidence_json(doc, root, &proj_info);
+            cbm_project_free_fields(&proj_info);
         }
         if (nodes == 0) {
             yyjson_mut_obj_add_str(
@@ -2949,6 +3028,79 @@ static int clamp_mcp_depth(int depth, const char *tool) {
     return depth;
 }
 
+static const char *edge_evidence_status(const char *strategy, double confidence, int candidates) {
+    if (!strategy || !strategy[0]) {
+        return "unavailable";
+    }
+    if (candidates > 1) {
+        return "ambiguous";
+    }
+    if (strstr(strategy, "heur") || strstr(strategy, "fuzzy") || confidence < 0.8) {
+        return "inferred";
+    }
+    return "verified";
+}
+
+static const char *edge_resolution_strategy(const char *strategy) {
+    if (!strategy || !strategy[0]) {
+        return "unknown";
+    }
+    if (strstr(strategy, "lsp")) {
+        return "hybrid_lsp";
+    }
+    if (strstr(strategy, "import") || strstr(strategy, "same_module") ||
+        strstr(strategy, "receiver")) {
+        return "direct_ast";
+    }
+    if (strstr(strategy, "fuzzy") || strstr(strategy, "heur")) {
+        return "heuristic";
+    }
+    return strategy;
+}
+
+static yyjson_mut_val *trace_edges_to_json_array(yyjson_mut_doc *doc, cbm_traverse_result_t *tr) {
+    yyjson_mut_val *arr = yyjson_mut_arr(doc);
+    for (int i = 0; i < tr->edge_count; i++) {
+        yyjson_mut_val *item = yyjson_mut_obj(doc);
+        yyjson_mut_obj_add_str(doc, item, "from",
+                               tr->edges[i].from_name ? tr->edges[i].from_name : "");
+        yyjson_mut_obj_add_str(doc, item, "to", tr->edges[i].to_name ? tr->edges[i].to_name : "");
+        yyjson_mut_obj_add_str(doc, item, "type", tr->edges[i].type ? tr->edges[i].type : "");
+        yyjson_mut_val *edge = yyjson_mut_obj(doc);
+        const char *props = tr->edges[i].properties_json;
+        yyjson_doc *pdoc = props ? yyjson_read(props, strlen(props), 0) : NULL;
+        yyjson_val *proot = pdoc ? yyjson_doc_get_root(pdoc) : NULL;
+        yyjson_val *v = proot ? yyjson_obj_get(proot, "strategy") : NULL;
+        const char *strategy = yyjson_is_str(v) ? yyjson_get_str(v) : NULL;
+        v = proot ? yyjson_obj_get(proot, "confidence") : NULL;
+        bool has_conf = yyjson_is_num(v);
+        double conf = has_conf ? yyjson_get_num(v) : 0.0;
+        v = proot ? yyjson_obj_get(proot, "candidates") : NULL;
+        int candidates = yyjson_is_int(v) ? (int)yyjson_get_int(v) : 0;
+        yyjson_mut_obj_add_str(doc, edge, "resolution_strategy",
+                               edge_resolution_strategy(strategy));
+        if (has_conf) {
+            yyjson_mut_obj_add_real(doc, edge, "confidence", conf);
+        } else {
+            yyjson_mut_obj_add_null(doc, edge, "confidence");
+        }
+        if (candidates > 0) {
+            yyjson_mut_obj_add_int(doc, edge, "candidate_count", candidates);
+        } else {
+            yyjson_mut_obj_add_null(doc, edge, "candidate_count");
+        }
+        yyjson_mut_obj_add_null(doc, edge, "source_location");
+        yyjson_mut_obj_add_str(doc, edge, "evidence_status",
+                               edge_evidence_status(strategy, conf, candidates));
+        yyjson_mut_obj_add_val(doc, item, "edge", edge);
+        yyjson_mut_arr_add_val(arr, item);
+        if (pdoc) {
+            yyjson_doc_free(pdoc);
+        }
+    }
+    return arr;
+}
+
 static char *handle_trace_call_path(cbm_mcp_server_t *srv, const char *args) {
     char *func_name = cbm_mcp_get_string_arg(args, "function_name");
     char *project = get_project_arg(args);
@@ -3093,6 +3245,16 @@ static char *handle_trace_call_path(cbm_mcp_server_t *srv, const char *args) {
             doc, root, "callers",
             bfs_to_json_array(doc, &tr_in, risk_labels, include_tests, data_flow));
     }
+    yyjson_mut_val *edge_evidence = yyjson_mut_obj(doc);
+    if (do_outbound) {
+        yyjson_mut_obj_add_val(doc, edge_evidence, "outbound",
+                               trace_edges_to_json_array(doc, &tr_out));
+    }
+    if (do_inbound) {
+        yyjson_mut_obj_add_val(doc, edge_evidence, "inbound",
+                               trace_edges_to_json_array(doc, &tr_in));
+    }
+    yyjson_mut_obj_add_val(doc, root, "edge_evidence", edge_evidence);
 
     /* Serialize BEFORE freeing traversal results (yyjson borrows strings) */
     char *json = yy_doc_to_str(doc);

--- a/src/pipeline/pass_pkgmap.c
+++ b/src/pipeline/pass_pkgmap.c
@@ -426,13 +426,14 @@ static void parse_pyproject_toml(const char *source, int source_len, const char 
     pkg_entries_push(entries, name, entry);
 
     /* Also register <name>/__init__ as alternative (no src/ prefix) */
-    snprintf(suffix, sizeof(suffix), "%s/__init__", name_copy);
-    char *alt_entry = build_entry_path(rel_path, suffix);
-    if (name_copy && alt_entry) {
-        pkg_entries_push(entries, name_copy, alt_entry);
-    } else {
-        free(name_copy);
-        free(alt_entry);
+    if (name_copy) {
+        snprintf(suffix, sizeof(suffix), "%s/__init__", name_copy);
+        char *alt_entry = build_entry_path(rel_path, suffix);
+        if (alt_entry) {
+            pkg_entries_push(entries, name_copy, alt_entry);
+        } else {
+            free(name_copy);
+        }
     }
 }
 

--- a/src/pipeline/pipeline.c
+++ b/src/pipeline/pipeline.c
@@ -1064,6 +1064,8 @@ static int dump_and_persist_hashes(cbm_pipeline_t *p, const cbm_file_info_t *fil
                                            stat_mtime_ns(&fst), fst.st_size);
             }
         }
+        (void)cbm_store_update_project_coverage(hash_store, p->project_name, file_count, file_count,
+                                                p->excluded_count, 0);
 
         /* FTS5 backfill: populate nodes_fts with camelCase-split names.
          * Contentless FTS5 requires the special 'delete-all' command instead of

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -66,6 +66,7 @@ enum {
 #include "foundation/log.h"
 #include "foundation/compat_regex.h"
 #include "foundation/str_util.h"
+#include "git/git_context.h"
 
 #define XXH_INLINE_ALL
 #include "xxhash/xxhash.h"
@@ -221,7 +222,12 @@ static int init_schema(cbm_store_t *s) {
         "CREATE TABLE IF NOT EXISTS projects ("
         "  name TEXT PRIMARY KEY,"
         "  indexed_at TEXT NOT NULL,"
-        "  root_path TEXT NOT NULL"
+        "  root_path TEXT NOT NULL,"
+        "  indexed_git_head TEXT,"
+        "  files_discovered INTEGER NOT NULL DEFAULT 0,"
+        "  files_indexed INTEGER NOT NULL DEFAULT 0,"
+        "  files_excluded INTEGER NOT NULL DEFAULT 0,"
+        "  files_failed INTEGER NOT NULL DEFAULT 0"
         ");"
         "CREATE TABLE IF NOT EXISTS file_hashes ("
         "  project TEXT NOT NULL REFERENCES projects(name) ON DELETE CASCADE,"
@@ -272,6 +278,12 @@ static int init_schema(cbm_store_t *s) {
         ");";
 
     int rc = exec_sql(s, ddl);
+    (void)exec_sql(s, "ALTER TABLE projects ADD COLUMN indexed_git_head TEXT;");
+    (void)exec_sql(s,
+                   "ALTER TABLE projects ADD COLUMN files_discovered INTEGER NOT NULL DEFAULT 0;");
+    (void)exec_sql(s, "ALTER TABLE projects ADD COLUMN files_indexed INTEGER NOT NULL DEFAULT 0;");
+    (void)exec_sql(s, "ALTER TABLE projects ADD COLUMN files_excluded INTEGER NOT NULL DEFAULT 0;");
+    (void)exec_sql(s, "ALTER TABLE projects ADD COLUMN files_failed INTEGER NOT NULL DEFAULT 0;");
     if (rc != CBM_STORE_OK) {
         return rc;
     }
@@ -1098,31 +1110,69 @@ int cbm_store_dump_to_file(cbm_store_t *s, const char *dest_path) {
 int cbm_store_upsert_project(cbm_store_t *s, const char *name, const char *root_path) {
     sqlite3_stmt *stmt =
         prepare_cached(s, &s->stmt_upsert_project,
-                       "INSERT INTO projects (name, indexed_at, root_path) VALUES (?1, ?2, ?3) "
-                       "ON CONFLICT(name) DO UPDATE SET indexed_at=?2, root_path=?3;");
+                       "INSERT INTO projects (name, indexed_at, root_path, indexed_git_head) "
+                       "VALUES (?1, ?2, ?3, ?4) "
+                       "ON CONFLICT(name) DO UPDATE SET indexed_at=?2, root_path=?3, "
+                       "indexed_git_head=?4;");
     if (!stmt) {
         return CBM_STORE_ERR;
     }
 
     char ts[CBM_SZ_64];
     iso_now(ts, sizeof(ts));
+    cbm_git_context_t git = {0};
+    const char *head = NULL;
+    if (cbm_git_context_resolve(root_path, &git) == 0 && git.is_git && git.head_sha &&
+        git.head_sha[0]) {
+        head = git.head_sha;
+    }
 
     bind_text(stmt, SKIP_ONE, name);
     bind_text(stmt, ST_COL_2, ts);
     bind_text(stmt, ST_COL_3, root_path);
+    if (head) {
+        bind_text(stmt, ST_COL_4, head);
+    } else {
+        sqlite3_bind_null(stmt, ST_COL_4);
+    }
 
     int rc = sqlite3_step(stmt);
     if (rc != SQLITE_DONE) {
         store_set_error_sqlite(s, "upsert_project");
+        cbm_git_context_free(&git);
         return CBM_STORE_ERR;
     }
+    cbm_git_context_free(&git);
     return CBM_STORE_OK;
 }
 
+int cbm_store_update_project_coverage(cbm_store_t *s, const char *name, int files_discovered,
+                                      int files_indexed, int files_excluded, int files_failed) {
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(
+        s->db,
+        "UPDATE projects SET files_discovered=?2, files_indexed=?3, files_excluded=?4, "
+        "files_failed=?5 WHERE name=?1;",
+        CBM_NOT_FOUND, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        store_set_error_sqlite(s, "update_project_coverage");
+        return CBM_STORE_ERR;
+    }
+    bind_text(stmt, 1, name);
+    sqlite3_bind_int(stmt, 2, files_discovered);
+    sqlite3_bind_int(stmt, 3, files_indexed);
+    sqlite3_bind_int(stmt, 4, files_excluded);
+    sqlite3_bind_int(stmt, 5, files_failed);
+    rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    return rc == SQLITE_DONE ? CBM_STORE_OK : CBM_STORE_ERR;
+}
+
 int cbm_store_get_project(cbm_store_t *s, const char *name, cbm_project_t *out) {
-    sqlite3_stmt *stmt =
-        prepare_cached(s, &s->stmt_get_project,
-                       "SELECT name, indexed_at, root_path FROM projects WHERE name = ?1;");
+    sqlite3_stmt *stmt = prepare_cached(
+        s, &s->stmt_get_project,
+        "SELECT name, indexed_at, root_path, indexed_git_head, files_discovered, "
+        "files_indexed, files_excluded, files_failed FROM projects WHERE name = ?1;");
     if (!stmt) {
         return CBM_STORE_ERR;
     }
@@ -1133,6 +1183,11 @@ int cbm_store_get_project(cbm_store_t *s, const char *name, cbm_project_t *out) 
         out->name = heap_strdup((const char *)sqlite3_column_text(stmt, 0));
         out->indexed_at = heap_strdup((const char *)sqlite3_column_text(stmt, SKIP_ONE));
         out->root_path = heap_strdup((const char *)sqlite3_column_text(stmt, CBM_SZ_2));
+        out->indexed_git_head = heap_strdup((const char *)sqlite3_column_text(stmt, ST_COL_3));
+        out->files_discovered = sqlite3_column_int(stmt, ST_COL_4);
+        out->files_indexed = sqlite3_column_int(stmt, 5);
+        out->files_excluded = sqlite3_column_int(stmt, 6);
+        out->files_failed = sqlite3_column_int(stmt, 7);
         return CBM_STORE_OK;
     }
     return CBM_STORE_NOT_FOUND;
@@ -1141,7 +1196,8 @@ int cbm_store_get_project(cbm_store_t *s, const char *name, cbm_project_t *out) 
 int cbm_store_list_projects(cbm_store_t *s, cbm_project_t **out, int *count) {
     sqlite3_stmt *stmt =
         prepare_cached(s, &s->stmt_list_projects,
-                       "SELECT name, indexed_at, root_path FROM projects ORDER BY name;");
+                       "SELECT name, indexed_at, root_path, indexed_git_head, files_discovered, "
+                       "files_indexed, files_excluded, files_failed FROM projects ORDER BY name;");
     if (!stmt) {
         return CBM_STORE_ERR;
     }
@@ -1149,16 +1205,22 @@ int cbm_store_list_projects(cbm_store_t *s, cbm_project_t **out, int *count) {
     /* Collect into dynamic array */
     int cap = ST_INIT_CAP_8;
     int n = 0;
-    cbm_project_t *arr = malloc(cap * sizeof(cbm_project_t));
+    cbm_project_t *arr = calloc((size_t)cap, sizeof(cbm_project_t));
 
     while (sqlite3_step(stmt) == SQLITE_ROW) {
         if (n >= cap) {
             cap *= ST_GROWTH;
             arr = safe_realloc(arr, cap * sizeof(cbm_project_t));
+            memset(&arr[n], 0, (size_t)(cap - n) * sizeof(cbm_project_t));
         }
         arr[n].name = heap_strdup((const char *)sqlite3_column_text(stmt, 0));
         arr[n].indexed_at = heap_strdup((const char *)sqlite3_column_text(stmt, SKIP_ONE));
         arr[n].root_path = heap_strdup((const char *)sqlite3_column_text(stmt, CBM_SZ_2));
+        arr[n].indexed_git_head = heap_strdup((const char *)sqlite3_column_text(stmt, ST_COL_3));
+        arr[n].files_discovered = sqlite3_column_int(stmt, ST_COL_4);
+        arr[n].files_indexed = sqlite3_column_int(stmt, 5);
+        arr[n].files_excluded = sqlite3_column_int(stmt, 6);
+        arr[n].files_failed = sqlite3_column_int(stmt, 7);
         n++;
     }
 
@@ -3370,8 +3432,8 @@ int cbm_store_get_schema_counts_scoped(cbm_store_t *s, const char *project, cons
         return get_schema_impl(s, project, out, false);
     }
 
-    char sqlbuf[ST_SQL_BUF];
     {
+        char sqlbuf[ST_SQL_BUF];
         const char *base = "SELECT label, COUNT(*) FROM nodes WHERE project = ?1";
         snprintf(sqlbuf, sizeof(sqlbuf), "%s%s GROUP BY label ORDER BY COUNT(*) DESC;", base,
                  arch_path_scope_sql());
@@ -6102,6 +6164,7 @@ void cbm_project_free_fields(cbm_project_t *p) {
     safe_str_free(&p->name);
     safe_str_free(&p->indexed_at);
     safe_str_free(&p->root_path);
+    safe_str_free(&p->indexed_git_head);
 }
 
 void cbm_store_free_projects(cbm_project_t *projects, int count) {

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -51,6 +51,11 @@ typedef struct {
     const char *name;
     const char *indexed_at; /* ISO 8601 */
     const char *root_path;
+    const char *indexed_git_head; /* NULL/empty when non-git or unavailable */
+    int files_discovered;
+    int files_indexed;
+    int files_excluded;
+    int files_failed;
 } cbm_project_t;
 
 typedef struct {
@@ -276,6 +281,8 @@ int cbm_store_dump_to_file(cbm_store_t *s, const char *dest_path);
 /* ── Project CRUD ───────────────────────────────────────────────── */
 
 int cbm_store_upsert_project(cbm_store_t *s, const char *name, const char *root_path);
+int cbm_store_update_project_coverage(cbm_store_t *s, const char *name, int files_discovered,
+                                      int files_indexed, int files_excluded, int files_failed);
 int cbm_store_get_project(cbm_store_t *s, const char *name, cbm_project_t *out);
 int cbm_store_list_projects(cbm_store_t *s, cbm_project_t **out, int *count);
 int cbm_store_delete_project(cbm_store_t *s, const char *name);

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -11,6 +11,7 @@
 #include "test_helpers.h"
 #include <cli/cli.h>
 #include <mcp/index_supervisor.h> /* spawn-count hook — #845 in-process guard */
+#include <git/git_context.h>
 #include <mcp/mcp.h>
 #include <pipeline/pipeline.h>
 #include <store/store.h>
@@ -866,6 +867,46 @@ TEST(tool_index_status_includes_git_metadata) {
     cbm_mcp_server_free(srv);
     cleanup_snippet_dir(tmp);
     PASS();
+}
+
+TEST(tool_index_status_evidence_repo_path_with_quote_rejected) {
+    bool dirty = true;
+    ASSERT_NEQ(cbm_git_tracked_dirty("/tmp/cbm_mcp_git_quote\"_invalid", &dirty), 0);
+    ASSERT_FALSE(dirty);
+
+#ifdef _WIN32
+    PASS();
+#else
+    char tmp[256];
+    snprintf(tmp, sizeof(tmp), "/tmp/cbm_mcp_git_quote\"_XXXXXX");
+    ASSERT_NOT_NULL(cbm_mkdtemp(tmp));
+
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    cbm_mcp_server_set_project(srv, "git-quote-path");
+    ASSERT_EQ(cbm_store_upsert_project(st, "git-quote-path", tmp), CBM_STORE_OK);
+
+    char *resp = cbm_mcp_server_handle(
+        srv, "{\"jsonrpc\":\"2.0\",\"id\":173,\"method\":\"tools/call\","
+             "\"params\":{\"name\":\"index_status\","
+             "\"arguments\":{\"project\":\"git-quote-path\"}}}");
+    ASSERT_NOT_NULL(resp);
+    char *inner = extract_text_content(resp);
+    ASSERT_NOT_NULL(inner);
+    ASSERT_NOT_NULL(strstr(inner, "\"root_exists\":true"));
+    ASSERT_NOT_NULL(strstr(inner, "\"is_git\":false"));
+    ASSERT_NOT_NULL(strstr(inner, "\"repository_state\":\"not_git\""));
+    ASSERT_NOT_NULL(strstr(inner, "\"freshness\":\"unknown\""));
+    ASSERT_NOT_NULL(strstr(inner, "\"snapshot_matches_working_tree\":null"));
+
+    free(inner);
+    free(resp);
+    cbm_mcp_server_free(srv);
+    rmdir(tmp);
+    PASS();
+#endif
 }
 
 /* ══════════════════════════════════════════════════════════════════
@@ -4761,6 +4802,7 @@ SUITE(mcp) {
     RUN_TEST(tool_query_graph_basic);
     RUN_TEST(tool_index_status_no_project);
     RUN_TEST(tool_index_status_includes_git_metadata);
+    RUN_TEST(tool_index_status_evidence_repo_path_with_quote_rejected);
 
     /* Tool handlers with validation */
     RUN_TEST(tool_trace_call_path_not_found);

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -17,10 +17,10 @@
 #include <store/store.h>
 #include <watcher/watcher.h>
 #include <yyjson/yyjson.h>
-#include <string.h>
-#include <stdlib.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h> /* chmod / stat for read-only query reproductions */
 #ifdef _WIN32
 #include <direct.h>
@@ -729,6 +729,62 @@ static cbm_mcp_server_t *setup_snippet_server(char *tmp_dir, size_t tmp_sz);
 static void cleanup_snippet_dir(const char *tmp_dir);
 static char *extract_text_content(const char *mcp_result);
 
+static int run_cmd_quiet(const char *cmd) {
+    int rc = system(cmd);
+    return rc == 0 ? 0 : -1;
+}
+
+static int setup_git_repo(char *tmp_dir, size_t tmp_sz) {
+    snprintf(tmp_dir, tmp_sz, "/tmp/cbm_mcp_git_evidence_XXXXXX");
+    if (!cbm_mkdtemp(tmp_dir)) {
+        return -1;
+    }
+
+    char file_path[512];
+    snprintf(file_path, sizeof(file_path), "%s/main.c", tmp_dir);
+    FILE *fp = fopen(file_path, "w");
+    if (!fp) {
+        return -1;
+    }
+    fputs("int main(void) { return 0; }\n", fp);
+    fclose(fp);
+
+    char cmd[2048];
+    snprintf(cmd, sizeof(cmd),
+             "git -C \"%s\" init -q && "
+             "git -C \"%s\" config user.email test@example.com && "
+             "git -C \"%s\" config user.name Test && "
+             "git -C \"%s\" add main.c && "
+             "git -C \"%s\" commit -q -m initial",
+             tmp_dir, tmp_dir, tmp_dir, tmp_dir, tmp_dir);
+    return run_cmd_quiet(cmd);
+}
+
+static char *git_head(const char *repo) {
+    char cmd[1024];
+#ifdef _WIN32
+    const char *null_dev = "NUL";
+#else
+    const char *null_dev = "/dev/null";
+#endif
+    snprintf(cmd, sizeof(cmd), "git -C \"%s\" rev-parse HEAD 2>%s", repo, null_dev);
+    FILE *fp = cbm_popen(cmd, "r");
+    if (!fp) {
+        return NULL;
+    }
+    char buf[128] = "";
+    if (!fgets(buf, sizeof(buf), fp)) {
+        cbm_pclose(fp);
+        return NULL;
+    }
+    cbm_pclose(fp);
+    char *nl = strchr(buf, '\n');
+    if (nl) {
+        *nl = '\0';
+    }
+    return strdup(buf);
+}
+
 TEST(tool_search_graph_includes_node_properties) {
     /* search_graph results must surface each node's properties_json
      * payload so callers don't have to round-trip through get_code_snippet
@@ -907,6 +963,115 @@ TEST(tool_index_status_evidence_repo_path_with_quote_rejected) {
     rmdir(tmp);
     PASS();
 #endif
+}
+
+TEST(tool_index_status_evidence_clean_git_repo) {
+    char tmp[256];
+    ASSERT_EQ(setup_git_repo(tmp, sizeof(tmp)), 0);
+    char *head = git_head(tmp);
+    ASSERT_NOT_NULL(head);
+
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    cbm_mcp_server_set_project(srv, "git-clean");
+    ASSERT_EQ(cbm_store_upsert_project(st, "git-clean", tmp), CBM_STORE_OK);
+    ASSERT_EQ(cbm_store_update_project_coverage(st, "git-clean", 1, 1, 0, 0), CBM_STORE_OK);
+
+    char sql[512];
+    snprintf(sql, sizeof(sql),
+             "UPDATE projects SET indexed_git_head='%s' WHERE name='git-clean';", head);
+    ASSERT_EQ(cbm_store_exec(st, sql), CBM_STORE_OK);
+
+    char *resp = cbm_mcp_server_handle(
+        srv, "{\"jsonrpc\":\"2.0\",\"id\":17,\"method\":\"tools/call\","
+             "\"params\":{\"name\":\"index_status\","
+             "\"arguments\":{\"project\":\"git-clean\"}}}");
+    ASSERT_NOT_NULL(resp);
+    char *inner = extract_text_content(resp);
+    ASSERT_NOT_NULL(inner);
+    ASSERT_NOT_NULL(strstr(inner, "\"evidence\""));
+    ASSERT_NOT_NULL(strstr(inner, "\"freshness\":\"current\""));
+    ASSERT_NOT_NULL(strstr(inner, "\"repository_state\":\"clean\""));
+    ASSERT_NOT_NULL(strstr(inner, "\"snapshot_matches_working_tree\":true"));
+    ASSERT_NOT_NULL(strstr(inner, "\"coverage_status\":\"complete\""));
+
+    free(inner);
+    free(resp);
+    free(head);
+    cbm_mcp_server_free(srv);
+    th_cleanup(tmp);
+    PASS();
+}
+
+TEST(tool_index_status_evidence_dirty_git_repo) {
+    char tmp[256];
+    ASSERT_EQ(setup_git_repo(tmp, sizeof(tmp)), 0);
+    char *head = git_head(tmp);
+    ASSERT_NOT_NULL(head);
+
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    cbm_mcp_server_set_project(srv, "git-dirty");
+    ASSERT_EQ(cbm_store_upsert_project(st, "git-dirty", tmp), CBM_STORE_OK);
+
+    char sql[512];
+    snprintf(sql, sizeof(sql),
+             "UPDATE projects SET indexed_git_head='%s' WHERE name='git-dirty';", head);
+    ASSERT_EQ(cbm_store_exec(st, sql), CBM_STORE_OK);
+
+    char file_path[512];
+    snprintf(file_path, sizeof(file_path), "%s/main.c", tmp);
+    ASSERT_EQ(th_append_file(file_path, "/* changed */\n"), 0);
+
+    char *resp = cbm_mcp_server_handle(
+        srv, "{\"jsonrpc\":\"2.0\",\"id\":18,\"method\":\"tools/call\","
+             "\"params\":{\"name\":\"index_status\","
+             "\"arguments\":{\"project\":\"git-dirty\"}}}");
+    ASSERT_NOT_NULL(resp);
+    char *inner = extract_text_content(resp);
+    ASSERT_NOT_NULL(inner);
+    ASSERT_NOT_NULL(strstr(inner, "\"freshness\":\"working_tree_changed\""));
+    ASSERT_NOT_NULL(strstr(inner, "\"repository_state\":\"dirty\""));
+    ASSERT_NOT_NULL(strstr(inner, "\"snapshot_matches_current_head\":true"));
+    ASSERT_NOT_NULL(strstr(inner, "\"snapshot_matches_working_tree\":false"));
+
+    free(inner);
+    free(resp);
+    free(head);
+    cbm_mcp_server_free(srv);
+    th_cleanup(tmp);
+    PASS();
+}
+
+TEST(tool_trace_path_includes_edge_evidence) {
+    char tmp[256];
+    cbm_mcp_server_t *srv = setup_snippet_server(tmp, sizeof(tmp));
+    ASSERT_NOT_NULL(srv);
+
+    char *resp = cbm_mcp_server_handle(
+        srv, "{\"jsonrpc\":\"2.0\",\"id\":19,\"method\":\"tools/call\","
+             "\"params\":{\"name\":\"trace_path\","
+             "\"arguments\":{\"project\":\"test-project\","
+             "\"function_name\":\"HandleRequest\",\"direction\":\"outbound\","
+             "\"depth\":1}}}");
+    ASSERT_NOT_NULL(resp);
+    char *inner = extract_text_content(resp);
+    ASSERT_NOT_NULL(inner);
+    ASSERT_NOT_NULL(strstr(inner, "\"edge_evidence\""));
+    ASSERT_NOT_NULL(strstr(inner, "\"resolution_strategy\":\"hybrid_lsp\""));
+    ASSERT_NOT_NULL(strstr(inner, "\"confidence\":0.95"));
+    ASSERT_NOT_NULL(strstr(inner, "\"candidate_count\":1"));
+    ASSERT_NOT_NULL(strstr(inner, "\"evidence_status\":\"verified\""));
+
+    free(inner);
+    free(resp);
+    cbm_mcp_server_free(srv);
+    cleanup_snippet_dir(tmp);
+    PASS();
 }
 
 /* ══════════════════════════════════════════════════════════════════
@@ -2658,7 +2823,6 @@ TEST(parse_file_uri_invalid) {
  *  SNIPPET TESTS — Port of internal/tools/snippet_test.go
  * ══════════════════════════════════════════════════════════════════ */
 
-#include <stdio.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -2758,7 +2922,12 @@ static cbm_mcp_server_t *setup_snippet_server(char *tmp_dir, size_t tmp_sz) {
     cbm_store_upsert_node(st, &n_run2);
 
     /* Create edges: HandleRequest -> ProcessOrder, HandleRequest -> Run1 */
-    cbm_edge_t e1 = {.project = proj_name, .source_id = id_hr, .target_id = id_po, .type = "CALLS"};
+    cbm_edge_t e1 = {.project = proj_name,
+                     .source_id = id_hr,
+                     .target_id = id_po,
+                     .type = "CALLS",
+                     .properties_json =
+                         "{\"strategy\":\"lsp_exact\",\"confidence\":0.95,\"candidates\":1}"};
     cbm_store_insert_edge(st, &e1);
 
     cbm_edge_t e2 = {
@@ -4803,6 +4972,9 @@ SUITE(mcp) {
     RUN_TEST(tool_index_status_no_project);
     RUN_TEST(tool_index_status_includes_git_metadata);
     RUN_TEST(tool_index_status_evidence_repo_path_with_quote_rejected);
+    RUN_TEST(tool_index_status_evidence_clean_git_repo);
+    RUN_TEST(tool_index_status_evidence_dirty_git_repo);
+    RUN_TEST(tool_trace_path_includes_edge_evidence);
 
     /* Tool handlers with validation */
     RUN_TEST(tool_trace_call_path_not_found);

--- a/tests/test_store_nodes.c
+++ b/tests/test_store_nodes.c
@@ -5,11 +5,13 @@
  * TestNodeDedup, TestProjectCRUD, TestUpsertNodeBatch, etc.)
  */
 #include "test_framework.h"
+#include "../src/foundation/compat.h"
 #include <store/store.h>
 #include <sqlite3.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <unistd.h>
 
 /* ── Schema / Open / Close ──────────────────────────────────────── */
 
@@ -108,6 +110,45 @@ TEST(store_project_delete) {
     ASSERT_EQ(rc, CBM_STORE_NOT_FOUND);
 
     cbm_store_close(s);
+    PASS();
+}
+
+TEST(store_project_migrates_legacy_index_metadata_defaults) {
+    char path[256];
+    snprintf(path, sizeof(path), "/tmp/cbm_store_legacy_project_XXXXXX");
+    int fd = cbm_mkstemp(path);
+    ASSERT_TRUE(fd >= 0);
+    close(fd);
+
+    sqlite3 *db = NULL;
+    ASSERT_EQ(sqlite3_open(path, &db), SQLITE_OK);
+    ASSERT_EQ(sqlite3_exec(db,
+                           "CREATE TABLE projects ("
+                           "name TEXT PRIMARY KEY,"
+                           "indexed_at TEXT NOT NULL,"
+                           "root_path TEXT NOT NULL);"
+                           "INSERT INTO projects(name, indexed_at, root_path) "
+                           "VALUES('legacy', '2024-01-01T00:00:00Z', '/tmp/legacy');",
+                           NULL, NULL, NULL),
+              SQLITE_OK);
+    sqlite3_close(db);
+
+    cbm_store_t *s = cbm_store_open_path(path);
+    ASSERT_NOT_NULL(s);
+
+    cbm_project_t p = {0};
+    ASSERT_EQ(cbm_store_get_project(s, "legacy", &p), CBM_STORE_OK);
+    ASSERT_STR_EQ(p.name, "legacy");
+    ASSERT_STR_EQ(p.root_path, "/tmp/legacy");
+    ASSERT_TRUE(p.indexed_git_head == NULL || p.indexed_git_head[0] == '\0');
+    ASSERT_EQ(p.files_discovered, 0);
+    ASSERT_EQ(p.files_indexed, 0);
+    ASSERT_EQ(p.files_excluded, 0);
+    ASSERT_EQ(p.files_failed, 0);
+
+    cbm_project_free_fields(&p);
+    cbm_store_close(s);
+    unlink(path);
     PASS();
 }
 
@@ -1550,6 +1591,7 @@ SUITE(store_nodes) {
     RUN_TEST(store_project_crud);
     RUN_TEST(store_project_update);
     RUN_TEST(store_project_delete);
+    RUN_TEST(store_project_migrates_legacy_index_metadata_defaults);
     RUN_TEST(store_node_crud);
     RUN_TEST(store_node_dedup);
     RUN_TEST(store_node_find_by_label);


### PR DESCRIPTION
## What does this PR do?

This PR adds machine-readable freshness and provenance evidence to MCP responses, helping clients determine whether results come from a current index, a stale or partial index, direct source resolution, or heuristic inference.

Changes include:

* Persisting the indexed Git HEAD and file coverage metrics for each project.
* Extending `index_status` with additive evidence about indexed/current revisions, working tree state, freshness, coverage, and known limitations.
* Returning `edge_evidence` from `trace_path` and `trace_call_path` when relationship provenance is available.
* Preserving backward compatibility by returning unknown or unavailable values when older indexes do not contain the new metadata.

## Why is this needed?

Consumers of the MCP need factual and inspectable signals to decide whether a result can be trusted as-is, whether the repository should be re-indexed, or whether the result should be verified directly against source code.

Rather than exposing an opaque reliability score, this change provides the underlying evidence needed for clients to make that decision.

## Checklist

* [x] Every commit is signed off (`git commit -s`)
* [x] Tests pass locally (`make -f Makefile.cbm test`)
* [x] Lint passes (`make -f Makefile.cbm lint-ci`)
* [x] New behavior is covered by a test

## Tracking

Closes #786
