### PR TITLE
fix(build): include <git2/sys/alloc.h> for git_allocator

### DIFF
--- a/internal/cbm/cbm.c
+++ b/internal/cbm/cbm.c
@@ -20,7 +20,8 @@
 #if defined(CBM_BIND_TS_ALLOCATOR) && CBM_BIND_TS_ALLOCATOR
 #include "sqlite3.h" // sqlite3_mem_methods, sqlite3_config, SQLITE_CONFIG_MALLOC — bind sqlite to mimalloc
 #if defined(HAVE_LIBGIT2)
-#include <git2.h> // git_allocator, git_libgit2_opts, GIT_OPT_SET_ALLOCATOR — bind libgit2 to mimalloc
+#include <git2.h>           // git_libgit2_opts, GIT_OPT_SET_ALLOCATOR — bind libgit2 to mimalloc
+#include <git2/sys/alloc.h> // git_allocator — not pulled in by <git2.h> (it's a sys/ header)
 #endif
 #endif
 #include <stdint.h> // uint32_t, uint64_t, int64_t


### PR DESCRIPTION
## What does this PR do?

Adds the missing `#include <git2/sys/alloc.h>` in `internal/cbm/cbm.c`.

The file uses `git_allocator` (to bind libgit2's allocator to mimalloc via `GIT_OPT_SET_ALLOCATOR`) but includes only `<git2.h>`, which does **not** pull in `<git2/sys/alloc.h>` where `git_allocator` is declared — it's a `sys/` header. When libgit2 is on the pkg-config path, the production build fails to compile:

```
internal/cbm/cbm.c:347: error: unknown type name 'git_allocator'
```

It was latent because the block is guarded by `CBM_BIND_TS_ALLOCATOR` (prod-only) **and** `HAVE_LIBGIT2`, so it compiles out unless libgit2 is present — which happens on a dev machine / the Nix dev shell with libgit2 installed, but not in CI. One-line fix.

Part of #705 (the macOS/Nix build report); split into its own narrow PR at the maintainer's request. `Refs #705` rather than `Fixes`, since #705 also covers the build-script and cross-arch work landing in separate PRs.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test`)
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [ ] New behavior is covered by a test (reproduce-first for bug fixes)

> **On the last three items:** the changed block is `CBM_BIND_TS_ALLOCATOR`-guarded (prod-only) and `HAVE_LIBGIT2`-gated, so it is compiled out of the ASan unit build — there is no runtime behavior to unit-test and `make test` does not exercise it. The fix is verified by compiling the **prod** binary with libgit2 on the pkg-config path (`scripts/build.sh` inside `nix develop`, or any host with `libgit2-dev`); `clang-format` is clean. No CI job currently builds with libgit2, which is why this regressed unseen — happy to add a libgit2 build-matrix entry in a follow-up if that would be useful.
