### PR TITLE
feat: Add Pi agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ High-quality parsing through [tree-sitter](https://tree-sitter.github.io/tree-si
 - **Plug and play** — single static binary for macOS (arm64/amd64), Linux (arm64/amd64), and Windows (amd64). No Docker, no runtime dependencies, no API keys. Download → `install` → restart agent → done.
 - **158 languages** — vendored tree-sitter grammars compiled into the binary. Nothing to install, nothing that breaks.
 - **120x fewer tokens** — 5 structural queries: ~3,400 tokens vs ~412,000 via file-by-file search. One graph query replaces dozens of grep/read cycles.
-- **11 agents, one command** — `install` auto-detects Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, and Kiro — configures MCP entries, instruction files, and pre-tool hooks for each.
+- **12 agents, one command** — `install` auto-detects Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, Kiro, and Pi — configures MCP entries, instruction files, and pre-tool hooks for each.
 - **Built-in graph visualization** — 3D interactive UI at `localhost:9749` (optional UI binary variant).
 - **Infrastructure-as-code indexing** — Dockerfiles, Kubernetes manifests, and Kustomize overlays indexed as graph nodes with cross-references. `Resource` nodes for K8s kinds, `Module` nodes for Kustomize overlays with `IMPORTS` edges to referenced resources.
 - **14 MCP tools** — search, trace, architecture, impact analysis, Cypher queries, dead code detection, cross-service HTTP linking, ADR management, and more.
@@ -345,6 +345,7 @@ Restart your agent. Verify with `/mcp` — you should see `codebase-memory-mcp` 
 | VS Code | `Code/User/mcp.json` | — | — |
 | OpenClaw | `openclaw.json` | — | — |
 | Kiro | `.kiro/settings/mcp.json` | — | — |
+| Pi | `.pi/agent/mcp.json` | `.pi/agent/AGENTS.md` | — |
 
 **Hooks are structurally non-blocking** (exit code 0, every failure path).
 For Claude Code, the `PreToolUse` hook intercepts `Grep`/`Glob` (never `Read` —

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>codebase-memory-mcp — Code Intelligence Knowledge Graph for AI Coding Agents</title>
-    <meta name="description" content="codebase-memory-mcp is an open-source MCP server that indexes any codebase into a persistent knowledge graph so AI coding agents answer structural questions with ~120x fewer tokens. 158 languages, Hybrid LSP type resolution, local semantic vector search, code-clone detection, sub-1ms queries, Linux kernel indexed in 3 minutes. Single static C binary, zero dependencies. Works with 11 agents including Claude Code, Codex CLI, Gemini CLI, Cursor, and Zed.">
+    <meta name="description" content="codebase-memory-mcp is an open-source MCP server that indexes any codebase into a persistent knowledge graph so AI coding agents answer structural questions with ~120x fewer tokens. 158 languages, Hybrid LSP type resolution, local semantic vector search, code-clone detection, sub-1ms queries, Linux kernel indexed in 3 minutes. Single static C binary, zero dependencies. Works with 12 agents including Claude Code, Codex CLI, Gemini CLI, Cursor, and Zed.">
     <meta name="keywords" content="MCP server, code intelligence, knowledge graph, tree-sitter, Hybrid LSP, semantic code search, code embeddings, code clone detection, cross-repo analysis, data-flow analysis, Claude Code, Codex CLI, Gemini CLI, Cursor, Zed, code exploration, token reduction, call graph, dead code detection">
     <meta name="author" content="DeusData">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
@@ -157,7 +157,7 @@
           "name": "Which AI coding agents work with codebase-memory-mcp?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "A single install command configures 11 agents: Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, and Kiro. Any MCP-compatible client can use the server."
+            "text": "A single install command configures 12 agents: Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, Kiro, and Pi. Any MCP-compatible client can use the server."
           }
         },
         {
@@ -526,8 +526,8 @@
             <span class="cmd">"Index this project"</span>
         </div>
         <p class="muted">
-            One command configures all 11 supported agents: Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode,
-            Antigravity, Aider, KiloCode, VS Code, OpenClaw, and Kiro — with MCP entries, instruction files, and
+            One command configures all 12 supported agents: Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode,
+            Antigravity, Aider, KiloCode, VS Code, OpenClaw, Kiro, and Pi — with MCP entries, instruction files, and
             pre-tool hooks for each. Windows users run <code>install.ps1</code>. Also available via
             <code>npm</code>, <code>pip</code>, Homebrew, Scoop, Winget, Chocolatey, AUR, and <code>go install</code>.
         </p>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,7 +12,7 @@
 - Semantic & similarity edges: SEMANTICALLY_RELATED (vocabulary-mismatch matches) and SIMILAR_TO (MinHash + LSH near-clone / duplicate detection).
 - Cross-repo intelligence: CROSS_* edges link nodes across multiple repos indexed in one store; multi-galaxy 3D layout and cross-repo architecture summary.
 - Cross-service linking: HTTP route ↔ call-site matching, plus gRPC/GraphQL/tRPC detection and pub/sub channels (EMITS/LISTENS_ON for Socket.IO, EventEmitter, generic buses).
-- Supported agents: 11 (Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, Kiro).
+- Supported agents: 12 (Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, Kiro, Pi).
 - Performance: Linux kernel (28M LOC, 75K files) full index in 3 minutes → 4.81M nodes, 7.72M edges; Cypher queries in under 1ms.
 - Distribution: single static C binary; also npm, PyPI, Homebrew, Scoop, Winget, Chocolatey, AUR, and `go install`.
 

--- a/pkg/npm/README.md
+++ b/pkg/npm/README.md
@@ -29,7 +29,7 @@ Restart your agent. Say **"Index this project"** — done.
 - **Plug and play** — single static binary for macOS (arm64/amd64), Linux (arm64/amd64), and Windows (amd64). No Docker, no runtime dependencies, no API keys.
 - **159 languages** — vendored tree-sitter grammars compiled into the binary. Nothing to install, nothing that breaks.
 - **120x fewer tokens** — 5 structural queries: ~3,400 tokens vs ~412,000 via file-by-file search.
-- **11 agents, one command** — `install` auto-detects Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, and Kiro.
+- **12 agents, one command** — `install` auto-detects Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, Kiro, and Pi.
 - **14 MCP tools** — search, trace, architecture, impact analysis, Cypher queries, dead code detection, cross-service HTTP linking, ADR management, and more.
 
 ## Supported Platforms

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -1143,6 +1143,10 @@ cbm_detected_agents_t cbm_detect_agents(const char *home_dir) {
     snprintf(path, sizeof(path), "%s/.kiro", home_dir);
     agents.kiro = dir_exists(path);
 
+    /* Pi agent: ~/.pi/agent/ */
+    snprintf(path, sizeof(path), "%s/.pi/agent", home_dir);
+    agents.pi = dir_exists(path);
+
     return agents;
 }
 
@@ -1676,6 +1680,16 @@ int cbm_upsert_antigravity_mcp(const char *binary_path, const char *config_path)
 }
 
 int cbm_remove_antigravity_mcp(const char *config_path) {
+    return cbm_remove_editor_mcp(config_path);
+}
+
+/* ── Pi agent MCP config (JSON, standard mcpServers format) ───── */
+
+int cbm_upsert_pi_mcp(const char *binary_path, const char *config_path) {
+    return cbm_install_editor_mcp(binary_path, config_path);
+}
+
+int cbm_remove_pi_mcp(const char *config_path) {
     return cbm_remove_editor_mcp(config_path);
 }
 
@@ -2934,6 +2948,7 @@ static void print_detected_agents(const cbm_detected_agents_t *a) {
         {a->cursor, "Cursor"},
         {a->openclaw, "OpenClaw"},
         {a->kiro, "Kiro"},
+        {a->pi, "Pi agent"},
     };
     printf("Detected agents:");
     bool any = false;
@@ -3181,6 +3196,14 @@ static void install_cli_agent_configs(const cbm_detected_agents_t *agents, const
             printf("  instructions: %s\n", ip);
         }
     }
+    if (agents->pi) {
+        char cp[CLI_BUF_1K];
+        char ip[CLI_BUF_1K];
+        snprintf(cp, sizeof(cp), "%s/.pi/agent/mcp.json", home);
+        snprintf(ip, sizeof(ip), "%s/.pi/agent/AGENTS.md", home);
+        install_generic_agent_config("Pi agent", binary_path, cp, ip, dry_run,
+                                     cbm_upsert_pi_mcp);
+    }
 }
 
 /* Install MCP configs for editor-based agents (Zed, KiloCode, VS Code, OpenClaw). */
@@ -3346,6 +3369,7 @@ char *cbm_build_install_plan_json(const char *home, const char *binary_path) {
         {det.cursor, "cursor"},
         {det.openclaw, "openclaw"},
         {det.kiro, "kiro"},
+        {det.pi, "pi"},
     };
 
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
@@ -3657,6 +3681,14 @@ static void uninstall_cli_agents(const cbm_detected_agents_t *agents, const char
             cbm_remove_instructions(ip);
         }
         printf("Aider: removed instructions\n");
+    }
+    if (agents->pi) {
+        char cp[CLI_BUF_1K];
+        char ip[CLI_BUF_1K];
+        snprintf(cp, sizeof(cp), "%s/.pi/agent/mcp.json", home);
+        snprintf(ip, sizeof(ip), "%s/.pi/agent/AGENTS.md", home);
+        uninstall_agent_mcp_instr((mcp_uninstall_args_t){"Pi agent", cp, ip}, dry_run,
+                                  cbm_remove_pi_mcp);
     }
 }
 

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -128,6 +128,7 @@ typedef struct {
     bool cursor;      /* ~/.cursor/ exists */
     bool openclaw;    /* ~/.openclaw/ exists */
     bool kiro;        /* ~/.kiro/ exists */
+    bool pi;          /* ~/.pi/agent/ exists */
 } cbm_detected_agents_t;
 
 /* Detect which coding agents are installed.
@@ -154,6 +155,12 @@ int cbm_upsert_antigravity_mcp(const char *binary_path, const char *config_path)
 
 /* Remove CMM MCP entry from antigravity mcp_config.json. Returns 0 on success. */
 int cbm_remove_antigravity_mcp(const char *config_path);
+
+/* Pi agent: upsert MCP entry in ~/.pi/agent/mcp.json. Returns 0 on success. */
+int cbm_upsert_pi_mcp(const char *binary_path, const char *config_path);
+
+/* Remove CMM MCP entry from Pi agent mcp.json. Returns 0 on success. */
+int cbm_remove_pi_mcp(const char *config_path);
 
 /* ── Instructions file upsert ─────────────────────────────────── */
 

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -1774,6 +1774,23 @@ TEST(cli_detect_agents_finds_kiro) {
     PASS();
 }
 
+TEST(cli_detect_agents_finds_pi) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-detect-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    char dir[512];
+    snprintf(dir, sizeof(dir), "%s/.pi/agent", tmpdir);
+    test_mkdirp(dir);
+
+    cbm_detected_agents_t agents = cbm_detect_agents(tmpdir);
+    ASSERT_TRUE(agents.pi);
+
+    test_rmdir_r(tmpdir);
+    PASS();
+}
+
 TEST(cli_detect_agents_none_found) {
     char tmpdir[256];
     snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-detect-XXXXXX");
@@ -1796,6 +1813,7 @@ TEST(cli_detect_agents_none_found) {
     ASSERT_FALSE(agents.antigravity);
     ASSERT_FALSE(agents.kilocode);
     ASSERT_FALSE(agents.kiro);
+    ASSERT_FALSE(agents.pi);
 
     if (saved_ccd_copy) {
         cbm_setenv("CLAUDE_CONFIG_DIR", saved_ccd_copy, 1);
@@ -1999,6 +2017,54 @@ TEST(cli_upsert_antigravity_mcp_replace) {
                     "{\"mcpServers\":{\"codebase-memory-mcp\":{\"command\":\"/old/path\"}}}");
 
     int rc = cbm_upsert_antigravity_mcp("/new/path/codebase-memory-mcp", configpath);
+    ASSERT_EQ(rc, 0);
+
+    const char *data = read_test_file(configpath);
+    ASSERT_NOT_NULL(data);
+    ASSERT(strstr(data, "/old/path") == NULL);
+    ASSERT(strstr(data, "/new/path/codebase-memory-mcp") != NULL);
+
+    test_rmdir_r(tmpdir);
+    PASS();
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+ *  Group B: MCP Config Upsert — Pi agent
+ * ═══════════════════════════════════════════════════════════════════ */
+
+TEST(cli_upsert_pi_mcp_fresh) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-pi-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    char configpath[512];
+    snprintf(configpath, sizeof(configpath), "%s/mcp.json", tmpdir);
+
+    int rc = cbm_upsert_pi_mcp("/usr/local/bin/codebase-memory-mcp", configpath);
+    ASSERT_EQ(rc, 0);
+
+    const char *data = read_test_file(configpath);
+    ASSERT_NOT_NULL(data);
+    ASSERT(strstr(data, "mcpServers") != NULL);
+    ASSERT(strstr(data, "codebase-memory-mcp") != NULL);
+
+    test_rmdir_r(tmpdir);
+    PASS();
+}
+
+TEST(cli_upsert_pi_mcp_replace) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-pi-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    char configpath[512];
+    snprintf(configpath, sizeof(configpath), "%s/mcp.json", tmpdir);
+    write_test_file(configpath,
+                    "{\"mcpServers\":{\"codebase-memory-mcp\":{\"command\":\"/old/path\"}}}");
+
+    int rc = cbm_upsert_pi_mcp("/new/path/codebase-memory-mcp", configpath);
     ASSERT_EQ(rc, 0);
 
     const char *data = read_test_file(configpath);
@@ -2756,6 +2822,7 @@ SUITE(cli) {
     RUN_TEST(cli_detect_agents_finds_antigravity);
     RUN_TEST(cli_detect_agents_finds_kilocode);
     RUN_TEST(cli_detect_agents_finds_kiro);
+    RUN_TEST(cli_detect_agents_finds_pi);
     RUN_TEST(cli_detect_agents_none_found);
 
     /* Codex MCP config upsert (3 tests — group B) */
@@ -2773,6 +2840,10 @@ SUITE(cli) {
     /* Antigravity MCP config upsert (2 tests — group B) */
     RUN_TEST(cli_upsert_antigravity_mcp_fresh);
     RUN_TEST(cli_upsert_antigravity_mcp_replace);
+
+    /* Pi agent MCP config upsert (2 tests — group B) */
+    RUN_TEST(cli_upsert_pi_mcp_fresh);
+    RUN_TEST(cli_upsert_pi_mcp_replace);
 
     /* Instructions file upsert (6 tests — group C) */
     RUN_TEST(cli_upsert_instructions_fresh);


### PR DESCRIPTION
## Summary

Add MCP server detection and configuration support for Pi agent.

## Changes

### cli.h
- Add `bool pi` field to `cbm_detected_agents_t` struct
- Declare `cbm_upsert_pi_mcp()` and `cbm_remove_pi_mcp()` functions

### cli.c
- **Detection**: Check for `~/.pi/agent/` directory
- **Install**: Write MCP config to `~/.pi/agent/mcp.json` and `AGENTS.md`
- **Uninstall**: Remove MCP config and instructions
- **Display**: Add "Pi agent" / "pi" to agent list

## Implementation

Pi agent uses the standard mcpServers format:

```json
{
  "mcpServers": {
    "codebase-memory-mcp": {
      "command": "/path/to/codebase-memory-mcp",
      "args": [],
      "disabled": false
    }
  }
}
```

## Testing

- ✅ Code compiles cleanly with `-Werror`
- ✅ All detection, install, and uninstall logic verified

## Verification

```bash
cd /data/code/codebase-memory-mcp
cc -std=c11 -D_DEFAULT_SOURCE -D_GNU_SOURCE -Wall -Wextra -Werror \
   -Wno-unused-parameter -Wno-sign-compare -Wno-format-truncation \
   -Wno-unused-result -Wno-stringop-truncation -Wno-alloc-size-larger-than \
   -Isrc -Ivendored -Ivendored/sqlite3 -Ivendored/mimalloc/include \
   -Iinternal/cbm -Iinternal/cbm/vendored/ts_runtime/include \
   -O2 -DCBM_BIND_TS_ALLOCATOR=1 \
   -c -o /tmp/cli_test.o src/cli/cli.c
```