### PR TITLE
fix(cli): const-qualify local pointers in codex_hook_strip for gcc 15

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -1500,11 +1500,11 @@ int cbm_remove_codex_mcp(const char *config_path) {
  * plus a leading newline). Returns a newly-malloc'd string the caller frees, or
  * NULL if no block was present (content is left untouched). */
 static char *codex_hook_strip(const char *content) {
-    char *begin = strstr(content, CODEX_HOOK_BEGIN);
+    const char *begin = strstr(content, CODEX_HOOK_BEGIN);
     if (!begin) {
         return NULL;
     }
-    char *end = strstr(begin, CODEX_HOOK_END);
+    const char *end = strstr(begin, CODEX_HOOK_END);
     if (!end) {
         return NULL;
     }
@@ -1513,7 +1513,7 @@ static char *codex_hook_strip(const char *content) {
         end++;
     }
     /* Drop one leading newline before the block, if any. */
-    char *cut = begin;
+    const char *cut = begin;
     if (cut > content && *(cut - CLI_SKIP_ONE) == '\n') {
         cut--;
     }


### PR DESCRIPTION
## Problem

Building from source with **gcc 15** (Ubuntu 25.x ships 15.2) fails:

```
src/cli/cli.c:1503:19: error: initialization discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
 1503 |     char *begin = strstr(content, CODEX_HOOK_BEGIN);
      |                   ^~~~~~
cc1: all warnings being treated as errors
```

This blocks `scripts/build.sh` on modern toolchains. Every other source file (including all 158 vendored grammars) compiles cleanly — this is the only blocker.

## Cause

`Makefile.cbm` builds with `-D_GNU_SOURCE -O2`, which enables glibc's optimized `string.h` macros. Under those, `strstr()` called on a `const char *` (with a constant needle) returns a `const char *`. Assigning that to a `char *` trips `-Werror=discarded-qualifiers` on gcc 15.

Minimal reproducer (gcc 15.2):

```c
#include <string.h>
int main(void) {
    const char *c = "hello";
    char *p = strstr(c, "ell");   /* errors under: gcc -D_GNU_SOURCE -O2 -Werror=discarded-qualifiers */
    return p ? 0 : 1;
}
```

(Compiles clean without `-D_GNU_SOURCE -O2`, which is why it only surfaces in the real build.)

## Fix

`codex_hook_strip()` only ever **reads** through `begin`, `end`, and `cut` (offset arithmetic and byte comparisons — never writes through them), so const-qualifying the three locals is the correct fix. It also matches the function's existing const contract: `content` is already declared `const char *`. The `malloc`'d output buffer (`out`) stays `char *`.

No behavior change.

## Testing

- Reproduced the failure on gcc 15.2; confirmed the patch resolves it.
- Full `scripts/build.sh` completes cleanly with the patch.
- Did not run `scripts/lint.sh` locally (no clang in my environment); the change conforms to surrounding style and builds under `-Wall -Wextra -Werror`.
