### PR TITLE
fix(architecture): "overview" compact subset + aspects schema enum + server-side validation

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -391,7 +391,11 @@ static const tool_def_t TOOLS[] = {
      "representative top_nodes, and the packages/edge_types that bind it) — use these to grasp "
      "the real architectural seams, which often cut across the folder layout.",
      "{\"type\":\"object\",\"properties\":{\"project\":{\"type\":\"string\"},\"aspects\":{\"type\":"
-     "\"array\",\"items\":{\"type\":\"string\"}}},\"required\":[\"project\"]}"},
+     "\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"all\",\"overview\",\"structure\","
+     "\"dependencies\",\"routes\",\"languages\",\"packages\",\"entry_points\",\"hotspots\","
+     "\"boundaries\",\"layers\",\"file_tree\",\"clusters\"]},\"description\":\"Aspects to "
+     "include. 'all' = everything; 'overview' = compact summary (all except file_tree); "
+     "omit = all.\"}},\"required\":[\"project\"]}"},
 
     {"search_code",
      "Graph-augmented code search. Finds text patterns via grep, then enriches results with "
@@ -1831,7 +1835,15 @@ static char *handle_delete_project(cbm_mcp_server_t *srv, const char *args) {
     return result;
 }
 
-/* Check if an aspect is requested (NULL aspects = all, or array contains "all" or the name). */
+/* "overview" = compact architecture summary: every aspect EXCEPT the large
+   per-file listing (file_tree), which alone dominates the payload (~275 entries)
+   and pushes the response past MAX_MCP_OUTPUT_TOKENS. */
+static bool aspect_in_overview(const char *name) {
+    return strcmp(name, "file_tree") != 0;
+}
+
+/* Check if an aspect is requested. NULL aspects = all. Array can contain "all"
+ * (everything), "overview" (everything except file_tree), or the aspect name. */
 static bool aspect_wanted(yyjson_doc *aspects_doc, yyjson_val *aspects_arr, const char *name) {
     if (!aspects_arr) {
         return true; /* no filter = all */
@@ -1841,9 +1853,10 @@ static bool aspect_wanted(yyjson_doc *aspects_doc, yyjson_val *aspects_arr, cons
     yyjson_val *val;
     while ((val = yyjson_arr_iter_next(&iter)) != NULL) {
         const char *s = yyjson_get_str(val);
-        if (s && (strcmp(s, "all") == 0 || strcmp(s, "overview") == 0 || strcmp(s, name) == 0)) {
-            return true;
-        }
+        if (!s) continue;
+        if (strcmp(s, "all") == 0) return true;
+        if (strcmp(s, "overview") == 0 && aspect_in_overview(name)) return true;
+        if (strcmp(s, name) == 0) return true;
     }
     (void)aspects_doc;
     return false;

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -1835,6 +1835,27 @@ static char *handle_delete_project(cbm_mcp_server_t *srv, const char *args) {
     return result;
 }
 
+/* Canonical list of valid aspect tokens for get_architecture.
+ * SSOT consumed by both the JSON-Schema enum (advisory, client-side)
+ * and the server-side validation (authoritative). Update both together
+ * if the aspect set changes. */
+static const char *VALID_ASPECTS[] = {
+    "all", "overview",
+    "structure", "dependencies", "routes",
+    "languages", "packages", "entry_points",
+    "hotspots", "boundaries", "layers",
+    "file_tree", "clusters",
+    NULL
+};
+
+static bool aspect_is_valid(const char *name) {
+    if (!name) return false;
+    for (int i = 0; VALID_ASPECTS[i]; i++) {
+        if (strcmp(name, VALID_ASPECTS[i]) == 0) return true;
+    }
+    return false;
+}
+
 /* "overview" = compact architecture summary: every aspect EXCEPT the large
    per-file listing (file_tree), which alone dominates the payload (~275 entries)
    and pushes the response past MAX_MCP_OUTPUT_TOKENS. */
@@ -1926,6 +1947,25 @@ static char *handle_get_architecture(cbm_mcp_server_t *srv, const char *args) {
             if (s && aspects_strs_count < MCP_COL_16) {
                 aspects_strs[aspects_strs_count++] = s;
             }
+        }
+    }
+
+    /* Server-side validation: reject unknown aspect tokens with a model-friendly
+     * error listing the valid values. The JSON Schema enum on this tool is
+     * advisory — not every MCP client validates client-side (Claude Code does
+     * not), so silent-empty was the failure mode before this check. */
+    for (int i = 0; i < aspects_strs_count; i++) {
+        if (!aspect_is_valid(aspects_strs[i])) {
+            char msg[512];
+            snprintf(msg, sizeof(msg),
+                "Unknown aspect '%s'. Valid: all, overview, structure, "
+                "dependencies, routes, languages, packages, entry_points, "
+                "hotspots, boundaries, layers, file_tree, clusters.",
+                aspects_strs[i]);
+            char *err = cbm_mcp_text_result(msg, true);
+            free(project);
+            if (aspects_doc) yyjson_doc_free(aspects_doc);
+            return err;
         }
     }
 

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -1841,7 +1841,7 @@ static bool aspect_wanted(yyjson_doc *aspects_doc, yyjson_val *aspects_arr, cons
     yyjson_val *val;
     while ((val = yyjson_arr_iter_next(&iter)) != NULL) {
         const char *s = yyjson_get_str(val);
-        if (s && (strcmp(s, "all") == 0 || strcmp(s, name) == 0)) {
+        if (s && (strcmp(s, "all") == 0 || strcmp(s, "overview") == 0 || strcmp(s, name) == 0)) {
             return true;
         }
     }

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -4931,17 +4931,21 @@ static int arch_clusters(cbm_store_t *s, const char *project, cbm_architecture_i
 
 /* ── GetArchitecture dispatch ──────────────────────────────────── */
 
+/* "overview" = compact architecture summary: every aspect EXCEPT the large
+   per-file listing (file_tree), which alone dominates the payload (~275 entries)
+   and pushes the response past MAX_MCP_OUTPUT_TOKENS. */
+static bool aspect_in_overview(const char *name) {
+    return strcmp(name, "file_tree") != 0;
+}
+
 static bool want_aspect(const char **aspects, int aspect_count, const char *name) {
     if (!aspects || aspect_count == 0) {
         return true;
     }
     for (int i = 0; i < aspect_count; i++) {
-        if (strcmp(aspects[i], "all") == 0 || strcmp(aspects[i], "overview") == 0) {
-            return true;
-        }
-        if (strcmp(aspects[i], name) == 0) {
-            return true;
-        }
+        if (strcmp(aspects[i], "all") == 0) return true;
+        if (strcmp(aspects[i], "overview") == 0 && aspect_in_overview(name)) return true;
+        if (strcmp(aspects[i], name) == 0) return true;
     }
     return false;
 }

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -4936,7 +4936,7 @@ static bool want_aspect(const char **aspects, int aspect_count, const char *name
         return true;
     }
     for (int i = 0; i < aspect_count; i++) {
-        if (strcmp(aspects[i], "all") == 0) {
+        if (strcmp(aspects[i], "all") == 0 || strcmp(aspects[i], "overview") == 0) {
             return true;
         }
         if (strcmp(aspects[i], name) == 0) {


### PR DESCRIPTION
## Summary

`get_architecture(aspects=["overview"])` previously returned only `{total_nodes, total_edges}` — `"overview"` was never registered in either aspect guard, and the JSON schema accepted any string (no enum), so the typo / unregistered token was silently accepted and produced an empty payload.

This PR turns that footgun into a useful, validated tool.

## What this PR does (3 layers)

### 1. `"overview"` is a useful compact subset, not an alias to `"all"`

The naive fix (treat `"overview"` as a synonym for `"all"`) still produces the ~30k-char overflow payload — `file_tree` alone is ~275 entries on a mid-size repo, pushing the response past `MAX_MCP_OUTPUT_TOKENS`.

`"overview"` now expands to every aspect **except `file_tree`**, gated by a small static helper present in both files:

```c
/* "overview" = compact architecture summary: every aspect EXCEPT the large
   per-file listing (file_tree), which alone dominates the payload (~275 entries)
   and pushes the response past MAX_MCP_OUTPUT_TOKENS. */
static bool aspect_in_overview(const char *name) {
    return strcmp(name, "file_tree") != 0;
}
```

`src/store/store.c` (gates DB sub-queries) and `src/mcp/mcp.c` (gates JSON serialization) both use it. Extending the block-list (e.g. also drop `clusters`) is one line.

### 2. JSON-Schema enum on `aspects` (advisory, client-side)

```json
"aspects": {
  "type": "array",
  "items": {
    "type": "string",
    "enum": ["all","overview","structure","dependencies","routes","languages",
             "packages","entry_points","hotspots","boundaries","layers",
             "file_tree","clusters"]
  },
  "description": "Aspects to include. 'all' = everything; 'overview' = compact summary (all except file_tree); omit = all."
}
```

Self-documenting and gives well-behaved MCP clients a clean client-side error on typos.

### 3. Server-side validation (authoritative)

The enum alone is advisory — many MCP clients (Claude Code included) do not validate against tool schemas before sending. Verified empirically: with only the enum in place, `aspects=["bogus"]` still produced silent-empty.

Server-side validation closes the loop:

```c
/* Canonical list of valid aspect tokens for get_architecture.
 * SSOT consumed by both the JSON-Schema enum (advisory, client-side)
 * and the server-side validation (authoritative). Update both together
 * if the aspect set changes. */
static const char *VALID_ASPECTS[] = {
    "all", "overview",
    "structure", "dependencies", "routes",
    "languages", "packages", "entry_points",
    "hotspots", "boundaries", "layers",
    "file_tree", "clusters",
    NULL
};
```

In `handle_get_architecture`, after parsing the aspects array, each token is checked against `VALID_ASPECTS`. On the first unknown token the handler returns `isError: true` with a model-friendly message listing the valid values, so an agent can self-correct without re-prompting:

> `Unknown aspect 'bogus'. Valid: all, overview, structure, dependencies, routes, languages, packages, entry_points, hotspots, boundaries, layers, file_tree, clusters.`

Defense in depth: client-side enum catches well-behaved clients early; server-side `aspect_is_valid` catches everyone else.

## Behavior matrix

| Call | Before PR | After PR |
|---|---|---|
| omit `aspects` | full payload (=all) | unchanged |
| `aspects=["all"]` | full payload incl. `file_tree` | unchanged |
| `aspects=["overview"]` | silent `{total_nodes,total_edges}` | full payload **minus `file_tree`**, stays under cap |
| `aspects=["hotspots"]` | only hotspots | unchanged |
| `aspects=["bogus"]` | silent `{total_nodes,total_edges}` | `isError: true` with valid-values list |

## Locally verified

Built without libgit2 (`make -f Makefile.cbm cbm LIBGIT2_FLAGS= LIBGIT2_LIBS=`), installed to `~/.local/bin/codebase-memory-mcp`. Hand-tests on an ~8k-node project after binary reload:

- `["overview"]` → 13 keys, no `file_tree`, comfortably under output cap
- `["all"]` → full payload incl. `file_tree` (unchanged)
- `["hotspots"]` → only hotspots (unchanged)
- `["bogus"]` → server returns the validation error string above

## Commits

1. `refactor(get_architecture): make "overview" a compact aspect subset + add aspects schema enum`
2. `feat(get_architecture): server-side aspect validation (defense in depth)`

(Both are kept separate so the subset semantics and the validation layer can be reviewed independently.)

## Test plan

- [ ] `get_architecture(aspects=["overview"])` → rich payload **without `file_tree`**, fits under the MCP token cap
- [ ] `get_architecture(aspects=["all"])` → unchanged, still includes `file_tree`
- [ ] `get_architecture(aspects=["bogus"])` → `isError: true` with valid-values list
- [ ] `get_architecture(aspects=["hotspots"])` → only `hotspots`
- [ ] `get_architecture()` (no `aspects`) → unchanged, returns all