### PR TITLE
docs: remove stale language and test counts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ The binary is output to `build/c/codebase-memory-mcp`.
 scripts/test.sh
 ```
 
-This builds with ASan + UBSan and runs all tests (~2040 cases). Key test files:
+This builds with ASan + UBSan and runs the full C test suite. Key test files:
 - `tests/test_pipeline.c` — pipeline integration tests
 - `tests/test_httplink.c` — HTTP route extraction and linking
 - `tests/test_mcp.c` — MCP protocol and tool handler tests
@@ -63,7 +63,7 @@ src/
   watcher/          Git-based background auto-sync
   cli/              CLI subcommands (install, update, uninstall, config)
   ui/               Graph visualization HTTP server (first-party httpd)
-internal/cbm/       Tree-sitter AST extraction (64 languages, vendored C grammars)
+internal/cbm/       Language registry, AST extraction, and vendored grammars
 vendored/           sqlite3, yyjson, mimalloc, xxhash, tre, nomic
 graph-ui/           React/Three.js frontend for graph visualization
 scripts/            Build, test, lint, security audit scripts

--- a/src/discover/discover.h
+++ b/src/discover/discover.h
@@ -2,7 +2,7 @@
  * discover.h — File discovery, language detection, and gitignore matching.
  *
  * Provides:
- *   - Language detection from filename/extension (CBM_SZ_64 languages)
+ *   - Language detection from filename/extension (CBMLanguage registry)
  *   - .m file disambiguation (Objective-C vs Magma vs MATLAB)
  *   - Gitignore-style pattern parsing and matching
  *   - Recursive directory walk with hardcoded + gitignore filtering

--- a/tests/test_language.c
+++ b/tests/test_language.c
@@ -1,7 +1,7 @@
 /*
  * test_language.c — Tests for language detection (filename + extension).
  *
- * RED phase: These tests define the expected behavior for all 64 languages.
+ * RED phase: These tests define the expected behavior for registered languages.
  */
 #include "../src/foundation/compat.h"
 #include "test_framework.h"


### PR DESCRIPTION
## Summary
- remove stale fixed test-count wording from CONTRIBUTING.md
- avoid hard-coded language-count references in contributor docs and related comments

## Validation
- rg -n "2040 cases|64 languages|CBM_SZ_64" CONTRIBUTING.md src/discover/discover.h tests/test_language.c
- git diff --check