### PR TITLE
ci: add issue-triage bots (stale, label-actions, area-labeler)

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,17 @@
+# Config for github/issue-labeler (.github/workflows/issue-labeler.yml).
+# Non-versioned format: one regex per label, matched against title + body.
+# Additive only — these never remove a maintainer's manual label.
+
+"windows": '(?i)\b(windows|win\s?1[01]|powershell|\.ps1|mapped drive|smb share|unc path)\b'
+
+"stability/performance": '(?i)(out of memory|\boom\b|memory leak|segfault|sigsegv|sigbus|crash(es|ed|ing)?|core dumped|\bhang(s|ing)?\b|deadlock|freezes?|time(s)?\s?out|timeout|never finishes|cgroup)'
+
+"parsing/quality": '(?i)(trace_path|query_graph|search_graph|calls? edge|missing (edges|nodes)|false positive|zero edges|0 edges|module node|not indexed|extraction|wrong (node|label))'
+
+"editor/integration": '(?i)(cursor|vscode|vs code|opencode|codex|claude code|gemini cli|antigravity|mcp client|\.mcp\.json|installer)'
+
+"ux/behavior": '(?i)(web ui|\bui\b|dashboard|3d graph|visuali[sz]ation|watcher|project name|frontend)'
+
+"cypher": '(?i)\bcypher\b'
+
+"language-request": '(?i)(language support|hybrid lsp|new language support|support for \w+ language)'

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,0 +1,35 @@
+# Config for dessant/label-actions (.github/workflows/label-actions.yml).
+# Each top-level key is a label; when that label is added to an issue, the
+# listed actions run. See https://github.com/dessant/label-actions
+
+# When a maintainer marks an issue as a duplicate.
+duplicate:
+  comment: >
+    Thanks for raising this! It looks like a duplicate of an existing issue —
+    the canonical one is linked above. Continuing the discussion there keeps
+    everything in one place. We leave this open for visibility; a maintainer
+    will close it once it's fully covered.
+  # We intentionally do NOT auto-close duplicates (we prefer linking).
+  # To auto-close instead, uncomment the two lines below:
+  # close: true
+  # close-reason: not planned
+
+# When a maintainer marks an issue as waiting on the reporter.
+# (The stale workflow then warns at 21 days and closes at 35.)
+awaiting-reporter:
+  comment: >
+    Thanks for the report! To move this forward we need a bit more so we can
+    reproduce it ourselves:
+
+
+    - the `codebase-memory-mcp --version` you're on
+
+    - the exact steps or command you ran
+
+    - a **public** repo (or a small dummy snippet) that shows the problem —
+    please don't paste proprietary code
+
+
+    Once that's here we'll pick it straight back up. Heads-up: issues left
+    `awaiting-reporter` are automatically closed after a few weeks of silence,
+    but a comment reopens the door anytime.

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,28 @@
+name: Issue area labeler
+
+# Adds area labels to new/edited issues based on keyword regexes in
+# .github/issue-labeler.yml. Additive only (sync-labels off): it never
+# removes a label a maintainer set by hand. Base bug/enhancement labels
+# already come from the issue forms.
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
+        with:
+          configuration-path: .github/issue-labeler.yml
+          enable-versioned-regex: 0
+          include-title: 1
+          include-body: 1
+          sync-labels: 0
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -1,0 +1,21 @@
+name: Label actions
+
+# Posts a templated comment when a maintainer adds certain labels.
+# Behavior is configured in .github/label-actions.yml. Issues only.
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: dessant/label-actions@65225c179d3b2502f6eda7b3d15101a3f412366b # v5.0.3
+        with:
+          process-only: issues

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,44 @@
+name: Stale awaiting-reporter
+
+# Only touches issues that a maintainer has explicitly marked `awaiting-reporter`.
+# Never touches pull requests, and never touches issues without that label.
+# A reporter comment removes `stale` and resets the clock.
+
+on:
+  schedule:
+    - cron: '17 2 * * *' # daily 02:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        with:
+          only-labels: 'awaiting-reporter'
+          stale-issue-label: 'stale'
+          days-before-issue-stale: 21
+          days-before-issue-close: 14
+          # Never act on pull requests with this workflow.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-stale-when-updated: true
+          close-issue-reason: not_planned
+          operations-per-run: 60
+          ascending: true
+          stale-issue-message: >
+            This issue has been waiting on more information for 21 days (a
+            version, exact steps, or a public repro), so it's now marked
+            `stale`. It will be closed in 14 days if there's no update — just
+            add a comment to keep it open. We're happy to pick it back up the
+            moment we can reproduce it.
+          close-issue-message: >
+            Closing because we haven't received the requested details and can't
+            reproduce it as-is. This isn't a "won't fix" — please comment with
+            the info (version + a public repro) and we'll reopen and dig in.
+            Thanks for the report.


### PR DESCRIPTION
## What

Three native GitHub Actions that automate the **mechanical** parts of issue triage. The judgment parts (writing a real first reply, accurately connecting duplicates, picking the right area label initially) stay manual — these bots just take the repetitive load off.

### 1. Stale lifecycle — `awaiting-reporter` → warn → close
`.github/workflows/stale.yml` (`actions/stale`)
- Acts **only** on issues a maintainer has labelled **`awaiting-reporter`** — never on PRs, never on unlabelled issues.
- 21 days idle → comments + adds `stale`; 14 more days → closes as `not planned`.
- A reporter comment removes `stale` and resets the clock automatically.
- Runs daily on a schedule (+ manual `workflow_dispatch`).

This replaces the hand-maintained stale-watch table.

### 2. Templated label comments
`.github/workflows/label-actions.yml` + `.github/label-actions.yml` (`dessant/label-actions`)
- Add **`duplicate`** → posts a "this is a duplicate, see the linked issue" comment. (We **link, not auto-close** — the auto-close lines are present but commented out.)
- Add **`awaiting-reporter`** → posts the "we need version + a public repro" template, so you don't retype it.

### 3. Keyword area-labeler
`.github/workflows/issue-labeler.yml` + `.github/issue-labeler.yml` (`github/issue-labeler`)
- On issue open/edit, adds area labels from title/body keywords: `windows`, `stability/performance`, `parsing/quality`, `editor/integration`, `ux/behavior`, `cypher`, `language-request`.
- **Additive only** (`sync-labels: 0`) — never removes a label set by hand. Base `bug` / `enhancement` keep coming from the issue forms.

## Labels added (already created on the repo)
- `awaiting-reporter` — waiting on the reporter; drives the stale workflow.
- `stale` — applied by the bot before closing.

## Security
- All third-party actions **pinned to full commit SHAs** (keeps Scorecard green): `actions/stale` v10.3.0, `dessant/label-actions` v5.0.3, `github/issue-labeler` v3.4.
- **Least privilege:** top-level `contents: read`; `issues: write` granted only on the jobs that need it. No PR write, no broad scopes.
- The labeler matches on regex only (no code execution); nothing here feeds issue text to an external service.

## Notes
- No AI/model dependency in this PR — it's all free on public-repo Actions minutes.
- Tuning is easy: thresholds in `stale.yml`, comment text in `label-actions.yml`, regexes in `issue-labeler.yml`.
