### PR TITLE
fix(smoke): de-flake 10c by corrupting the signature instead of removing it

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1208,33 +1208,37 @@ if [ "$(uname -s)" = "Darwin" ]; then
   BIN_ARCH=$(file "$SECURITY_BIN" | grep -o 'arm64\|x86_64' | head -1)
 
   if [ "$BIN_ARCH" = "arm64" ]; then
-    # arm64: a SIGNED binary whose CODE has been tampered (CodeDirectory hash mismatch) must be
-    # SIGKILLed (exit 137 = 128+9) by AMFI before user code runs. Neither `codesign
-    # --remove-signature` nor garbling the signature blob triggers this — since macOS 11 a binary
-    # with a missing/invalid signature is ad-hoc re-signed on exec by newer macOS and RUNS (exit 0),
-    # which made this test flaky then consistently red on updated CI runner images. The reliable
-    # trigger is tampering the signed CODE while leaving the valid signature attached: the kernel
-    # validates the executed page against the (intact) CodeDirectory hash, finds the mismatch, and
-    # kills the process. Done on a SEPARATE copy so the original $SECURITY_BIN stays intact for the
-    # 10e re-sign test. Refs: github.com/garrytan/gstack#997, github.com/nodejs/node#40827.
+    # arm64 integrity check: tampering the signed code must be DETECTED by the code signature.
+    # The original check (run a tampered/unsigned binary and expect SIGKILL 137) is NOT deterministic
+    # on current macOS for an ad-hoc-signed CLI binary, which is why this test went flaky then red.
+    # Observed on CI:
+    #   - `codesign --remove-signature` then run -> macOS 11+ ad-hoc re-signs on exec and RUNS (exit 0)
+    #   - garbling only the signature blob then run -> same, re-signed/ignored (exit 0)
+    #   - tampering the code then run -> with no CS_KILL/hardened-runtime flag the kernel does NOT
+    #     kill the page; it executes the garbage and crashes with SIGILL (exit 132), not 137
+    # (runs 28350650225 / 28354735368 / 28360363173 / 28365724001). The deterministic, meaningful
+    # invariant is that `codesign --verify` REJECTS a tampered binary -- the CodeDirectory page hashes
+    # no longer match the modified code -- while the untampered binary verifies cleanly (10a above).
+    # This is a pure userspace hash check (no tampered code is ever executed). Done on a SEPARATE copy
+    # so the original $SECURITY_BIN stays intact for the 10e re-sign test.
+    # Refs: github.com/garrytan/gstack#997, github.com/nodejs/node#40827.
     TAMPER_BIN="${SECURITY_BIN}.tampered"
     cp "$SECURITY_BIN" "$TAMPER_BIN"
-    # Zero the entry-point instructions (LC_MAIN entryoff = start of __text) plus a span of early
-    # __text, leaving the Mach-O header + load commands (offset 0..entryoff) intact so the binary
-    # still parses. The tampered code pages no longer match their CodeDirectory hashes -> SIGKILL.
+    # Tamper signed code: zero the entry-point instructions (LC_MAIN entryoff = start of __text) plus
+    # a span of early __text, leaving the Mach-O header + load commands + signature blob intact so the
+    # file still parses and still carries its now-stale signature for --verify to reject.
     ENTRY_OFF=$(otool -l "$SECURITY_BIN" 2>/dev/null | awk '/LC_MAIN/{f=1} f&&/entryoff/{print $2; exit}')
     ENTRY_OFF=${ENTRY_OFF:-2184}
     dd if=/dev/zero of="$TAMPER_BIN" bs=1 seek="$ENTRY_OFF" count=4096 conv=notrunc 2>/dev/null
     dd if=/dev/zero of="$TAMPER_BIN" bs=4096 seek=4 count=512 conv=notrunc 2>/dev/null
-    UNSIGNED_EXIT=0
-    "$TAMPER_BIN" --version > /dev/null 2>&1 || UNSIGNED_EXIT=$?
-    rm -f "$TAMPER_BIN"
-    if [ "$UNSIGNED_EXIT" -eq 137 ] || [ "$UNSIGNED_EXIT" -eq 9 ]; then
-      echo "OK 10c: tampered-code arm64 binary killed (exit $UNSIGNED_EXIT)"
-    else
-      echo "FAIL 10c: tampered-code arm64 exit=$UNSIGNED_EXIT (expected 137)"
+    if codesign --verify "$TAMPER_BIN" 2>/dev/null; then
+      echo "FAIL 10c: codesign --verify ACCEPTED a tampered arm64 binary (integrity check broken)"
+      rm -f "$TAMPER_BIN"
       exit 1
+    else
+      echo "OK 10c: codesign --verify rejected tampered arm64 binary"
     fi
+    rm -f "$TAMPER_BIN"
   else
     # x86_64: signing is not enforced; an unsigned binary should still run
     codesign --remove-signature "$SECURITY_BIN" 2>/dev/null || true

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1204,23 +1204,35 @@ if [ "$(uname -s)" = "Darwin" ]; then
     exit 1
   fi
 
-  codesign --remove-signature "$SECURITY_BIN" 2>/dev/null || true
-
   # Detect binary architecture (not shell arch — Rosetta reports x86_64 for arm64 binaries)
   BIN_ARCH=$(file "$SECURITY_BIN" | grep -o 'arm64\|x86_64' | head -1)
 
   if [ "$BIN_ARCH" = "arm64" ]; then
-    # arm64: unsigned must SIGKILL (exit 137 = 128+9)
+    # arm64: a binary whose code signature is INVALID must SIGKILL (exit 137 = 128+9).
+    # We CORRUPT the signature blob in place instead of `codesign --remove-signature`: since macOS
+    # 11, a binary with NO LC_CODE_SIGNATURE is ad-hoc re-signed on exec by newer macOS and RUNS
+    # (exit 0) — that made this test flaky, then consistently red on updated CI runner images.
+    # Leaving the LC_CODE_SIGNATURE load command intact but garbling its blob makes AMFI see
+    # "signed but invalid" and reject it before any user code runs (deterministic). Corrupting only
+    # the signature blob (not the code) keeps the later 10e re-sign valid — it replaces the blob and
+    # the code is untouched. Refs: github.com/garrytan/gstack#997, nodejs/node#40827.
+    SIG_OFF=$(otool -l "$SECURITY_BIN" 2>/dev/null | awk '/LC_CODE_SIGNATURE/{f=1} f&&/dataoff/{print $2; exit}')
+    if [ -n "$SIG_OFF" ]; then
+      head -c 1024 /dev/urandom | dd of="$SECURITY_BIN" bs=1 seek="$((SIG_OFF + 8))" count=1024 conv=notrunc 2>/dev/null
+    else
+      codesign --remove-signature "$SECURITY_BIN" 2>/dev/null || true
+    fi
     UNSIGNED_EXIT=0
     "$SECURITY_BIN" --version > /dev/null 2>&1 || UNSIGNED_EXIT=$?
     if [ "$UNSIGNED_EXIT" -eq 137 ] || [ "$UNSIGNED_EXIT" -eq 9 ]; then
-      echo "OK 10c: unsigned arm64 binary killed (exit $UNSIGNED_EXIT)"
+      echo "OK 10c: invalid-signature arm64 binary killed (exit $UNSIGNED_EXIT)"
     else
-      echo "FAIL 10c: unsigned arm64 exit=$UNSIGNED_EXIT (expected 137)"
+      echo "FAIL 10c: invalid-signature arm64 exit=$UNSIGNED_EXIT (expected 137)"
       exit 1
     fi
   else
-    # x86_64: unsigned should still run
+    # x86_64: signing is not enforced; an unsigned binary should still run
+    codesign --remove-signature "$SECURITY_BIN" 2>/dev/null || true
     if "$SECURITY_BIN" --version > /dev/null 2>&1; then
       echo "OK 10c: unsigned x86_64 binary runs (no signing required)"
     else

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1208,26 +1208,31 @@ if [ "$(uname -s)" = "Darwin" ]; then
   BIN_ARCH=$(file "$SECURITY_BIN" | grep -o 'arm64\|x86_64' | head -1)
 
   if [ "$BIN_ARCH" = "arm64" ]; then
-    # arm64: a binary whose code signature is INVALID must SIGKILL (exit 137 = 128+9).
-    # We CORRUPT the signature blob in place instead of `codesign --remove-signature`: since macOS
-    # 11, a binary with NO LC_CODE_SIGNATURE is ad-hoc re-signed on exec by newer macOS and RUNS
-    # (exit 0) — that made this test flaky, then consistently red on updated CI runner images.
-    # Leaving the LC_CODE_SIGNATURE load command intact but garbling its blob makes AMFI see
-    # "signed but invalid" and reject it before any user code runs (deterministic). Corrupting only
-    # the signature blob (not the code) keeps the later 10e re-sign valid — it replaces the blob and
-    # the code is untouched. Refs: github.com/garrytan/gstack#997, nodejs/node#40827.
-    SIG_OFF=$(otool -l "$SECURITY_BIN" 2>/dev/null | awk '/LC_CODE_SIGNATURE/{f=1} f&&/dataoff/{print $2; exit}')
-    if [ -n "$SIG_OFF" ]; then
-      head -c 1024 /dev/urandom | dd of="$SECURITY_BIN" bs=1 seek="$((SIG_OFF + 8))" count=1024 conv=notrunc 2>/dev/null
-    else
-      codesign --remove-signature "$SECURITY_BIN" 2>/dev/null || true
-    fi
+    # arm64: a SIGNED binary whose CODE has been tampered (CodeDirectory hash mismatch) must be
+    # SIGKILLed (exit 137 = 128+9) by AMFI before user code runs. Neither `codesign
+    # --remove-signature` nor garbling the signature blob triggers this — since macOS 11 a binary
+    # with a missing/invalid signature is ad-hoc re-signed on exec by newer macOS and RUNS (exit 0),
+    # which made this test flaky then consistently red on updated CI runner images. The reliable
+    # trigger is tampering the signed CODE while leaving the valid signature attached: the kernel
+    # validates the executed page against the (intact) CodeDirectory hash, finds the mismatch, and
+    # kills the process. Done on a SEPARATE copy so the original $SECURITY_BIN stays intact for the
+    # 10e re-sign test. Refs: github.com/garrytan/gstack#997, github.com/nodejs/node#40827.
+    TAMPER_BIN="${SECURITY_BIN}.tampered"
+    cp "$SECURITY_BIN" "$TAMPER_BIN"
+    # Zero the entry-point instructions (LC_MAIN entryoff = start of __text) plus a span of early
+    # __text, leaving the Mach-O header + load commands (offset 0..entryoff) intact so the binary
+    # still parses. The tampered code pages no longer match their CodeDirectory hashes -> SIGKILL.
+    ENTRY_OFF=$(otool -l "$SECURITY_BIN" 2>/dev/null | awk '/LC_MAIN/{f=1} f&&/entryoff/{print $2; exit}')
+    ENTRY_OFF=${ENTRY_OFF:-2184}
+    dd if=/dev/zero of="$TAMPER_BIN" bs=1 seek="$ENTRY_OFF" count=4096 conv=notrunc 2>/dev/null
+    dd if=/dev/zero of="$TAMPER_BIN" bs=4096 seek=4 count=512 conv=notrunc 2>/dev/null
     UNSIGNED_EXIT=0
-    "$SECURITY_BIN" --version > /dev/null 2>&1 || UNSIGNED_EXIT=$?
+    "$TAMPER_BIN" --version > /dev/null 2>&1 || UNSIGNED_EXIT=$?
+    rm -f "$TAMPER_BIN"
     if [ "$UNSIGNED_EXIT" -eq 137 ] || [ "$UNSIGNED_EXIT" -eq 9 ]; then
-      echo "OK 10c: invalid-signature arm64 binary killed (exit $UNSIGNED_EXIT)"
+      echo "OK 10c: tampered-code arm64 binary killed (exit $UNSIGNED_EXIT)"
     else
-      echo "FAIL 10c: invalid-signature arm64 exit=$UNSIGNED_EXIT (expected 137)"
+      echo "FAIL 10c: tampered-code arm64 exit=$UNSIGNED_EXIT (expected 137)"
       exit 1
     fi
   else


### PR DESCRIPTION
De-flakes smoke test **10c** (Phase 10 binary security E2E).

**Root cause:** the test's premise — "a tampered/unsigned arm64 binary is SIGKILLed (exit 137)" — is *empirically false* on current macOS CI runners for an **ad-hoc-signed CLI binary**. The cbm binary has no `CS_KILL`/hardened-runtime flag, so the kernel does not kill a bad page at runtime. Observed across four dry-runs:

| Tamper method | Run | Result |
|---|---|---|
| `codesign --remove-signature` then run | `28350650225`, `28354735368` | **exit 0** (macOS 11+ ad-hoc re-signs on exec) |
| corrupt signature blob then run | `28360363173` | **exit 0** (re-signed/ignored) |
| tamper code then run | `28365724001` | **exit 132** (SIGILL — executes the garbage, not killed) |

So **no runtime exit code is a deterministic guard** here, and "tamper → crash" is near-tautological (zeroed code crashes regardless of signing).

**Fix:** assert the real, deterministic integrity invariant — **`codesign --verify` rejects a tampered copy** (the CodeDirectory page hashes no longer match the modified code), while the untampered binary verifies cleanly (10a above). It's a pure userspace hash check; **no tampered code is ever executed**. Tampering is done on a **separate copy** (`$SECURITY_BIN.tampered`), so the original is untouched and the **10e re-sign** step stays valid. x86_64 unchanged.

This is neither a skip nor a weakening — it replaces a false runtime premise with the actual security property the test exists to verify (the signature detects tampering). Unrelated to the seal fix (#677). Verified via a full dry-run on this branch.

Refs: [garrytan/gstack#997](https://github.com/garrytan/gstack/issues/997), [nodejs/node#40827](https://github.com/nodejs/node/issues/40827)
