### PR TITLE
fix(store): open query stores READONLY so queries never mutate dbs

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -4685,12 +4685,33 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
     /* ADRs are stored in the SQLite store (project_summaries), the SAME
      * backend the UI /api/adr endpoints use — so writes via the MCP tool and
      * the UI are visible to each other (#256). */
-    cbm_store_t *store = resolve_store(srv, project);
-    if (!store) {
+    cbm_store_t *resolved = resolve_store(srv, project);
+    if (!resolved) {
         free(project);
         free(mode_str);
         free(content);
         return cbm_mcp_text_result("project not found", true);
+    }
+
+    /* resolve_store opens file-backed projects READ-ONLY (query stores must
+     * not mutate the DB). manage_adr is the only resolve_store caller that
+     * WRITES, so it needs a writable handle. For a file-backed project open a
+     * dedicated read-write handle to the same DB file (the project is verified
+     * to exist via resolve_store, so cbm_store_open_path won't create a ghost
+     * DB). For an in-memory / embedded store (db_path == NULL) the resolved
+     * store is already writable — use it directly. */
+    cbm_store_t *store = resolved;
+    cbm_store_t *owned_rw = NULL;
+    const char *resolved_db_path = cbm_store_db_path(resolved);
+    if (resolved_db_path) {
+        owned_rw = cbm_store_open_path(resolved_db_path);
+        if (!owned_rw) {
+            free(project);
+            free(mode_str);
+            free(content);
+            return cbm_mcp_text_result("project not found", true);
+        }
+        store = owned_rw;
     }
 
     /* One-time migration: older versions wrote ADRs to a file at
@@ -4739,6 +4760,9 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
     yyjson_mut_doc_free(doc);
     if (have_adr) {
         cbm_store_adr_free(&adr);
+    }
+    if (owned_rw) {
+        cbm_store_close(owned_rw);
     }
     free(project);
     free(mode_str);

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -26,6 +26,10 @@ enum {
     ST_FOUND = -1,
     ST_BUF_16 = 16,
     ST_BUF_64 = 64,
+    /* file: URI for the immutable read-only fallback. A path is at most
+     * CBM_SZ_1K; percent-encoding can triple it, plus the "file://" prefix,
+     * the "?immutable=1" suffix and a leading '/'. */
+    ST_QUERY_URI_MAX = 3 * 1024 + 64,
     ST_GROWTH = 2,
     ST_MAX_DEGREE = 8192,
     ST_HALF_SEC = 500000,
@@ -322,7 +326,16 @@ int64_t cbm_store_resolve_mmap_size(void) {
     return (int64_t)parsed;
 }
 
-static int configure_pragmas(cbm_store_t *s, bool in_memory) {
+/* Configure connection pragmas.
+ *   in_memory  — :memory: DB (synchronous OFF, no journal file).
+ *   read_only  — query-only connection opened SQLITE_OPEN_READONLY. Runs
+ *                ONLY non-writing pragmas (foreign_keys, temp_store,
+ *                busy_timeout, mmap_size) and SKIPS journal_mode=WAL,
+ *                wal_checkpoint and synchronous — those WRITE to the DB/WAL
+ *                and would (a) mutate the DB on every read query and (b)
+ *                fail on a read-only DB file / filesystem.
+ * in_memory and read_only are mutually exclusive. */
+static int configure_pragmas(cbm_store_t *s, bool in_memory, bool read_only) {
     int rc;
     rc = exec_sql(s, "PRAGMA foreign_keys = ON;");
     if (rc != CBM_STORE_OK) {
@@ -335,6 +348,16 @@ static int configure_pragmas(cbm_store_t *s, bool in_memory) {
 
     if (in_memory) {
         rc = exec_sql(s, "PRAGMA synchronous = OFF;");
+    } else if (read_only) {
+        /* Non-writing pragmas only — see the function comment. */
+        rc = exec_sql(s, "PRAGMA busy_timeout = 10000;");
+        if (rc != CBM_STORE_OK) {
+            return rc;
+        }
+        char mmap_sql[ST_BUF_64];
+        snprintf(mmap_sql, sizeof(mmap_sql), "PRAGMA mmap_size = %lld;",
+                 (long long)cbm_store_resolve_mmap_size());
+        rc = exec_sql(s, mmap_sql);
     } else {
         rc = exec_sql(s, "PRAGMA busy_timeout = 10000;");
         if (rc != CBM_STORE_OK) {
@@ -593,7 +616,7 @@ static cbm_store_t *store_open_internal(const char *path, bool in_memory) {
     sqlite3_create_function(s->db, "cbm_camel_split", SKIP_ONE, SQLITE_UTF8 | SQLITE_DETERMINISTIC,
                             NULL, sqlite_camel_split, NULL, NULL);
 
-    if (configure_pragmas(s, in_memory) != CBM_STORE_OK || init_schema(s) != CBM_STORE_OK ||
+    if (configure_pragmas(s, in_memory, false) != CBM_STORE_OK || init_schema(s) != CBM_STORE_OK ||
         create_user_indexes(s) != CBM_STORE_OK) {
         sqlite3_close(s->db);
         safe_str_free(&s->db_path);
@@ -615,6 +638,69 @@ cbm_store_t *cbm_store_open_path(const char *db_path) {
     return store_open_internal(db_path, false);
 }
 
+const char *cbm_store_db_path(const cbm_store_t *s) {
+    return s ? s->db_path : NULL;
+}
+
+/* Build a SQLite "file:" URI with immutable=1 from a filesystem path.
+ * immutable=1 bypasses WAL and locking and reads the main DB file directly —
+ * used only as a fallback for read-only filesystems where the wal-index
+ * (-shm) cannot be created. URI-special characters are percent-encoded.
+ * Windows backslashes are normalized to '/', and a leading '/' is inserted
+ * for drive-letter paths so the drive is not parsed as a URI authority.
+ * Returns false if the output buffer is too small. */
+static bool build_immutable_uri(const char *path, char *out, size_t out_sz) {
+    static const char PREFIX[] = "file://";
+    static const char SUFFIX[] = "?immutable=1";
+    static const char HEX[] = "0123456789ABCDEF";
+    size_t prefix_len = sizeof(PREFIX) - 1;
+    size_t suffix_len = sizeof(SUFFIX) - 1;
+    if (prefix_len + 1 > out_sz) {
+        return false;
+    }
+    memcpy(out, PREFIX, prefix_len);
+    size_t pos = prefix_len;
+
+    /* Ensure the path component begins with '/' (POSIX absolute paths already
+     * do; Windows "C:\..." gets a leading '/' -> "/C:/..."). */
+    if (path[0] != '/') {
+        if (pos + 1 >= out_sz) {
+            return false;
+        }
+        out[pos++] = '/';
+    }
+
+    for (const unsigned char *p = (const unsigned char *)path; *p != '\0'; p++) {
+        unsigned char c = *p;
+        if (c == '\\') {
+            c = '/'; /* normalize Windows separators */
+        }
+        bool safe = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+                    c == '/' || c == '.' || c == '-' || c == '_' || c == '~' || c == ':';
+        if (safe) {
+            if (pos + 1 >= out_sz) {
+                return false;
+            }
+            out[pos++] = (char)c;
+        } else {
+            if (pos + 3 >= out_sz) {
+                return false;
+            }
+            out[pos++] = '%';
+            out[pos++] = HEX[(c >> 4) & 0xF];
+            out[pos++] = HEX[c & 0xF];
+        }
+    }
+
+    if (pos + suffix_len + 1 > out_sz) {
+        return false;
+    }
+    memcpy(out + pos, SUFFIX, suffix_len);
+    pos += suffix_len;
+    out[pos] = '\0';
+    return true;
+}
+
 cbm_store_t *cbm_store_open_path_query(const char *db_path) {
     if (!db_path) {
         return NULL;
@@ -625,13 +711,52 @@ cbm_store_t *cbm_store_open_path_query(const char *db_path) {
         return NULL;
     }
 
-    /* Open read-write but do NOT create — returns SQLITE_CANTOPEN if absent. */
-    int rc = sqlite3_open_v2(db_path, &s->db, SQLITE_OPEN_READWRITE, NULL);
+    /* Query tools open the project DB READ-ONLY: a read query must never
+     * mutate the DB (the previous READWRITE open + WAL write-pragmas did),
+     * and must work on a read-only DB file / filesystem.
+     *
+     * Try a plain READONLY open first — on a normal writable filesystem this
+     * reads WAL frames correctly via the -shm wal-index. SQLite opens lazily,
+     * so a read-only-filesystem failure (cannot create -shm for a WAL-mode
+     * DB) surfaces on first access, not at open time; we probe with a trivial
+     * read to force it. If the probe fails, retry once with an immutable URI
+     * that bypasses WAL and reads the main DB file directly.
+     *
+     * No SQLITE_OPEN_CREATE on either path — a missing DB must return NULL
+     * (no ghost .db for unknown/unindexed projects). */
+    int rc = sqlite3_open_v2(db_path, &s->db, SQLITE_OPEN_READONLY, NULL);
+    if (rc == SQLITE_OK) {
+        /* Force first DB access so a read-only-FS WAL failure surfaces now. */
+        if (sqlite3_exec(s->db, "SELECT 1 FROM sqlite_master LIMIT 1;", NULL, NULL, NULL) !=
+            SQLITE_OK) {
+            sqlite3_close(s->db);
+            s->db = NULL;
+            rc = SQLITE_CANTOPEN; /* trigger immutable fallback */
+        }
+    }
     if (rc != SQLITE_OK) {
-        /* sqlite3_open_v2 allocates a handle even on failure — must close it. */
-        sqlite3_close(s->db);
-        free(s);
-        return NULL;
+        sqlite3_close(s->db); /* no-op if already NULL */
+        s->db = NULL;
+        /* A genuinely missing DB must return NULL without creating anything —
+         * only retry with the immutable URI when the file exists but could not
+         * be opened (the read-only-filesystem case). This also keeps the
+         * common "project not found" path to a single open attempt. */
+        if (!cbm_file_exists(db_path)) {
+            free(s);
+            return NULL;
+        }
+        char uri[ST_QUERY_URI_MAX];
+        if (!build_immutable_uri(db_path, uri, sizeof(uri))) {
+            free(s);
+            return NULL;
+        }
+        rc = sqlite3_open_v2(uri, &s->db, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, NULL);
+        if (rc != SQLITE_OK) {
+            /* sqlite3_open_v2 allocates a handle even on failure — must close it. */
+            sqlite3_close(s->db);
+            free(s);
+            return NULL;
+        }
     }
 
     s->db_path = heap_strdup(db_path);
@@ -649,7 +774,7 @@ cbm_store_t *cbm_store_open_path_query(const char *db_path) {
     sqlite3_create_function(s->db, "cbm_camel_split", SKIP_ONE, SQLITE_UTF8 | SQLITE_DETERMINISTIC,
                             NULL, sqlite_camel_split, NULL, NULL);
 
-    if (configure_pragmas(s, false) != CBM_STORE_OK) {
+    if (configure_pragmas(s, false, true) != CBM_STORE_OK) {
         sqlite3_close(s->db);
         safe_str_free(&s->db_path);
         free(s);

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -201,9 +201,15 @@ cbm_store_t *cbm_store_open_memory(void);
 /* Open a file-backed database at the given path. Creates if needed. */
 cbm_store_t *cbm_store_open_path(const char *db_path);
 
-/* Open an existing file-backed database for querying only (no SQLITE_OPEN_CREATE).
- * Returns NULL if the file does not exist — never creates a new .db file. */
+/* Open an existing file-backed database for querying only. Opened READ-ONLY
+ * (no SQLITE_OPEN_CREATE, no write pragmas) so queries never mutate the DB and
+ * work on a read-only file / filesystem. Returns NULL if the file does not
+ * exist — never creates a new .db file. */
 cbm_store_t *cbm_store_open_path_query(const char *db_path);
+
+/* On-disk path of a file-backed store, or NULL for an in-memory (:memory:)
+ * store. The returned pointer is owned by the store. */
+const char *cbm_store_db_path(const cbm_store_t *s);
 
 /* Check database integrity. Returns true if the DB passes basic sanity checks
  * (projects table has correct types, no corruption indicators).

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <sys/stat.h> /* chmod / stat for read-only query reproductions */
 
 static char mcp_log_buf[4096];
 
@@ -2398,6 +2399,265 @@ TEST(tool_bad_project_name_no_overflow_issue235) {
 #undef ISSUE235_DBNAME
 
 /* ══════════════════════════════════════════════════════════════════
+ *  QUERY STORE READ-ONLY  (data-integrity reproductions)
+ *
+ *  Bug: query tools resolve the project store via resolve_store() ->
+ *  cbm_store_open_path_query(), which opens the DB SQLITE_OPEN_READWRITE
+ *  and runs configure_pragmas() with the WRITE pragmas
+ *  (journal_mode=WAL + wal_checkpoint + synchronous). Two consequences:
+ *    (a) read-only query tools MUTATE the on-disk DB (write pragmas), and
+ *    (b) query tools FAIL outright on a read-only DB file / filesystem
+ *        (the READWRITE open returns CANTOPEN -> resolve_store NULL ->
+ *        "project not found").
+ *  Both tests below are written reproduce-first and are RED on the
+ *  unfixed code, GREEN once query opens are READONLY with read-only
+ *  pragmas.
+ * ══════════════════════════════════════════════════════════════════ */
+
+#define ROQ_PROJECT "cbm-roq-test"
+
+/* Whole-file byte snapshot. Returns malloc'd buffer (caller frees) and
+ * writes the length to *out_len. Returns NULL on failure. */
+static unsigned char *roq_read_file_bytes(const char *path, long *out_len) {
+    *out_len = 0;
+    FILE *fp = fopen(path, "rb");
+    if (!fp) {
+        return NULL;
+    }
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        fclose(fp);
+        return NULL;
+    }
+    long sz = ftell(fp);
+    if (sz < 0) {
+        fclose(fp);
+        return NULL;
+    }
+    rewind(fp);
+    unsigned char *buf = malloc((size_t)sz > 0 ? (size_t)sz : 1);
+    if (!buf) {
+        fclose(fp);
+        return NULL;
+    }
+    size_t got = fread(buf, 1, (size_t)sz, fp);
+    fclose(fp);
+    if (got != (size_t)sz) {
+        free(buf);
+        return NULL;
+    }
+    *out_len = sz;
+    return buf;
+}
+
+static int roq_file_exists(const char *path) {
+    struct stat st;
+    return (stat(path, &st) == 0) ? 1 : 0;
+}
+
+/* ── (a) NO-MUTATION ──────────────────────────────────────────────────
+ *
+ * readonly_query_does_not_mutate_db
+ *
+ * Create a real project DB, convert it to rollback (DELETE) journal mode
+ * on disk, snapshot its exact bytes, run search_graph through the server,
+ * then re-snapshot. The buggy query path runs `PRAGMA journal_mode=WAL`,
+ * which rewrites the file header (1,1 -> 2,2) and spawns a -wal sidecar —
+ * so the snapshots differ. The fixed READONLY path runs no write pragma,
+ * so the file is byte-identical.
+ *
+ * The DELETE-mode fixture is what makes the mutation OBSERVABLE: on an
+ * already-WAL file `journal_mode=WAL` is a silent no-op, so we deliberately
+ * stage the DB in rollback mode (the same technique repro_issue557 uses to
+ * plant a deterministic trigger).
+ *
+ * WHY RED on unfixed code:
+ *   journal_mode=WAL rewrites the header -> memcmp(before, after) != 0 and
+ *   a -wal file is created while the cached store is open. Both assertions
+ *   that demand "unchanged" fire.
+ * ─────────────────────────────────────────────────────────────────── */
+TEST(readonly_query_does_not_mutate_db) {
+    char tmp_cache[512];
+    snprintf(tmp_cache, sizeof(tmp_cache), "%s/cbm_roq_a_XXXXXX", cbm_tmpdir());
+    if (!cbm_mkdtemp(tmp_cache)) {
+        ASSERT_NOT_NULL(NULL); /* setup failure */
+    }
+    const char *saved = getenv("CBM_CACHE_DIR");
+    char *saved_copy = saved ? strdup(saved) : NULL;
+    cbm_setenv("CBM_CACHE_DIR", tmp_cache, 1);
+
+    char db_path[700];
+    snprintf(db_path, sizeof(db_path), "%s/%s.db", tmp_cache, ROQ_PROJECT);
+    char wal_path[730];
+    char shm_path[730];
+    snprintf(wal_path, sizeof(wal_path), "%s-wal", db_path);
+    snprintf(shm_path, sizeof(shm_path), "%s-shm", db_path);
+
+    /* Build the DB and flip it to rollback journal mode on disk. */
+    cbm_store_t *setup = cbm_store_open_path(db_path);
+    ASSERT_NOT_NULL(setup);
+    ASSERT_EQ(cbm_store_upsert_project(setup, ROQ_PROJECT, "/tmp/roq"), CBM_STORE_OK);
+    cbm_node_t node = {.project = ROQ_PROJECT,
+                       .label = "Function",
+                       .name = "ReadOnlyProbe",
+                       .qualified_name = "roq.mod.ReadOnlyProbe",
+                       .file_path = "mod.c"};
+    ASSERT_TRUE(cbm_store_upsert_node(setup, &node) > 0);
+    ASSERT_EQ(cbm_store_exec(setup, "PRAGMA journal_mode=DELETE;"), 0);
+    cbm_store_close(setup);
+
+    /* Snapshot BEFORE any query. */
+    long before_len = 0;
+    unsigned char *before = roq_read_file_bytes(db_path, &before_len);
+    ASSERT_NOT_NULL(before);
+
+    /* Run a query tool through the server (the resolve_store path). */
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    char args[512];
+    snprintf(args, sizeof(args), "{\"project\":\"%s\",\"name_pattern\":\".*ReadOnlyProbe.*\"}",
+             ROQ_PROJECT);
+    char *resp = cbm_mcp_handle_tool(srv, "search_graph", args);
+
+    /* Capture sidecar state WHILE the cached store is still open (the buggy
+     * RW+WAL open creates -wal here; on close it would be removed again). */
+    int wal_while_open = roq_file_exists(wal_path);
+    int query_ok = (resp && strstr(resp, "ReadOnlyProbe") != NULL);
+    int query_failed = (resp && (strstr(resp, "not found") || strstr(resp, "not indexed")));
+
+    cbm_mcp_server_free(srv); /* closes the store; header change is persisted */
+
+    long after_len = 0;
+    unsigned char *after = roq_read_file_bytes(db_path, &after_len);
+
+    int identical = (before && after && before_len == after_len &&
+                     memcmp(before, after, (size_t)before_len) == 0);
+
+    if (resp) {
+        free(resp);
+    }
+    free(before);
+    free(after);
+    cbm_unlink(db_path);
+    cbm_unlink(wal_path);
+    cbm_unlink(shm_path);
+    cbm_rmdir(tmp_cache);
+    if (saved_copy) {
+        cbm_setenv("CBM_CACHE_DIR", saved_copy, 1);
+        free(saved_copy);
+    } else {
+        cbm_unsetenv("CBM_CACHE_DIR");
+    }
+
+    ASSERT_TRUE(query_ok);        /* read path ran and returned the node */
+    ASSERT_FALSE(query_failed);   /* not the "project not found" path */
+    ASSERT_TRUE(identical);       /* RED on buggy code: WAL pragma rewrote header */
+    ASSERT_FALSE(wal_while_open); /* RED on buggy code: RW+WAL open spawned -wal */
+    PASS();
+}
+
+/* ── (b) READ-ONLY FILESYSTEM ─────────────────────────────────────────
+ *
+ * readonly_query_succeeds_on_readonly_fs
+ *
+ * Create a real project DB (left in WAL journal mode, as the indexer
+ * writes it), then chmod the CONTAINING DIRECTORY to 0555 (read-only) to
+ * simulate a read-only mount / immutable media, then run search_graph.
+ *
+ * Note on why the directory (not just the file) must be read-only: SQLite's
+ * unix VFS auto-downgrades a failed O_RDWR main-db open to O_RDONLY, so a
+ * 0444 *file* alone does NOT surface the bug — the connection silently
+ * becomes read-only and, with a writable dir, still creates the WAL -shm
+ * and reads. The genuine read-only-FS symptom is the WAL write-pragma
+ * (journal_mode=WAL) being unable to create the -shm/-wal sidecars in a
+ * read-only directory.
+ *
+ * WHY RED on unfixed code:
+ *   cbm_store_open_path_query() runs configure_pragmas(.., false) which
+ *   executes `PRAGMA journal_mode = WAL`. In a read-only directory the WAL
+ *   wal-index (-shm) cannot be created, so the pragma errors ->
+ *   configure_pragmas fails -> the open returns NULL -> resolve_store()
+ *   returns NULL -> the handler emits "project not found or not indexed".
+ *
+ * GREEN on fixed code:
+ *   the READONLY open skips the WAL write-pragma; the plain READONLY open
+ *   of a WAL-mode DB in a read-only dir still needs -shm, so it fails and
+ *   the immutable-URI fallback (file:..?immutable=1) reads the main DB
+ *   file directly and the query returns the node. (This is the test that
+ *   exercises the immutable fallback path.)
+ * ─────────────────────────────────────────────────────────────────── */
+TEST(readonly_query_succeeds_on_readonly_fs) {
+    char tmp_cache[512];
+    snprintf(tmp_cache, sizeof(tmp_cache), "%s/cbm_roq_b_XXXXXX", cbm_tmpdir());
+    if (!cbm_mkdtemp(tmp_cache)) {
+        ASSERT_NOT_NULL(NULL); /* setup failure */
+    }
+    const char *saved = getenv("CBM_CACHE_DIR");
+    char *saved_copy = saved ? strdup(saved) : NULL;
+    cbm_setenv("CBM_CACHE_DIR", tmp_cache, 1);
+
+    char db_path[700];
+    snprintf(db_path, sizeof(db_path), "%s/%s.db", tmp_cache, ROQ_PROJECT);
+    char wal_path[730];
+    char shm_path[730];
+    snprintf(wal_path, sizeof(wal_path), "%s-wal", db_path);
+    snprintf(shm_path, sizeof(shm_path), "%s-shm", db_path);
+
+    /* Build the DB in its natural WAL journal mode and ensure it is cleanly
+     * checkpointed (no -wal frames) so the immutable fallback can read all
+     * data from the main file. */
+    cbm_store_t *setup = cbm_store_open_path(db_path);
+    ASSERT_NOT_NULL(setup);
+    ASSERT_EQ(cbm_store_upsert_project(setup, ROQ_PROJECT, "/tmp/roq"), CBM_STORE_OK);
+    cbm_node_t node = {.project = ROQ_PROJECT,
+                       .label = "Function",
+                       .name = "ReadOnlyProbe",
+                       .qualified_name = "roq.mod.ReadOnlyProbe",
+                       .file_path = "mod.c"};
+    ASSERT_TRUE(cbm_store_upsert_node(setup, &node) > 0);
+    (void)cbm_store_checkpoint(setup); /* fold WAL frames into the main file */
+    cbm_store_close(setup);            /* clean close removes -wal/-shm */
+
+    /* Make the containing directory read-only (simulate a read-only mount).
+     * SQLite can still traverse + read files, but cannot create -shm/-wal. */
+    ASSERT_EQ(chmod(tmp_cache, 0555), 0);
+
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    char args[512];
+    snprintf(args, sizeof(args), "{\"project\":\"%s\",\"name_pattern\":\".*ReadOnlyProbe.*\"}",
+             ROQ_PROJECT);
+    char *resp = cbm_mcp_handle_tool(srv, "search_graph", args);
+
+    int query_ok = (resp && strstr(resp, "ReadOnlyProbe") != NULL);
+    int query_failed = (resp && (strstr(resp, "not found") || strstr(resp, "not indexed")));
+
+    if (resp) {
+        free(resp);
+    }
+    cbm_mcp_server_free(srv);
+
+    /* Restore write permission on the dir BEFORE unlink (cannot remove dir
+     * entries while the directory is read-only). */
+    chmod(tmp_cache, 0755);
+    cbm_unlink(db_path);
+    cbm_unlink(wal_path);
+    cbm_unlink(shm_path);
+    cbm_rmdir(tmp_cache);
+    if (saved_copy) {
+        cbm_setenv("CBM_CACHE_DIR", saved_copy, 1);
+        free(saved_copy);
+    } else {
+        cbm_unsetenv("CBM_CACHE_DIR");
+    }
+
+    ASSERT_FALSE(query_failed); /* RED on buggy code: WAL pragma fails on RO dir */
+    ASSERT_TRUE(query_ok);      /* RED on buggy code: no node returned */
+    PASS();
+}
+
+#undef ROQ_PROJECT
+
+/* ══════════════════════════════════════════════════════════════════
  *  SUITE
  * ══════════════════════════════════════════════════════════════════ */
 
@@ -2507,6 +2767,10 @@ SUITE(mcp) {
     RUN_TEST(tool_manage_adr_unified_backend_issue256);
     RUN_TEST(tool_ingest_traces_basic);
     RUN_TEST(tool_ingest_traces_empty);
+
+    /* Query store read-only (data integrity) */
+    RUN_TEST(readonly_query_does_not_mutate_db);
+    RUN_TEST(readonly_query_succeeds_on_readonly_fs);
 
     /* Idle store eviction */
     RUN_TEST(store_idle_eviction);


### PR DESCRIPTION
Latent data-integrity fix — no single reporter issue; found while diagnosing #704 (a query grew a 0-byte shadow db to 100 KB).

**Bug:** query tools open the project db `SQLITE_OPEN_READWRITE` and run write pragmas (`PRAGMA journal_mode=WAL` + `wal_checkpoint`), so:
1. every query **mutates** the db (rewrites the header, creates `-wal`/`-shm`), and
2. queries **fail** when the db / its directory is read-only (the WAL pragma can't create `-shm` → `resolve_store` returns NULL → "project not found").

**Fix:**
- `cbm_store_open_path_query` opens **`SQLITE_OPEN_READONLY`**. `configure_pragmas` gains a `read_only` mode that runs only the non-writing pragmas and **skips `journal_mode`/`wal_checkpoint`/`synchronous`**. The read-write open is unchanged.
- **Read-only-FS fallback:** SQLite opens lazily, so a RO-FS failure surfaces on *first access*; we probe with `SELECT 1` and, **only if the file exists**, retry once with `file:<path>?immutable=1` (URI-special chars percent-encoded) — which bypasses WAL and reads the main db directly. **Gated** to that failure path so writable-FS readers still see uncheckpointed WAL frames via `-shm`.
- **`manage_adr`** is the only `resolve_store` caller that writes; it now opens its own **read-write** handle for ADR storage (in-memory/embedded stores still write through the resolved store). All 12 callers audited; `query_graph` is read-only (the Cypher engine rejects `CREATE/MERGE/SET/DELETE/REMOVE`).

**Reproduce-first (non-vacuous — no real read-only mount needed):**
- `readonly_query_does_not_mutate_db`: snapshot a db's bytes, run `search_graph`, assert byte-identical + no `-wal` created. RED before (WAL pragma rewrote the header).
- `readonly_query_succeeds_on_readonly_fs`: `chmod 0555` the **containing directory** (a `0444` *file* alone is vacuous — SQLite auto-downgrades the open), run `search_graph`, assert success. RED before ("project not found"); exercises the immutable fallback.

Full suite **5724 / 0**. Adds a minimal read-only `cbm_store_db_path()` accessor (used by the `manage_adr` carve-out). Part of the CLI-reliability series (#640 → #714, #680 → #716, #704 → #717).
