### PR TITLE
fix(foundation): open UTF-8 repo paths with _wfopen on Windows

### DIFF
--- a/src/discover/language.c
+++ b/src/discover/language.c
@@ -11,6 +11,7 @@
 #include "cbm.h" // CBMLanguage, CBM_LANG_*
 
 #include "foundation/constants.h"
+#include "foundation/compat_fs.h" // cbm_fopen
 
 enum { LANG_SCAN_PASSES = 2 };
 #define SLEN(s) (sizeof(s) - 1)
@@ -998,7 +999,7 @@ CBMLanguage cbm_disambiguate_m(const char *path) {
         return CBM_LANG_MATLAB;
     }
 
-    FILE *f = fopen(path, "r");
+    FILE *f = cbm_fopen(path, "r"); /* wide-open on Windows: handles non-ASCII (CJK) paths */
     if (!f) {
         return CBM_LANG_MATLAB;
     }

--- a/src/foundation/compat_fs.c
+++ b/src/foundation/compat_fs.c
@@ -188,6 +188,23 @@ int cbm_exec_no_shell(const char *const *argv) {
     return (int)_spawnvp(_P_WAIT, argv[0], argv);
 }
 
+FILE *cbm_fopen(const char *path, const char *mode) {
+    wchar_t *wpath = cbm_utf8_to_wide(path);
+    if (!wpath) {
+        return NULL;
+    }
+    /* mode is always short ASCII ("rb"/"wb"/...): widen byte-for-byte. */
+    wchar_t wmode[8];
+    size_t i = 0;
+    for (; mode && mode[i] && i < (sizeof(wmode) / sizeof(wmode[0])) - 1; i++) {
+        wmode[i] = (wchar_t)(unsigned char)mode[i];
+    }
+    wmode[i] = L'\0';
+    FILE *f = _wfopen(wpath, wmode);
+    free(wpath);
+    return f;
+}
+
 #else /* POSIX */
 
 /* ── POSIX implementation ────────────────────────────────── */
@@ -316,6 +333,10 @@ int cbm_exec_no_shell(const char *const *argv) {
         return WEXITSTATUS(status);
     }
     return CBM_NOT_FOUND; /* killed by signal */
+}
+
+FILE *cbm_fopen(const char *path, const char *mode) {
+    return fopen(path, mode);
 }
 
 #endif /* _WIN32 */

--- a/src/foundation/compat_fs.h
+++ b/src/foundation/compat_fs.h
@@ -41,6 +41,13 @@ int cbm_pclose(FILE *f);
 
 /* ── File operations ──────────────────────────────────────────── */
 
+/* Portable fopen. On Windows, `path` is UTF-8 and is widened to UTF-16 for
+ * _wfopen, so non-ASCII paths (e.g. a CJK repo dir) open correctly regardless of
+ * the active ANSI code page. Plain fopen() on Windows interprets the bytes in the
+ * ACP, so a UTF-8 CJK path fails to open — which silently breaks file content
+ * reads during indexing. POSIX: a thin fopen() wrapper. Returns NULL on error. */
+FILE *cbm_fopen(const char *path, const char *mode);
+
 /* Create directory (and parents). mode is ignored on Windows. Returns true on success. */
 bool cbm_mkdir_p(const char *path, int mode);
 

--- a/src/pipeline/pass_definitions.c
+++ b/src/pipeline/pass_definitions.c
@@ -22,6 +22,7 @@ enum { PD_JSON_FIELD_OVERHEAD = 6 };
 #include "graph_buffer/graph_buffer.h"
 #include "foundation/log.h"
 #include "foundation/compat.h"
+#include "foundation/compat_fs.h" // cbm_fopen
 #include "cbm.h"
 #include "simhash/minhash.h"
 #include "semantic/ast_profile.h"
@@ -33,7 +34,7 @@ enum { PD_JSON_FIELD_OVERHEAD = 6 };
 /* Read entire file into heap-allocated buffer. Returns NULL on error.
  * Caller must free(). Sets *out_len to byte count. */
 static char *read_file(const char *path, int *out_len) {
-    FILE *f = fopen(path, "rb");
+    FILE *f = cbm_fopen(path, "rb"); /* wide-open on Windows: handles non-ASCII (CJK) paths */
     if (!f) {
         return NULL;
     }

--- a/src/pipeline/pass_envscan.c
+++ b/src/pipeline/pass_envscan.c
@@ -316,7 +316,7 @@ static int scan_line(const char *line, file_type_t ft, char *key_out, size_t key
 /* Scan a single file for env URL bindings. Returns number of bindings added. */
 static int scan_env_file(const char *full_path, const char *rel, file_type_t ft,
                          cbm_env_binding_t *out, int max_out) {
-    FILE *f = fopen(full_path, "r");
+    FILE *f = cbm_fopen(full_path, "r"); /* wide-open on Windows: handles non-ASCII (CJK) paths */
     if (!f) {
         return 0;
     }

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -54,6 +54,7 @@ enum { PP_CSHARP_M_PREFIX_LEN = 2 };
 #include "helpers.h" /* cbm_kind_in_set_free_cache — per-worker-thread cache teardown */
 #include "pipeline/worker_pool.h"
 #include "foundation/compat.h"
+#include "foundation/compat_fs.h" // cbm_fopen
 #include "foundation/compat_thread.h"
 #include "graph_buffer/graph_buffer.h"
 #include "service_patterns.h"
@@ -86,7 +87,7 @@ static uint64_t extract_now_ns(void) {
 
 /* Read file into a malloc'd buffer (= mimalloc in production). */
 static char *read_file(const char *path, int *out_len) {
-    FILE *f = fopen(path, "rb");
+    FILE *f = cbm_fopen(path, "rb"); /* wide-open on Windows: handles non-ASCII (CJK) paths */
     if (!f) {
         return NULL;
     }

--- a/src/pipeline/pass_semantic.c
+++ b/src/pipeline/pass_semantic.c
@@ -19,6 +19,7 @@
 #include "graph_buffer/graph_buffer.h"
 #include "foundation/log.h"
 #include "foundation/compat.h"
+#include "foundation/compat_fs.h" // cbm_fopen
 #include "cbm.h"
 
 #include <stdio.h>
@@ -26,7 +27,7 @@
 #include <string.h>
 
 static char *read_file(const char *path, int *out_len) {
-    FILE *f = fopen(path, "rb");
+    FILE *f = cbm_fopen(path, "rb"); /* wide-open on Windows: handles non-ASCII (CJK) paths */
     if (!f) {
         return NULL;
     }


### PR DESCRIPTION
## Summary

- Add portable `cbm_fopen()` in `compat_fs`: on Windows, UTF-8 paths are converted to UTF-16 and opened via `_wfopen`; on POSIX it delegates to `fopen`.
- Route project source file reads through `cbm_fopen` in the indexing hot path (`pass_parallel`, `pass_definitions`, `pass_semantic`, `pass_envscan`) and language disambiguation (`language.c`).

## Problem

On Windows with a non-UTF-8 ANSI code page (e.g. GBK / ACP 936), `fopen()` interprets path bytes in the system code page. When the repo absolute path contains non-ASCII characters (e.g. a CJK directory name), UTF-8 path bytes are misinterpreted and `fopen` fails.

Directory discovery already uses wide-char APIs (`cbm_opendir` / `FindFirstFileW`), so the file tree is built. Extraction passes, however, use `fopen` in `read_file()` and silently skip every source file. The resulting index contains only `File` / `Folder` / `CONTAINS_*` nodes — no symbols, no `IMPORTS` / `CALLS` edges, and `file_hashes` stays empty.

## Verification

Reproduced and fixed on Windows 11 (ACP 936):

| Metric | Before (`fopen`) | After (`cbm_fopen`) |
|--------|------------------|---------------------|
| Nodes | 61 (structure only) | 426 |
| Edges | 59 (`CONTAINS_*` only) | 1095 (`IMPORTS`, `CALLS`, `DEFINES`, …) |
| File→file IMPORTS edges | 0 | 12+ |
| File→file CALLS edges | 0 | 103 |

Minimal repro: `fopen(utf8_path_to_cjk_file)` returns NULL; `_wfopen(wide_path)` opens and reads successfully.

Built with official toolchain: MSYS2 CLANG64, `scripts/build.sh CC=clang CXX=clang++`.

## Test plan

- [x] Manual repro on Windows (ACP 936): CJK repo path indexes with symbols
- [x] `gcc -fsyntax-only` on all changed files (MSYS2 clang 22.1.7)
- [x] Production binary build via `scripts/build.sh`
- [ ] CI `scripts/test.sh` (maintainer / Linux CI)

## Notes

This is a focused bug fix (7 files, ~40 lines). No API surface or pipeline algorithm changes.

Integrators calling the CLI on Windows with non-ASCII paths in JSON args may still need ASCII `\uXXXX` escaping for argv (separate from this fix); MCP/stdio paths are unaffected.
