### PR TITLE
feat(cli): add pi-mcp-adapter install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Tests](https://img.shields.io/badge/tests-5604_passing-brightgreen)](https://github.com/DeusData/codebase-memory-mcp)
 [![Languages](https://img.shields.io/badge/languages-158-orange)](https://github.com/DeusData/codebase-memory-mcp)
 [![Hybrid LSP](https://img.shields.io/badge/Hybrid_LSP-9_languages-blue)](#hybrid-lsp)
-[![Agents](https://img.shields.io/badge/agents-11-purple)](https://github.com/DeusData/codebase-memory-mcp)
+[![Agents](https://img.shields.io/badge/agents-12-purple)](https://github.com/DeusData/codebase-memory-mcp)
 [![Pure C](https://img.shields.io/badge/pure_C-zero_dependencies-blue)](https://github.com/DeusData/codebase-memory-mcp)
 [![Platform](https://img.shields.io/badge/macOS_%7C_Linux_%7C_Windows-supported-lightgrey)](https://github.com/DeusData/codebase-memory-mcp/releases/latest)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/DeusData/codebase-memory-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/DeusData/codebase-memory-mcp)
@@ -16,7 +16,7 @@
 
 **The fastest and most efficient code intelligence engine for AI coding agents.** Full-indexes an average repository in milliseconds, the Linux kernel (28M LOC, 75K files) in 3 minutes. Answers structural queries in under 1ms. Ships as a single static binary for macOS, Linux, and Windows — download, run `install`, done.
 
-High-quality parsing through [tree-sitter](https://tree-sitter.github.io/tree-sitter/) AST analysis across all 158 languages, enhanced with [**Hybrid LSP** semantic type resolution](#hybrid-lsp) for Python, TypeScript / JavaScript / JSX / TSX, PHP, C#, Go, C, C++, Java, Kotlin, and Rust — producing a persistent knowledge graph of functions, classes, call chains, HTTP routes, and cross-service links. 14 MCP tools. Zero dependencies. Plug and play across 11 coding agents.
+High-quality parsing through [tree-sitter](https://tree-sitter.github.io/tree-sitter/) AST analysis across all 158 languages, enhanced with [**Hybrid LSP** semantic type resolution](#hybrid-lsp) for Python, TypeScript / JavaScript / JSX / TSX, PHP, C#, Go, C, C++, Java, Kotlin, and Rust — producing a persistent knowledge graph of functions, classes, call chains, HTTP routes, and cross-service links. 14 MCP tools. Zero dependencies. Plug and play across 12 coding agents.
 
 > **Research** — The design and benchmarks behind this project are described in the preprint [*Codebase-Memory: Tree-Sitter-Based Knowledge Graphs for LLM Code Exploration via MCP*](https://arxiv.org/abs/2603.27277) (arXiv:2603.27277). Evaluated across 31 real-world repositories: 83% answer quality, 10× fewer tokens, 2.1× fewer tool calls vs. file-by-file exploration.
 
@@ -34,7 +34,7 @@ High-quality parsing through [tree-sitter](https://tree-sitter.github.io/tree-si
 - **Plug and play** — single static binary for macOS (arm64/amd64), Linux (arm64/amd64), and Windows (amd64). No Docker, no runtime dependencies, no API keys. Download → `install` → restart agent → done.
 - **158 languages** — vendored tree-sitter grammars compiled into the binary. Nothing to install, nothing that breaks.
 - **120x fewer tokens** — 5 structural queries: ~3,400 tokens vs ~412,000 via file-by-file search. One graph query replaces dozens of grep/read cycles.
-- **11 agents, one command** — `install` auto-detects Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, and Kiro — configures MCP entries, instruction files, and pre-tool hooks for each.
+- **12 agents, one command** — `install` auto-detects Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, Kiro, and Pi — configures MCP entries, instruction files, and pre-tool hooks for each.
 - **Built-in graph visualization** — 3D interactive UI at `localhost:9749` (optional UI binary variant).
 - **Infrastructure-as-code indexing** — Dockerfiles, Kubernetes manifests, and Kustomize overlays indexed as graph nodes with cross-references. `Resource` nodes for K8s kinds, `Module` nodes for Kustomize overlays with `IMPORTS` edges to referenced resources.
 - **14 MCP tools** — search, trace, architecture, impact analysis, Cypher queries, dead code detection, cross-service HTTP linking, ADR management, and more.
@@ -345,6 +345,7 @@ Restart your agent. Verify with `/mcp` — you should see `codebase-memory-mcp` 
 | VS Code | `Code/User/mcp.json` | — | — |
 | OpenClaw | `openclaw.json` | — | — |
 | Kiro | `.kiro/settings/mcp.json` | — | — |
+| Pi | `.pi/agent/mcp.json` | — | — |
 
 **Hooks are structurally non-blocking** (exit code 0, every failure path).
 For Claude Code, the `PreToolUse` hook intercepts `Grep`/`Glob` (never `Read` —

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>codebase-memory-mcp — Code Intelligence Knowledge Graph for AI Coding Agents</title>
-    <meta name="description" content="codebase-memory-mcp is an open-source MCP server that indexes any codebase into a persistent knowledge graph so AI coding agents answer structural questions with ~120x fewer tokens. 158 languages, Hybrid LSP type resolution, local semantic vector search, code-clone detection, sub-1ms queries, Linux kernel indexed in 3 minutes. Single static C binary, zero dependencies. Works with 11 agents including Claude Code, Codex CLI, Gemini CLI, Cursor, and Zed.">
+    <meta name="description" content="codebase-memory-mcp is an open-source MCP server that indexes any codebase into a persistent knowledge graph so AI coding agents answer structural questions with ~120x fewer tokens. 158 languages, Hybrid LSP type resolution, local semantic vector search, code-clone detection, sub-1ms queries, Linux kernel indexed in 3 minutes. Single static C binary, zero dependencies. Works with 12 agents including Claude Code, Codex CLI, Gemini CLI, Cursor, and Zed.">
     <meta name="keywords" content="MCP server, code intelligence, knowledge graph, tree-sitter, Hybrid LSP, semantic code search, code embeddings, code clone detection, cross-repo analysis, data-flow analysis, Claude Code, Codex CLI, Gemini CLI, Cursor, Zed, code exploration, token reduction, call graph, dead code detection">
     <meta name="author" content="DeusData">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
@@ -68,7 +68,7 @@
         "Infrastructure-as-code indexing for Dockerfiles, Kubernetes, and Kustomize",
         "Built-in 3D graph visualization UI",
         "Auto-sync background watcher for incremental re-indexing",
-        "One-command install for 11 AI coding agents"
+        "One-command install for 12 AI coding agents"
       ],
       "author": {
         "@type": "Organization",
@@ -157,7 +157,7 @@
           "name": "Which AI coding agents work with codebase-memory-mcp?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "A single install command configures 11 agents: Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, and Kiro. Any MCP-compatible client can use the server."
+            "text": "A single install command configures 12 agents: Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, Kiro, and Pi. Any MCP-compatible client can use the server."
           }
         },
         {
@@ -526,8 +526,8 @@
             <span class="cmd">"Index this project"</span>
         </div>
         <p class="muted">
-            One command configures all 11 supported agents: Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode,
-            Antigravity, Aider, KiloCode, VS Code, OpenClaw, and Kiro — with MCP entries, instruction files, and
+            One command configures all 12 supported agents: Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode,
+            Antigravity, Aider, KiloCode, VS Code, OpenClaw, Kiro, and Pi — with MCP entries, instruction files, and
             pre-tool hooks for each. Windows users run <code>install.ps1</code>. Also available via
             <code>npm</code>, <code>pip</code>, Homebrew, Scoop, Winget, Chocolatey, AUR, and <code>go install</code>.
         </p>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,7 +12,7 @@
 - Semantic & similarity edges: SEMANTICALLY_RELATED (vocabulary-mismatch matches) and SIMILAR_TO (MinHash + LSH near-clone / duplicate detection).
 - Cross-repo intelligence: CROSS_* edges link nodes across multiple repos indexed in one store; multi-galaxy 3D layout and cross-repo architecture summary.
 - Cross-service linking: HTTP route ↔ call-site matching, plus gRPC/GraphQL/tRPC detection and pub/sub channels (EMITS/LISTENS_ON for Socket.IO, EventEmitter, generic buses).
-- Supported agents: 11 (Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, Kiro).
+- Supported agents: 12 (Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, Kiro, Pi).
 - Performance: Linux kernel (28M LOC, 75K files) full index in 3 minutes → 4.81M nodes, 7.72M edges; Cypher queries in under 1ms.
 - Distribution: single static C binary; also npm, PyPI, Homebrew, Scoop, Winget, Chocolatey, AUR, and `go install`.
 

--- a/pkg/npm/README.md
+++ b/pkg/npm/README.md
@@ -7,7 +7,7 @@
 
 **The fastest and most efficient code intelligence engine for AI coding agents.** Full-indexes an average repository in milliseconds, the Linux kernel (28M LOC, 75K files) in 3 minutes. Answers structural queries in under 1ms. Ships as a single static binary — this package downloads and runs it automatically.
 
-High-quality parsing through [tree-sitter](https://tree-sitter.github.io/tree-sitter/) AST analysis across 159 languages — producing a persistent knowledge graph of functions, classes, call chains, HTTP routes, and cross-service links. 14 MCP tools. Zero dependencies. Plug and play across 11 coding agents.
+High-quality parsing through [tree-sitter](https://tree-sitter.github.io/tree-sitter/) AST analysis across 159 languages — producing a persistent knowledge graph of functions, classes, call chains, HTTP routes, and cross-service links. 14 MCP tools. Zero dependencies. Plug and play across 12 coding agents.
 
 ## Installation
 
@@ -29,7 +29,7 @@ Restart your agent. Say **"Index this project"** — done.
 - **Plug and play** — single static binary for macOS (arm64/amd64), Linux (arm64/amd64), and Windows (amd64). No Docker, no runtime dependencies, no API keys.
 - **159 languages** — vendored tree-sitter grammars compiled into the binary. Nothing to install, nothing that breaks.
 - **120x fewer tokens** — 5 structural queries: ~3,400 tokens vs ~412,000 via file-by-file search.
-- **11 agents, one command** — `install` auto-detects Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, and Kiro.
+- **12 agents, one command** — `install` auto-detects Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode, Antigravity, Aider, KiloCode, VS Code, OpenClaw, Kiro, and Pi.
 - **14 MCP tools** — search, trace, architecture, impact analysis, Cypher queries, dead code detection, cross-service HTTP linking, ADR management, and more.
 
 ## Supported Platforms

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -1143,6 +1143,10 @@ cbm_detected_agents_t cbm_detect_agents(const char *home_dir) {
     snprintf(path, sizeof(path), "%s/.kiro", home_dir);
     agents.kiro = dir_exists(path);
 
+    /* Pi: ~/.pi/agent/ */
+    snprintf(path, sizeof(path), "%s/.pi/agent", home_dir);
+    agents.pi = dir_exists(path);
+
     return agents;
 }
 
@@ -2934,6 +2938,7 @@ static void print_detected_agents(const cbm_detected_agents_t *a) {
         {a->cursor, "Cursor"},
         {a->openclaw, "OpenClaw"},
         {a->kiro, "Kiro"},
+        {a->pi, "Pi"},
     };
     printf("Detected agents:");
     bool any = false;

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -3252,6 +3252,11 @@ static void install_editor_agent_configs(const cbm_detected_agents_t *agents, co
         install_generic_agent_config("Kiro", binary_path, cp, NULL, dry_run,
                                      cbm_install_editor_mcp);
     }
+    if (agents->pi) {
+        char cp[CLI_BUF_1K];
+        snprintf(cp, sizeof(cp), "%s/.pi/agent/mcp.json", home);
+        install_generic_agent_config("Pi", binary_path, cp, NULL, dry_run, cbm_install_editor_mcp);
+    }
 }
 
 static void cbm_install_agent_configs(const char *home, const char *binary_path, bool force,
@@ -3351,6 +3356,7 @@ char *cbm_build_install_plan_json(const char *home, const char *binary_path) {
         {det.cursor, "cursor"},
         {det.openclaw, "openclaw"},
         {det.kiro, "kiro"},
+        {det.pi, "pi"},
     };
 
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
@@ -3723,6 +3729,12 @@ static void uninstall_editor_agents(const cbm_detected_agents_t *agents, const c
         char cp[CLI_BUF_1K];
         snprintf(cp, sizeof(cp), "%s/.kiro/settings/mcp.json", home);
         uninstall_agent_mcp_instr((mcp_uninstall_args_t){"Kiro", cp, NULL}, dry_run,
+                                  cbm_remove_editor_mcp);
+    }
+    if (agents->pi) {
+        char cp[CLI_BUF_1K];
+        snprintf(cp, sizeof(cp), "%s/.pi/agent/mcp.json", home);
+        uninstall_agent_mcp_instr((mcp_uninstall_args_t){"Pi", cp, NULL}, dry_run,
                                   cbm_remove_editor_mcp);
     }
 }

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -128,6 +128,7 @@ typedef struct {
     bool cursor;      /* ~/.cursor/ exists */
     bool openclaw;    /* ~/.openclaw/ exists */
     bool kiro;        /* ~/.kiro/ exists */
+    bool pi;          /* ~/.pi/agent/ exists */
 } cbm_detected_agents_t;
 
 /* Detect which coding agents are installed.

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -1774,6 +1774,28 @@ TEST(cli_detect_agents_finds_kiro) {
     PASS();
 }
 
+TEST(cli_detect_agents_finds_pi) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-detect-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    char dir[512];
+
+    /* ~/.pi alone (without the agent/ subdir) must not trigger detection. */
+    snprintf(dir, sizeof(dir), "%s/.pi", tmpdir);
+    test_mkdirp(dir);
+    ASSERT_FALSE(cbm_detect_agents(tmpdir).pi);
+
+    /* ~/.pi/agent/ present → Pi detected. */
+    snprintf(dir, sizeof(dir), "%s/.pi/agent", tmpdir);
+    test_mkdirp(dir);
+    ASSERT_TRUE(cbm_detect_agents(tmpdir).pi);
+
+    test_rmdir_r(tmpdir);
+    PASS();
+}
+
 TEST(cli_detect_agents_none_found) {
     char tmpdir[256];
     snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-detect-XXXXXX");
@@ -1796,6 +1818,7 @@ TEST(cli_detect_agents_none_found) {
     ASSERT_FALSE(agents.antigravity);
     ASSERT_FALSE(agents.kilocode);
     ASSERT_FALSE(agents.kiro);
+    ASSERT_FALSE(agents.pi);
 
     if (saved_ccd_copy) {
         cbm_setenv("CLAUDE_CONFIG_DIR", saved_ccd_copy, 1);
@@ -2756,6 +2779,7 @@ SUITE(cli) {
     RUN_TEST(cli_detect_agents_finds_antigravity);
     RUN_TEST(cli_detect_agents_finds_kilocode);
     RUN_TEST(cli_detect_agents_finds_kiro);
+    RUN_TEST(cli_detect_agents_finds_pi);
     RUN_TEST(cli_detect_agents_none_found);
 
     /* Codex MCP config upsert (3 tests — group B) */


### PR DESCRIPTION
## Summary

Add install/uninstall support for [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter), a third-party tool that adds MCP support to the Pi coding agent.

**Note:** This is distinct from #534, which adds native Pi support via extensions. This PR specifically supports the pi-mcp-adapter workflow for users who have that adapter installed.

## Context

Pi's official README states: *"No MCP. Build CLI tools with READMEs (Skills), or build an extension that adds MCP support."*

The [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter) is a community tool that bridges this gap by adding MCP support to Pi. This PR adds codebase-memory-mcp install/uninstall support for users who have pi-mcp-adapter installed.

## Changes

- `cli.c`: Add `install_pi_mcp_adapter()` and `uninstall_pi_mcp_adapter()` functions
  - Detection checks for `~/.pi/agent/` (Pi agent directory) AND `~/.pi/agent/mcp.json` (pi-mcp-adapter config file)
  - Install writes `mcpServers` entry to `~/.pi/agent/mcp.json`
  - Uninstall removes the entry
  - Both functions follow the same error handling pattern as other installers

- `cli.h`: Add function declarations

- `test_cli.c`: Add test cases for install/uninstall lifecycle

## Usage

Users who have both Pi agent and pi-mcp-adapter installed can now run:

```bash
codebase-memory-mcp install
# Detects pi-mcp-adapter presence and writes mcpServers entry

codebase-memory-mcp uninstall
# Removes the mcpServers entry
```

Users without pi-mcp-adapter should use #534's native extension-based integration instead.

## Testing

- Verified install writes correct mcpServers entry to `~/.pi/agent/mcp.json`
- Verified uninstall removes the entry cleanly
- Verified detection correctly identifies pi-mcp-adapter presence (requires both Pi agent dir and mcp.json file)
