### PR TITLE
Fix OpenClaw MCP config path

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -980,9 +980,14 @@ fi
 echo "OK 8v: VS Code MCP"
 
 # 8w: OpenClaw MCP
-CMD=$(json_get "$FAKE_HOME/.openclaw/openclaw.json" "d['mcpServers']['codebase-memory-mcp']['command']")
+CMD=$(json_get "$FAKE_HOME/.openclaw/openclaw.json" "d['mcp']['servers']['codebase-memory-mcp']['command']")
 if ! path_match "$CMD" "$SELF_PATH"; then
   echo "FAIL 8w: OpenClaw command='$CMD'"
+  exit 1
+fi
+ENABLED=$(json_get "$FAKE_HOME/.openclaw/openclaw.json" "d['mcp']['servers']['codebase-memory-mcp'].get('enabled')")
+if [ "$ENABLED" != "True" ]; then
+  echo "FAIL 8w: OpenClaw enabled='$ENABLED'"
   exit 1
 fi
 echo "OK 8w: OpenClaw MCP"
@@ -1091,7 +1096,7 @@ fi
 if cat "$FAKE_HOME/.openclaw/openclaw.json" 2>/dev/null | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
-sys.exit(1 if 'codebase-memory-mcp' in d.get('mcpServers', {}) else 0)
+sys.exit(1 if 'codebase-memory-mcp' in d.get('mcp', {}).get('servers', {}) else 0)
 " 2>/dev/null; then
   echo "OK 9k: OpenClaw MCP removed"
 else

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -863,6 +863,96 @@ int cbm_remove_editor_mcp(const char *config_path) {
     return rc;
 }
 
+/* ── OpenClaw MCP (nested mcp.servers with command + args) ────── */
+
+int cbm_install_openclaw_mcp(const char *binary_path, const char *config_path) {
+    if (!binary_path || !config_path) {
+        return CLI_ERR;
+    }
+
+    yyjson_mut_doc *mdoc = yyjson_mut_doc_new(NULL);
+    if (!mdoc) {
+        return CLI_ERR;
+    }
+
+    yyjson_doc *doc = read_json_file(config_path);
+    yyjson_mut_val *root;
+    if (doc) {
+        root = yyjson_val_mut_copy(mdoc, yyjson_doc_get_root(doc));
+        yyjson_doc_free(doc);
+    } else {
+        root = yyjson_mut_obj(mdoc);
+    }
+    if (!root) {
+        yyjson_mut_doc_free(mdoc);
+        return CLI_ERR;
+    }
+    yyjson_mut_doc_set_root(mdoc, root);
+
+    yyjson_mut_val *mcp = yyjson_mut_obj_get(root, "mcp");
+    if (!mcp || !yyjson_mut_is_obj(mcp)) {
+        mcp = yyjson_mut_obj(mdoc);
+        yyjson_mut_obj_add_val(mdoc, root, "mcp", mcp);
+    }
+
+    yyjson_mut_val *servers = yyjson_mut_obj_get(mcp, "servers");
+    if (!servers || !yyjson_mut_is_obj(servers)) {
+        servers = yyjson_mut_obj(mdoc);
+        yyjson_mut_obj_add_val(mdoc, mcp, "servers", servers);
+    }
+
+    yyjson_mut_obj_remove_key(servers, "codebase-memory-mcp");
+
+    yyjson_mut_val *entry = yyjson_mut_obj(mdoc);
+    yyjson_mut_obj_add_bool(mdoc, entry, "enabled", true);
+    yyjson_mut_obj_add_str(mdoc, entry, "command", binary_path);
+    yyjson_mut_val *args = yyjson_mut_arr(mdoc);
+    yyjson_mut_obj_add_val(mdoc, entry, "args", args);
+    yyjson_mut_obj_add_val(mdoc, servers, "codebase-memory-mcp", entry);
+
+    int rc = write_json_file(config_path, mdoc);
+    yyjson_mut_doc_free(mdoc);
+    return rc;
+}
+
+int cbm_remove_openclaw_mcp(const char *config_path) {
+    if (!config_path) {
+        return CLI_ERR;
+    }
+
+    yyjson_doc *doc = read_json_file(config_path);
+    if (!doc) {
+        return CLI_ERR;
+    }
+
+    yyjson_mut_doc *mdoc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *root = yyjson_val_mut_copy(mdoc, yyjson_doc_get_root(doc));
+    yyjson_doc_free(doc);
+    if (!root) {
+        yyjson_mut_doc_free(mdoc);
+        return CLI_ERR;
+    }
+    yyjson_mut_doc_set_root(mdoc, root);
+
+    yyjson_mut_val *mcp = yyjson_mut_obj_get(root, "mcp");
+    if (!mcp || !yyjson_mut_is_obj(mcp)) {
+        yyjson_mut_doc_free(mdoc);
+        return 0;
+    }
+
+    yyjson_mut_val *servers = yyjson_mut_obj_get(mcp, "servers");
+    if (!servers || !yyjson_mut_is_obj(servers)) {
+        yyjson_mut_doc_free(mdoc);
+        return 0;
+    }
+
+    yyjson_mut_obj_remove_key(servers, "codebase-memory-mcp");
+
+    int rc = write_json_file(config_path, mdoc);
+    yyjson_mut_doc_free(mdoc);
+    return rc;
+}
+
 /* ── VS Code MCP (servers key with type:stdio) ────────────────── */
 
 int cbm_install_vscode_mcp(const char *binary_path, const char *config_path) {
@@ -3234,7 +3324,7 @@ static void install_editor_agent_configs(const cbm_detected_agents_t *agents, co
         char cp[CLI_BUF_1K];
         snprintf(cp, sizeof(cp), "%s/.openclaw/openclaw.json", home);
         install_generic_agent_config("OpenClaw", binary_path, cp, NULL, dry_run,
-                                     cbm_install_editor_mcp);
+                                     cbm_install_openclaw_mcp);
     }
     if (agents->kiro) {
         char cp[CLI_BUF_1K];
@@ -3712,7 +3802,7 @@ static void uninstall_editor_agents(const cbm_detected_agents_t *agents, const c
         char cp[CLI_BUF_1K];
         snprintf(cp, sizeof(cp), "%s/.openclaw/openclaw.json", home);
         uninstall_agent_mcp_instr((mcp_uninstall_args_t){"OpenClaw", cp, NULL}, dry_run,
-                                  cbm_remove_editor_mcp);
+                                  cbm_remove_openclaw_mcp);
     }
     if (agents->kiro) {
         char cp[CLI_BUF_1K];

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -94,6 +94,16 @@ int cbm_install_editor_mcp(const char *binary_path, const char *config_path);
  * Returns 0 on success. */
 int cbm_remove_editor_mcp(const char *config_path);
 
+/* Install MCP server entry in OpenClaw JSON config.
+ * Format: { "mcp": { "servers": { "codebase-memory-mcp":
+ * { "enabled": true, "command": binary_path, "args": [] } } } }
+ * Preserves existing entries. Returns 0 on success. */
+int cbm_install_openclaw_mcp(const char *binary_path, const char *config_path);
+
+/* Remove MCP server entry from OpenClaw JSON config.
+ * Returns 0 on success. */
+int cbm_remove_openclaw_mcp(const char *config_path);
+
 /* Install MCP server entry in VS Code JSON config.
  * Format: { "servers": { "codebase-memory-mcp": { "type": "stdio", "command": binary_path } } }
  * Returns 0 on success. */

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -718,6 +718,83 @@ TEST(cli_gemini_mcp_install) {
     PASS();
 }
 
+TEST(cli_openclaw_mcp_install_uses_nested_servers) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-openclaw-mcp-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    char configpath[512];
+    snprintf(configpath, sizeof(configpath), "%s/.openclaw/openclaw.json", tmpdir);
+
+    int rc = cbm_install_openclaw_mcp("/usr/local/bin/codebase-memory-mcp", configpath);
+    ASSERT_EQ(rc, 0);
+
+    const char *data = read_test_file(configpath);
+    ASSERT_NOT_NULL(data);
+    ASSERT(strstr(data, "\"mcp\"") != NULL);
+    ASSERT(strstr(data, "\"servers\"") != NULL);
+    ASSERT(strstr(data, "\"enabled\": true") != NULL);
+    ASSERT(strstr(data, "\"command\": \"/usr/local/bin/codebase-memory-mcp\"") != NULL);
+    ASSERT(strstr(data, "\"args\": []") != NULL);
+    ASSERT(strstr(data, "\"mcpServers\"") == NULL);
+
+    test_rmdir_r(tmpdir);
+    PASS();
+}
+
+TEST(cli_openclaw_mcp_preserves_existing_config) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-openclaw-mcp-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    char dir[512];
+    snprintf(dir, sizeof(dir), "%s/.openclaw", tmpdir);
+    test_mkdirp(dir);
+
+    char configpath[512];
+    snprintf(configpath, sizeof(configpath), "%s/openclaw.json", dir);
+    write_test_file(configpath,
+                    "{\"theme\":\"dark\",\"mcp\":{\"servers\":{\"other\":{\"command\":\"x\"}}}}");
+
+    int rc = cbm_install_openclaw_mcp("/usr/local/bin/codebase-memory-mcp", configpath);
+    ASSERT_EQ(rc, 0);
+
+    const char *data = read_test_file(configpath);
+    ASSERT_NOT_NULL(data);
+    ASSERT(strstr(data, "theme") != NULL);
+    ASSERT(strstr(data, "other") != NULL);
+    ASSERT(strstr(data, "codebase-memory-mcp") != NULL);
+    ASSERT(strstr(data, "\"mcpServers\"") == NULL);
+
+    test_rmdir_r(tmpdir);
+    PASS();
+}
+
+TEST(cli_openclaw_mcp_uninstall_uses_nested_servers) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-openclaw-mcp-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    char configpath[512];
+    snprintf(configpath, sizeof(configpath), "%s/.openclaw/openclaw.json", tmpdir);
+
+    ASSERT_EQ(cbm_install_openclaw_mcp("/usr/local/bin/codebase-memory-mcp", configpath), 0);
+    ASSERT_EQ(cbm_remove_openclaw_mcp(configpath), 0);
+
+    const char *data = read_test_file(configpath);
+    ASSERT_NOT_NULL(data);
+    ASSERT(strstr(data, "\"mcp\"") != NULL);
+    ASSERT(strstr(data, "\"servers\"") != NULL);
+    ASSERT(strstr(data, "\"codebase-memory-mcp\"") == NULL);
+    ASSERT(strstr(data, "\"mcpServers\"") == NULL);
+
+    test_rmdir_r(tmpdir);
+    PASS();
+}
+
 /* ═══════════════════════════════════════════════════════════════════
  *  VS Code MCP config tests
  * ═══════════════════════════════════════════════════════════════════ */
@@ -2693,6 +2770,9 @@ SUITE(cli) {
     RUN_TEST(cli_editor_mcp_preserves_others);
     RUN_TEST(cli_editor_mcp_uninstall);
     RUN_TEST(cli_gemini_mcp_install);
+    RUN_TEST(cli_openclaw_mcp_install_uses_nested_servers);
+    RUN_TEST(cli_openclaw_mcp_preserves_existing_config);
+    RUN_TEST(cli_openclaw_mcp_uninstall_uses_nested_servers);
 
     /* VS Code MCP (2 tests — install_test.go) */
     RUN_TEST(cli_vscode_mcp_install);


### PR DESCRIPTION
## Summary

Fixes #653 by giving OpenClaw a dedicated MCP config writer/remover instead of reusing the editor `mcpServers` shape.

OpenClaw now writes:

```json
{
  "mcp": {
    "servers": {
      "codebase-memory-mcp": {
        "enabled": true,
        "command": "<binary>",
        "args": []
      }
    }
  }
}
```

and uninstall removes from `mcp.servers` instead of top-level `mcpServers`.

## Changes

- Add `cbm_install_openclaw_mcp` / `cbm_remove_openclaw_mcp`.
- Route OpenClaw install/uninstall to those functions.
- Add CLI unit coverage for install, preserve-existing-config, and uninstall.
- Update smoke-test OpenClaw checks to read/write `mcp.servers`.

## Validation

- `git diff --check` ✅
- `bash -n scripts/smoke-test.sh` ✅
- `make -f Makefile.cbm test` attempted, but this runner is missing zlib headers:
  - `tests/test_cli.c:23:10: fatal error: zlib.h: No such file or directory`
  - `src/cli/cli.c:87:10: fatal error: zlib.h: No such file or directory`

So I could validate patch cleanliness and shell syntax here, but not the full C test suite without `zlib.h`/dev headers installed.
