### PR TITLE
fix(mcp): replace `.db`-targeting `stat()` with `cbm_file_size` on Windows (> 2 GB)

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -953,7 +953,7 @@ static bool is_project_db_file(const char *name, size_t len) {
 /* Open a .db file briefly, collect node/edge counts and root_path,
  * then append a JSON entry to arr. */
 static void build_project_json_entry(yyjson_mut_doc *doc, yyjson_mut_val *arr, const char *dir_path,
-                                     const char *name, size_t name_len, const struct stat *st) {
+                                     const char *name, size_t name_len, int64_t size_bytes) {
     char project_name[CBM_SZ_1K];
     snprintf(project_name, sizeof(project_name), "%.*s", (int)(name_len - 3), name);
 
@@ -985,7 +985,7 @@ static void build_project_json_entry(yyjson_mut_doc *doc, yyjson_mut_val *arr, c
     add_git_context_json(doc, p, root_path_buf[0] ? root_path_buf : NULL);
     yyjson_mut_obj_add_int(doc, p, "nodes", nodes);
     yyjson_mut_obj_add_int(doc, p, "edges", edges);
-    yyjson_mut_obj_add_int(doc, p, "size_bytes", (int64_t)st->st_size);
+    yyjson_mut_obj_add_int(doc, p, "size_bytes", size_bytes);
     yyjson_mut_arr_add_val(arr, p);
 }
 
@@ -1024,11 +1024,11 @@ static char *handle_list_projects(cbm_mcp_server_t *srv, const char *args) {
         }
         char full_path[CBM_SZ_2K];
         snprintf(full_path, sizeof(full_path), "%s/%s", dir_path, name);
-        struct stat st;
-        if (stat(full_path, &st) != 0) {
+        int64_t size_bytes = cbm_file_size(full_path);
+        if (size_bytes < 0) {
             continue;
         }
-        build_project_json_entry(doc, arr, dir_path, name, len, &st);
+        build_project_json_entry(doc, arr, dir_path, name, len, size_bytes);
     }
     cbm_closedir(d);
 
@@ -2653,8 +2653,7 @@ static char *handle_cross_repo_mode(const char *repo_path, const char *args) {
 static void try_artifact_bootstrap(const char *project_name, const char *repo_path) {
     char db_buf[CBM_SZ_1K];
     project_db_path(project_name, db_buf, sizeof(db_buf));
-    struct stat db_st;
-    if (stat(db_buf, &db_st) != 0 && cbm_artifact_exists(repo_path)) {
+    if (cbm_file_size(db_buf) < 0 && cbm_artifact_exists(repo_path)) {
         cbm_log_info("index.artifact_bootstrap", "project", project_name);
         cbm_artifact_import(repo_path, db_buf);
     }
@@ -4490,8 +4489,7 @@ static void maybe_auto_index(cbm_mcp_server_t *srv) {
         char db_check[CBM_SZ_1K];
         snprintf(db_check, sizeof(db_check), "%s/%s.db", cbm_resolve_cache_dir(),
                  srv->session_project);
-        struct stat st;
-        if (stat(db_check, &st) == 0) {
+        if (cbm_file_size(db_check) >= 0) {
             /* Already indexed → register watcher for change detection */
             cbm_log_info("autoindex.skip", "reason", "already_indexed", "project",
                          srv->session_project);


### PR DESCRIPTION
Fixes #578

## Summary

The reported bug: on Windows, `list_projects` drops any `.db` > 2 GB from the
UI project list. Root cause is a bare `stat()`, whose `st_size` is a 32-bit
`long` on Windows — for files > 2 GB the call fails with `EOVERFLOW` and the
entry is silently skipped.

While triaging that, two more `.db`-targeting `stat()` sites in `mcp.c` turned
out to share the exact same > 2 GB bug, so this PR fixes all three in one go:

- `list_projects` — drops the project from the UI list (the reported symptom).
- `maybe_auto_index` — mis-detects the `.db` as absent and **re-indexes the
  project on every server start** (when `auto_index` is on).
- `try_artifact_bootstrap` — mis-detects it as absent and **wastes an artifact
  import** (immediately overwritten by the ensuing pipeline rebuild).

All three now use the codebase's existing `cbm_file_size` helper (already
wide-char + 64-bit clean, already used by the UI layer) instead of `stat()`.

## Root cause

`struct stat::st_size` is a 32-bit `long` on Windows (MinGW / MSVC), so
`stat()` on a > 2 GB file fails with `EOVERFLOW` (returns -1). Each of the
three sites treated that -1 as "file missing" or "skip", so a valid > 2 GB
`.db` was silently dropped / re-indexed / re-imported.
(`build_project_json_entry` also read `(int64_t)st->st_size` — moot on Windows
since the entry never reached it, and would truncate anyway.)

## The fix

Single file changed: `src/mcp/mcp.c` (+7 / −9). No new function, no new
include. Each site swaps `stat()` for the existing `cbm_file_size()` (declared
in `foundation/platform.h`, which `mcp.c` already includes):

- **`list_projects` / `build_project_json_entry`** — size is now taken as
  `int64_t` from `cbm_file_size(full_path)` (was `(int64_t)st->st_size`); the
  skip guard becomes `if (size_bytes < 0) continue;`.
- **`try_artifact_bootstrap`** — `stat(db_buf) != 0` (missing) →
  `cbm_file_size(db_buf) < 0`.
- **`maybe_auto_index`** — `stat(db_check) == 0` (present) →
  `cbm_file_size(db_check) >= 0`.

`cbm_file_size` is wide-char + 64-bit clean on Windows (`GetFileAttributesExW`
+ `cbm_utf8_to_wide`, composing `nFileSizeHigh`/`nFileSizeLow` into `int64_t`)
and uses plain `stat()` on POSIX (`off_t` is already 64-bit under LFS). It
returns `CBM_NOT_FOUND` (`-1`) on failure, so the existing missing-file logic
is preserved at every site.

## Relation to prior work (#386 / #394)

Distinct from the merged #386 (`fix(windows): use wide-char API for non-ASCII
path support`), despite sharing the `stat` surface:

- **#386** addressed **path encoding** (non-ASCII UTF-8 paths via
  `stat`→`_wstat64`). Its changes (`discover.c`, `compat_fs.c`, `platform.c`,
  `win_utf8.h`) **do not touch `mcp.c`**, so these sites kept their bare
  `stat()`.
- **This PR** addresses the **file-size** dimension: `struct stat::st_size` is
  a 32-bit `long` on Windows, so a > 2 GB `.db` makes `stat()` fail with
  `EOVERFLOW`. Orthogonal to path encoding.

This PR adds **no new helper**. It reuses `cbm_file_size`, which already existed
on `main` (introduced in `94a9a92`, well before #386) and which #386 happened to
upgrade to wide-char safety on the Windows side. A naive migration to #386's
`wide_stat` would **not** have fixed this: `wide_stat` writes the `_stat64`
result back into a `struct stat`, where `st_size` stays 32-bit on Windows, so
the size would truncate instead of failing. `cbm_file_size` returns `int64_t`
directly, which is what actually closes the hole.

Not a duplicate of anything under #394 (Windows cluster) — none of its 8
sub-issues cover the large-file / `st_size`-overflow class.

## Verification

`cbm_file_size` returns the size as `int64_t` on both platforms — on Windows
via `GetFileAttributesExW` (no 32-bit `st_size` in play, so `EOVERFLOW` is
impossible), on POSIX via `stat()` (identical to the old path). The > 2 GB case
can no longer be dropped / re-indexed / re-imported, and POSIX behaviour is
unchanged. CI runs the full test suite on Windows and POSIX on PR open.
