### PR TITLE
fix: use _wfopen on Windows to support non-ASCII (CJK/U...) file paths

### DIFF
--- a/src/foundation/compat_fs.c
+++ b/src/foundation/compat_fs.c
@@ -130,6 +130,22 @@ int cbm_pclose(FILE *f) {
     return _pclose(f);
 }
 
+/* Open a file with wide-char _wfopen for UTF-8 path support on Windows. */
+FILE *cbm_fopen(const char *path, const char *mode) {
+    wchar_t *wpath = cbm_utf8_to_wide(path);
+    if (!wpath) {
+        return NULL;
+    }
+    wchar_t wmode[8] = {0};
+    if (mbstowcs(wmode, mode, 7) == (size_t)-1) {
+        free(wpath);
+        return NULL;
+    }
+    FILE *f = _wfopen(wpath, wmode);
+    free(wpath);
+    return f;
+}
+
 bool cbm_mkdir_p(const char *path, int mode) {
     (void)mode;
     wchar_t *wpath = cbm_utf8_to_wide(path);
@@ -260,6 +276,10 @@ FILE *cbm_popen(const char *cmd, const char *mode) {
 
 int cbm_pclose(FILE *f) {
     return pclose(f);
+}
+
+FILE *cbm_fopen(const char *path, const char *mode) {
+    return fopen(path, mode);
 }
 
 bool cbm_mkdir_p(const char *path, int mode) {

--- a/src/foundation/compat_fs.h
+++ b/src/foundation/compat_fs.h
@@ -56,4 +56,8 @@ int cbm_rmdir(const char *path);
  * POSIX: fork() + execvp(). Windows: _spawnvp(). */
 int cbm_exec_no_shell(const char *const *argv);
 
+/* Open a file for reading. On Windows, uses wide-char _wfopen to support
+ * non-ASCII (UTF-8) paths. On POSIX, delegates to fopen(). */
+FILE *cbm_fopen(const char *path, const char *mode);
+
 #endif /* CBM_COMPAT_FS_H */

--- a/src/pipeline/pass_calls.c
+++ b/src/pipeline/pass_calls.c
@@ -19,6 +19,7 @@ enum { PC_RING = 4, PC_RING_MASK = 3, PC_SIG_SCAN = 15, PC_REGEX_GRP = 2 };
 #include "graph_buffer/graph_buffer.h"
 #include "foundation/log.h"
 #include "foundation/compat.h"
+#include "foundation/compat_fs.h"
 #include "foundation/str_util.h"
 #include "cbm.h"
 #include "service_patterns.h"
@@ -32,7 +33,7 @@ enum { PC_RING = 4, PC_RING_MASK = 3, PC_SIG_SCAN = 15, PC_REGEX_GRP = 2 };
 
 /* Read entire file into heap-allocated buffer. Caller must free(). */
 static char *read_file(const char *path, int *out_len) {
-    FILE *f = fopen(path, "rb");
+    FILE *f = cbm_fopen(path, "rb");
     if (!f) {
         return NULL;
     }

--- a/src/pipeline/pass_definitions.c
+++ b/src/pipeline/pass_definitions.c
@@ -22,6 +22,7 @@ enum { PD_JSON_FIELD_OVERHEAD = 6 };
 #include "graph_buffer/graph_buffer.h"
 #include "foundation/log.h"
 #include "foundation/compat.h"
+#include "foundation/compat_fs.h"
 #include "cbm.h"
 #include "simhash/minhash.h"
 #include "semantic/ast_profile.h"
@@ -33,7 +34,7 @@ enum { PD_JSON_FIELD_OVERHEAD = 6 };
 /* Read entire file into heap-allocated buffer. Returns NULL on error.
  * Caller must free(). Sets *out_len to byte count. */
 static char *read_file(const char *path, int *out_len) {
-    FILE *f = fopen(path, "rb");
+    FILE *f = cbm_fopen(path, "rb");
     if (!f) {
         return NULL;
     }

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -57,6 +57,7 @@ enum { PP_CSHARP_M_PREFIX_LEN = 2 };
 #include "pipeline/worker_pool.h"
 #include "foundation/compat.h"
 #include "foundation/compat_thread.h"
+#include "foundation/compat_fs.h"
 #include "graph_buffer/graph_buffer.h"
 #include "service_patterns.h"
 #include "foundation/platform.h"
@@ -88,7 +89,7 @@ static uint64_t extract_now_ns(void) {
 
 /* Read file into a malloc'd buffer (= mimalloc in production). */
 static char *read_file(const char *path, int *out_len) {
-    FILE *f = fopen(path, "rb");
+    FILE *f = cbm_fopen(path, "rb");
     if (!f) {
         return NULL;
     }


### PR DESCRIPTION
## Summary

On Windows, `fopen()` uses the active ANSI codepage (e.g. GBK on zh-CN, Shift-JIS on ja-JP, CP1251 on ru-RU) rather than UTF-8. When a repository path contains characters outside ASCII-7 — **any non-English language**: Chinese, Japanese, Korean, Cyrillic, Arabic, accented Latin (é/ü/ñ), Thai, Hebrew, Devanagari, etc. — every file's tree-sitter definitions pass fails (`defs=0`, `errors=N` for all files). The resulting knowledge graph contains only File/Folder nodes with zero code intelligence.

The existing directory-enumeration code in `compat_fs.c` already handles this correctly via `FindFirstFileW`/`_wmkdir`/`_wunlink` with wide-character paths. This PR applies the same pattern to file **reading** for tree-sitter parsing.

## Changes

| File | Change |
|------|--------|
| `src/foundation/compat_fs.h` | Declare `cbm_fopen()` |
| `src/foundation/compat_fs.c` | Implement `cbm_fopen()`: `_wfopen` on Windows, `fopen` on POSIX |
| `src/pipeline/pass_parallel.c` | Replace `fopen` → `cbm_fopen` |
| `src/pipeline/pass_calls.c` | Replace `fopen` → `cbm_fopen` |
| `src/pipeline/pass_definitions.c` | Replace `fopen` → `cbm_fopen` |

All three pipeline files had a duplicated `read_file()` static function. Each now calls `cbm_fopen()` instead of raw `fopen()`.

## Testing

### Before (v0.8.1)
```
pass=definitions defs=0 calls=0 imports=0 errors=41   ← ALL files fail
```

### After (this PR)
```
pass=definitions defs=215 calls=259 imports=18 errors=0  ← all pass
```

Tested on a 41-file TypeScript/JS/Python/CSS project with CJK directory names (`F:/.../智能体/智能体原型/`). Full index: 245 nodes, 347 edges, 197ms.

## Related

- Fixes #636 (this specific bug)
- Related to #571 (project name truncation for CJK paths — cosmetic, already fixed)
- This is the **functional** fix that makes the tool work for non-English Windows users
