### PR TITLE
fix(graph-ui): fix Windows folder navigation in the index picker

### DIFF
--- a/graph-ui/src/components/StatsTab.test.tsx
+++ b/graph-ui/src/components/StatsTab.test.tsx
@@ -158,6 +158,35 @@ describe("StatsTab index modal", () => {
     expect(await screen.findByText("projects")).toBeInTheDocument();
     expect(screen.queryByText("Documents")).not.toBeInTheDocument();
   });
+
+  it("replaces the meaningless '/' root with the drive on Windows", async () => {
+    const fetchMock = mockProjectsFetch((url) => {
+      if (url.startsWith("/api/browse")) {
+        const m = /[?&]path=([^&]*)/.exec(url);
+        const path = m ? decodeURIComponent(m[1]) : "C:/Users/rap";
+        return new Response(JSON.stringify({
+          path,
+          parent: "C:/",
+          dirs: ["Documents"],
+          roots: ["/"], // older backend: no drive enumeration
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return undefined;
+    });
+
+    render(<StatsTab onSelectProject={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Index your first repository" }));
+
+    /* The bogus "/" quick-jump is gone; the current drive root is offered. */
+    expect(await screen.findByRole("button", { name: "Browse C:/" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Browse /" })).not.toBeInTheDocument();
+
+    /* Clicking it browses to the drive root, not "/". */
+    fireEvent.click(screen.getByRole("button", { name: "Browse C:/" }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/browse?path=C%3A%2F");
+    });
+  });
 });
 
 describe("IndexProgress", () => {

--- a/graph-ui/src/components/StatsTab.test.tsx
+++ b/graph-ui/src/components/StatsTab.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen, waitFor, act } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, act } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { StatsTab, IndexProgress } from "./StatsTab";
 import { messages } from "../lib/i18n";
@@ -43,6 +43,7 @@ function mockProjectsFetch(extra?: (url: string, init?: RequestInit) => Response
 
 describe("StatsTab index modal", () => {
   afterEach(() => {
+    cleanup();
     vi.unstubAllGlobals();
   });
 
@@ -92,6 +93,39 @@ describe("StatsTab index modal", () => {
     expect(screen.getByText("beta")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Index beta" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Browse D:/" })).toBeInTheDocument();
+  });
+
+  it("navigates Windows breadcrumb segments to real drive paths", async () => {
+    const fetchMock = mockProjectsFetch((url) => {
+      if (url.startsWith("/api/browse")) {
+        return new Response(JSON.stringify({
+          path: "C:/Users/rap",
+          parent: "C:/Users",
+          dirs: ["Documents", "Downloads"],
+          roots: ["C:/", "D:/"],
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return undefined;
+    });
+
+    render(<StatsTab onSelectProject={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Index your first repository" }));
+
+    /* No bogus unified "/" root crumb on a Windows drive path. */
+    await screen.findByRole("button", { name: "C:" });
+    expect(screen.queryByRole("button", { name: "/" })).not.toBeInTheDocument();
+
+    /* Clicking the drive crumb browses to "C:/", not "/C:". */
+    fireEvent.click(screen.getByRole("button", { name: "C:" }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/browse?path=C%3A%2F");
+    });
+
+    /* Clicking a nested crumb browses to "C:/Users", not "/C:/Users". */
+    fireEvent.click(screen.getByRole("button", { name: "Users" }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/browse?path=C%3A%2FUsers");
+    });
   });
 });
 

--- a/graph-ui/src/components/StatsTab.test.tsx
+++ b/graph-ui/src/components/StatsTab.test.tsx
@@ -187,6 +187,26 @@ describe("StatsTab index modal", () => {
       expect(fetchMock).toHaveBeenCalledWith("/api/browse?path=C%3A%2F");
     });
   });
+
+  it("does not auto-refresh on POSIX when a path is typed", async () => {
+    const fetchMock = mockProjectsFetch(); // browse returns POSIX path "/home/dev"
+
+    render(<StatsTab onSelectProject={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Index your first repository" }));
+    await screen.findByText("alpha"); // initial POSIX listing
+
+    const browseCalls = () =>
+      fetchMock.mock.calls.filter((c) => String(c[0]).startsWith("/api/browse")).length;
+    const before = browseCalls();
+
+    fireEvent.change(screen.getByLabelText("Repository path"), {
+      target: { value: "/usr/local" },
+    });
+
+    /* Wait past the debounce window; a POSIX path must NOT trigger a re-browse. */
+    await new Promise((r) => setTimeout(r, 400));
+    expect(browseCalls()).toBe(before);
+  });
 });
 
 describe("IndexProgress", () => {

--- a/graph-ui/src/components/StatsTab.test.tsx
+++ b/graph-ui/src/components/StatsTab.test.tsx
@@ -127,6 +127,37 @@ describe("StatsTab index modal", () => {
       expect(fetchMock).toHaveBeenCalledWith("/api/browse?path=C%3A%2FUsers");
     });
   });
+
+  it("refreshes the folder list when a drive is typed into the path field", async () => {
+    mockProjectsFetch((url) => {
+      if (url.startsWith("/api/browse")) {
+        const m = /[?&]path=([^&]*)/.exec(url);
+        const path = m ? decodeURIComponent(m[1]) : "C:/Users/rap";
+        const onD = path.replace(/\\/g, "/").toUpperCase().startsWith("D:");
+        return new Response(JSON.stringify({
+          path,
+          parent: "C:/",
+          dirs: onD ? ["projects", "games"] : ["Documents", "Downloads"],
+          roots: ["C:/", "D:/"],
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return undefined;
+    });
+
+    render(<StatsTab onSelectProject={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Index your first repository" }));
+
+    /* Initial C: listing is shown. */
+    expect(await screen.findByText("Documents")).toBeInTheDocument();
+
+    /* Typing a different drive refreshes the listing to that drive (debounced). */
+    fireEvent.change(await screen.findByLabelText("Repository path"), {
+      target: { value: "D:/" },
+    });
+
+    expect(await screen.findByText("projects")).toBeInTheDocument();
+    expect(screen.queryByText("Documents")).not.toBeInTheDocument();
+  });
 });
 
 describe("IndexProgress", () => {

--- a/graph-ui/src/components/StatsTab.tsx
+++ b/graph-ui/src/components/StatsTab.tsx
@@ -269,6 +269,20 @@ function CreateIndexModal({ onClose, onCreated }: { onClose: () => void; onCreat
     return "/" + parts.join("/");
   };
 
+  /* Root/drive quick-jump buttons. On Windows the POSIX "/" root is meaningless
+   * — browsing it returns an empty listing — so drop it and offer drive roots
+   * instead. An older backend may not enumerate drives, so always include the
+   * current drive; other drives stay reachable by typing a path. */
+  const displayRoots = (() => {
+    if (!isWinPath) return roots;
+    const drives = Array.from(new Set(
+      roots.filter((r) => /^[A-Za-z]:[\\/]?$/.test(r)).map((r) => `${r[0].toUpperCase()}:/`),
+    ));
+    const curRoot = `${displayPath[0].toUpperCase()}:/`;
+    if (!drives.includes(curRoot)) drives.unshift(curRoot);
+    return drives;
+  })();
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={onClose}>
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
@@ -312,7 +326,7 @@ function CreateIndexModal({ onClose, onCreated }: { onClose: () => void; onCreat
             className="flex-1 bg-white/[0.04] border border-white/[0.06] rounded-lg px-3 py-2 text-[12px] text-foreground outline-none focus:border-primary/40 placeholder:text-foreground/20"
           />
           <div className="flex items-center gap-1">
-            {roots.map((root) => (
+            {displayRoots.map((root) => (
               <button
                 key={root}
                 aria-label={t.index.browseRoot(root)}

--- a/graph-ui/src/components/StatsTab.tsx
+++ b/graph-ui/src/components/StatsTab.tsx
@@ -239,6 +239,16 @@ function CreateIndexModal({ onClose, onCreated }: { onClose: () => void; onCreat
   /* Breadcrumb segments */
   const displayPath = currentPath.replace(/\\/g, "/");
   const segments = displayPath.split("/").filter(Boolean);
+  /* A Windows drive path ("C:/Users/rap") has no unified "/" root — its first
+   * segment is the drive letter. Build crumb targets accordingly so clicking a
+   * segment navigates to a real directory instead of a bogus "/C:/..." path
+   * that the backend rejects as "not a directory". */
+  const isWinPath = /^[A-Za-z]:$/.test(segments[0] ?? "");
+  const crumbPath = (i: number): string => {
+    const parts = segments.slice(0, i + 1);
+    if (isWinPath) return parts.length === 1 ? `${parts[0]}/` : parts.join("/");
+    return "/" + parts.join("/");
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={onClose}>
@@ -297,12 +307,14 @@ function CreateIndexModal({ onClose, onCreated }: { onClose: () => void; onCreat
 
         {/* Breadcrumb */}
         <div className="px-5 py-2 border-y border-border/20 flex items-center gap-0.5 overflow-x-auto text-[11px] shrink-0">
-          <button onClick={() => browse("/")} className="text-primary/60 hover:text-primary shrink-0 transition-colors">/</button>
+          {!isWinPath && (
+            <button onClick={() => browse("/")} className="text-primary/60 hover:text-primary shrink-0 transition-colors">/</button>
+          )}
           {segments.map((seg, i) => (
             <span key={i} className="flex items-center gap-0.5 shrink-0">
-              <span className="text-foreground/15">/</span>
+              {(i > 0 || !isWinPath) && <span className="text-foreground/15">/</span>}
               <button
-                onClick={() => browse("/" + segments.slice(0, i + 1).join("/"))}
+                onClick={() => browse(crumbPath(i))}
                 className={`transition-colors ${i === segments.length - 1 ? "text-foreground/70 font-medium" : "text-primary/50 hover:text-primary"}`}
               >
                 {seg}

--- a/graph-ui/src/components/StatsTab.tsx
+++ b/graph-ui/src/components/StatsTab.tsx
@@ -179,25 +179,44 @@ function CreateIndexModal({ onClose, onCreated }: { onClose: () => void; onCreat
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const filterRef = useRef<HTMLInputElement>(null);
+  /* Path whose listing is currently shown. Lets the typed-path effect skip a
+   * redundant re-fetch after browse() sets currentPath itself. */
+  const lastBrowsedRef = useRef<string>("");
 
-  const browse = useCallback(async (path?: string) => {
-    setLoading(true);
+  const browse = useCallback(async (path?: string, opts?: { silent?: boolean }) => {
+    const silent = opts?.silent ?? false;
+    if (!silent) setLoading(true);
     setError(null);
     try {
       const q = path ? `?path=${encodeURIComponent(path)}` : "";
       const res = await fetch(`/api/browse${q}`);
       const data = await res.json();
       if (data.error) throw new Error(data.error);
+      lastBrowsedRef.current = data.path ?? "";
       setCurrentPath(data.path ?? "");
       setDirs((data.dirs ?? []).sort());
       setRoots(data.roots ?? ["/"]);
       setParentPath(data.parent ?? "/");
-    } catch (e) { setError(e instanceof Error ? e.message : "Browse failed"); }
-    finally { setLoading(false); }
+    } catch (e) {
+      /* Silent (typed-path) refreshes keep the last good listing instead of
+       * flashing an error while the user is still typing a path. */
+      if (!silent) setError(e instanceof Error ? e.message : "Browse failed");
+    }
+    finally { if (!silent) setLoading(false); }
   }, []);
 
   useEffect(() => { browse(); }, [browse]);
   useEffect(() => { filterRef.current?.focus(); }, []);
+
+  /* When the user types a path directly into the Repository path field, refresh
+   * the folder listing to match (debounced). Without this the breadcrumb and
+   * path box updated but the directory list stayed stale — e.g. typing "D:/"
+   * still showed the previous location's folders. */
+  useEffect(() => {
+    if (!currentPath || currentPath === lastBrowsedRef.current) return;
+    const id = setTimeout(() => { void browse(currentPath, { silent: true }); }, 350);
+    return () => clearTimeout(id);
+  }, [currentPath, browse]);
 
   const filteredDirs = useMemo(() => {
     const q = filter.trim().toLowerCase();
@@ -267,6 +286,7 @@ function CreateIndexModal({ onClose, onCreated }: { onClose: () => void; onCreat
               aria-label={t.index.repositoryPath}
               value={currentPath}
               onChange={(e) => setCurrentPath(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void browse(currentPath); } }}
               className="w-full bg-white/[0.04] border border-white/[0.06] rounded-lg px-3 py-2 text-[12px] text-foreground font-mono outline-none focus:border-primary/40"
             />
           </label>

--- a/graph-ui/src/components/StatsTab.tsx
+++ b/graph-ui/src/components/StatsTab.tsx
@@ -208,12 +208,14 @@ function CreateIndexModal({ onClose, onCreated }: { onClose: () => void; onCreat
   useEffect(() => { browse(); }, [browse]);
   useEffect(() => { filterRef.current?.focus(); }, []);
 
-  /* When the user types a path directly into the Repository path field, refresh
-   * the folder listing to match (debounced). Without this the breadcrumb and
-   * path box updated but the directory list stayed stale — e.g. typing "D:/"
-   * still showed the previous location's folders. */
+  /* Windows only: when the user types a drive path into the Repository path
+   * field, refresh the folder listing to match (debounced). On Windows, typing
+   * is the way to switch drives, and without this the breadcrumb and path box
+   * updated but the directory list stayed stale (e.g. typing "D:/" still showed
+   * the previous drive's folders). POSIX navigation is left unchanged. */
   useEffect(() => {
     if (!currentPath || currentPath === lastBrowsedRef.current) return;
+    if (!/^[A-Za-z]:/.test(currentPath.replace(/\\/g, "/"))) return;
     const id = setTimeout(() => { void browse(currentPath, { silent: true }); }, 350);
     return () => clearTimeout(id);
   }, [currentPath, browse]);
@@ -300,7 +302,7 @@ function CreateIndexModal({ onClose, onCreated }: { onClose: () => void; onCreat
               aria-label={t.index.repositoryPath}
               value={currentPath}
               onChange={(e) => setCurrentPath(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void browse(currentPath); } }}
+              onKeyDown={(e) => { if (e.key === "Enter" && /^[A-Za-z]:/.test(currentPath.replace(/\\/g, "/"))) { e.preventDefault(); void browse(currentPath); } }}
               className="w-full bg-white/[0.04] border border-white/[0.06] rounded-lg px-3 py-2 text-[12px] text-foreground font-mono outline-none focus:border-primary/40"
             />
           </label>


### PR DESCRIPTION
## Summary

Fixes several issues with the repository folder picker (the **New Index** modal) on **Windows**. All changes are frontend-only (`graph-ui`) and Windows-scoped, so POSIX (Linux/macOS) navigation is left byte-for-byte unchanged, guarded by an `isWinPath` check.

On Windows the picker was effectively unusable: clicking breadcrumb segments errored with *"not a directory"*, switching drives didn't update the listing, and the `/` quick-jump button led to an empty view.

<img width="515" height="514" alt="Screenshot 2026-07-01 160803" src="https://github.com/user-attachments/assets/8ea09e9b-358e-4662-85fa-ac887211cb37" />

## Changes

- **Breadcrumb navigation.** On a Windows drive path (`C:/Users/x`) the breadcrumb built click targets as `"/" + segments` (`/C:/Users`), which the backend rejects as *"not a directory"*. It now builds drive-aware targets (`C:/`, `C:/Users`) and drops the meaningless leading `/` crumb on Windows.
- **Typed-path refresh.** Typing a path (e.g. `D:/`) updated the input and breadcrumb but never re-fetched the directory listing, so switching drives by typing showed the previous drive's folders. Added a debounced, silent `/api/browse` refresh (plus Enter-to-navigate), scoped to Windows drive paths. This matters because older backends don't enumerate drives, making typing the only way to switch drives.
- **Drive quick-jump.** On Windows the POSIX `/` quick-jump root is meaningless (browsing it returns an empty listing). It now offers drive roots instead, always including the current drive (derived from the browsed path), so it works even when the backend returns `roots: ["/"]`.

## Testing

- `graph-ui` unit tests: **12/12 passing**, including new regression tests for Windows breadcrumb navigation, typed-drive refresh, `/` to drive-root replacement, and a POSIX-negative test asserting a typed POSIX path does **not** trigger a re-browse.
- Manually verified in the running UI on Windows: breadcrumb clicks, typing `D:/`, and the drive-root quick-jump all list the correct folders.

## Notes

- Backend (`src/ui/http_server.c`) is unchanged; these fixes work against existing/older builds that return `roots: ["/"]`.
- The **"Project name" field removal** that was previously part of this PR has been split into a separate PR (#805) per review request, so this PR is now scoped purely to the four Windows navigation commits.
