### PR TITLE
fix(build): rebuild lsp_all.o when its included headers change

### DIFF
--- a/Makefile.cbm
+++ b/Makefile.cbm
@@ -135,6 +135,18 @@ EXTRACTION_SRCS = \
 # LSP resolvers (compiled as one unit via lsp_all.c)
 LSP_SRCS = $(CBM_DIR)/lsp_all.c
 
+# Header/source dependencies of the lsp_all unity object. lsp_all.c #includes
+# every lsp/*.c resolver, which in turn include cbm.h — and CBMCall is copied
+# BY VALUE across the lsp -> pipeline boundary (cbm_calls_push). This object is
+# compiled standalone and linked in, NOT recompiled with the rest on every link,
+# so it must list the headers/sources it pulls in. Without this, a changed struct
+# layout (e.g. a new CBMCall field) leaves a stale lsp_all.o with the old layout —
+# an ODR mismatch that under-reads the by-value struct copy. Explicit because this
+# Makefile does not use compiler auto-dependency (-MMD) generation.
+LSP_UNITY_DEPS = $(CBM_DIR)/lsp_all.c \
+                 $(wildcard $(CBM_DIR)/lsp/*.c $(CBM_DIR)/lsp/*.h \
+                            $(CBM_DIR)/lsp/generated/*.c $(CBM_DIR)/*.h)
+
 # Tree-sitter runtime
 TS_RUNTIME_SRC = $(CBM_DIR)/ts_runtime.c
 
@@ -434,7 +446,7 @@ $(BUILD_DIR)/%.o: $(CBM_DIR)/%.c | $(BUILD_DIR)
 $(BUILD_DIR)/ts_runtime.o: $(CBM_DIR)/ts_runtime.c | $(BUILD_DIR)
 	$(CC) $(GRAMMAR_CFLAGS_TEST) -c -o $@ $<
 
-$(BUILD_DIR)/lsp_all.o: $(CBM_DIR)/lsp_all.c | $(BUILD_DIR)
+$(BUILD_DIR)/lsp_all.o: $(LSP_UNITY_DEPS) | $(BUILD_DIR)
 	$(CC) $(GRAMMAR_CFLAGS_TEST) $(SANITIZE) -c -o $@ $<
 
 $(BUILD_DIR)/preprocessor.o: $(CBM_DIR)/preprocessor.cpp | $(BUILD_DIR)
@@ -524,7 +536,7 @@ $(BUILD_DIR)/prod_%.o: $(CBM_DIR)/%.c | $(BUILD_DIR)
 $(BUILD_DIR)/prod_ts_runtime.o: $(CBM_DIR)/ts_runtime.c | $(BUILD_DIR)
 	$(CC) $(GRAMMAR_CFLAGS) -c -o $@ $<
 
-$(BUILD_DIR)/prod_lsp_all.o: $(CBM_DIR)/lsp_all.c | $(BUILD_DIR)
+$(BUILD_DIR)/prod_lsp_all.o: $(LSP_UNITY_DEPS) | $(BUILD_DIR)
 	$(CC) $(GRAMMAR_CFLAGS) -c -o $@ $<
 
 $(BUILD_DIR)/prod_preprocessor.o: $(CBM_DIR)/preprocessor.cpp | $(BUILD_DIR)


### PR DESCRIPTION
Fixes #661

### Problem
On an **incremental** build, `make` can link a **stale `lsp_all.o`**. ASan surfaces it as a stack-buffer-underflow during Rust-LSP tests:

```
ERROR: AddressSanitizer: stack-buffer-underflow ... in __interceptor_memcpy
  #1 cbm_calls_push internal/cbm/cbm.c:128
  #2 rust_inject_syn_call internal/cbm/lsp/rust_lsp.c:3366
  ...
  'call' (line 3363) <== Memory access at offset 0 partially underflows this variable
```

### Root cause
`lsp_all.o` is a unity object that `#include`s every `lsp/*.c` resolver; those include `cbm.h`, and `CBMCall` is copied **by value** across the lsp→pipeline boundary (`cbm_calls_push`). Its Make rule depended only on `lsp_all.c`, **not** on `cbm.h`. After `CBMCall` gained `bool is_method` (#477), incremental builds kept a stale `lsp_all.o` compiled against the old 304-byte layout, while the rest of the tree recompiled against the new 312-byte layout — an ODR mismatch, so the by-value struct copy under-reads the shorter stale struct.

Clean builds (CI) always recompile both sides together, so the layouts match and CI never sees it. It only bites incremental developer builds after the struct changed.

### Fix
Add an `LSP_UNITY_DEPS` prerequisite list (`lsp/*.c`, `lsp/*.h`, `lsp/generated/*.c`, `internal/cbm/*.h`) to both `lsp_all.o` and `prod_lsp_all.o`, so the unity object rebuilds when any included header or unity source changes. Wildcard-based, so new LSP resolvers (e.g. an added `perl_lsp.c`) are covered automatically. Explicit prerequisites rather than `-MMD` auto-deps, to match the Makefile's existing style.

### Verification
- `touch internal/cbm/cbm.h` → `lsp_all.o` now rebuilds (it didn't before); no-op rebuild is a clean no-op.
- Clean build + full ASan test suite green; `rustlsp_dbg_macro_inner_call` no longer aborts.