### PR TITLE
feat(build): add a macOS cross-architecture dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,52 @@
     let
       systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+
+      # Cross dev shell (macOS only): build the *other* darwin arch locally.
+      # The native clang already cross-EMITS object code via -arch (scripts/env.sh
+      # exports ARCHFLAGS); this shell only puts the target-arch zlib (a hard
+      # `-lz` dependency) and libgit2 (optional, found via pkg-config) on the
+      # link path, since the host-arch copies can't satisfy an x86_64/arm64 link.
+      # Building needs no Rosetta; *running* an x86_64 binary on Apple Silicon
+      # does. The target-arch libs are fetched as prebuilt substitutes. Returns
+      # {} on Linux/Windows (no cross target).
+      crossDevShells = pkgs:
+        let
+          inherit (nixpkgs) lib;
+          crossTarget =
+            {
+              "aarch64-darwin" = "x86_64-darwin";
+              "x86_64-darwin" = "aarch64-darwin";
+            }
+            .${pkgs.system} or null;
+          mkCrossShell =
+            targetSystem:
+            let
+              tpkgs = nixpkgs.legacyPackages.${targetSystem};
+              targetArch = if targetSystem == "x86_64-darwin" then "x86_64" else "arm64";
+            in
+            pkgs.mkShell {
+              # Host toolchain only (clang comes from the shell stdenv); do NOT
+              # pull host zlib/libgit2 in — that's the wrong-arch copy we avoid.
+              nativeBuildInputs = [ pkgs.pkg-config pkgs.gnumake ];
+              shellHook = ''
+                # libgit2 headers + libs come through pkg-config (the Makefile
+                # auto-detects it). zlib is a bare `-lz`/`#include <zlib.h>`, so
+                # supply its include (header is arch-independent) and lib dir by
+                # hand. NIX_LDFLAGS is searched before the link's own -L, so the
+                # target-arch slice resolves; the host-arch copy (if any reaches
+                # ld) is skipped as "wrong architecture".
+                export PKG_CONFIG_PATH="${lib.getDev tpkgs.libgit2}/lib/pkgconfig:${lib.getDev tpkgs.zlib}/lib/pkgconfig''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+                export NIX_CFLAGS_COMPILE="-I${lib.getDev tpkgs.zlib}/include ''${NIX_CFLAGS_COMPILE:-}"
+                export NIX_LDFLAGS="-L${lib.getLib tpkgs.zlib}/lib -L${lib.getLib tpkgs.libgit2}/lib ''${NIX_LDFLAGS:-}"
+                echo "[cross] target ${targetSystem} — build with: scripts/build.sh --arch ${targetArch}"
+              '';
+            };
+        in
+        lib.optionalAttrs (crossTarget != null) {
+          # `nix develop .#cross` then `scripts/build.sh --arch <target>`.
+          cross = mkCrossShell crossTarget;
+        };
     in
     {
       packages = forAllSystems (pkgs: {
@@ -49,6 +95,6 @@
           # otherwise the build falls back to shelling out to `git log`.
           packages = [ pkgs.pkg-config pkgs.libgit2 ];
         };
-      });
+      } // crossDevShells pkgs);
     };
 }


### PR DESCRIPTION
## What does this PR do?

Adds a `cross` flake dev shell so macOS users can build the *other* arch locally: `nix develop .#cross` then `scripts/build.sh --arch x86_64` (on Apple Silicon) produces a working x86_64 binary — and vice versa on Intel.

The native clang already cross-*emits* object code via `-arch` (set up by the build fix in #723 — `scripts/env.sh` exports `ARCHFLAGS`). The only thing missing for a cross *link* is the target-arch dependency libraries, because the dev shell's `zlib`/`libgit2` are host-arch only. This shell puts the target-arch `zlib` (a hard `-lz` dependency) and `libgit2` (optional, via pkg-config) on the link path; they're fetched as prebuilt substitutes, so **building needs no Rosetta** — only *running* an x86_64 binary on Apple Silicon does.

Scope is deliberately minimal: `flake.nix` only, an added `crossDevShells` helper plus one merged attribute. The existing `default` shell is untouched, and there are **no `flake.lock` / `.envrc` changes**.

### Validation (host aarch64-darwin, targeting x86_64)

```
$ nix develop .#cross
[cross] target x86_64-darwin — build with: scripts/build.sh --arch x86_64
$ scripts/build.sh --arch x86_64
=== Build complete: build/c/codebase-memory-mcp ===
$ file build/c/codebase-memory-mcp
build/c/codebase-memory-mcp: Mach-O 64-bit x86_64 executable
$ otool -L build/c/codebase-memory-mcp | grep -Ei 'git2|libz'
  /nix/store/…-libgit2-1.9.4-lib/lib/libgit2.1.9.dylib   # x86_64
  /nix/store/…-zlib-1.3.2/lib/libz.dylib                 # x86_64
```

The binary links the **x86_64** slices of libgit2 + zlib (no stale host-arch references). Constraint, as flagged on #705: a working x86_64 build needs x86_64 `zlib` (mandatory) + `libgit2`, which this shell provides as substitutes.

Depends on #723 (`ARCHFLAGS` + the compiler capability probe) — the cross shell is only useful once that lands, so please merge this after #723. `Refs #705`.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Tests pass locally (`make -f Makefile.cbm test`)
- [ ] Lint passes (`make -f Makefile.cbm lint-ci`)
- [ ] New behavior is covered by a test (reproduce-first for bug fixes)

> **On the checklist:** this is a `flake.nix`-only change — it adds an opt-in dev shell and does not touch the C sources, scripts, or Makefile, so `make test` / `lint-ci` are unaffected (no C or lint surface). Validation is the flake evaluation (both `default` and `cross` shells evaluate on aarch64-darwin; `default` on Linux) plus the cross-build transcript above. There is no CI runner for macOS cross-arch today; happy to discuss adding one.
