### PR TITLE
docs: add real-world bash/ops-tooling repo example to Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ Benchmarked on Apple M3 Pro:
 
 **Token efficiency**: Five structural queries consumed ~3,400 tokens via codebase-memory-mcp versus ~412,000 tokens via file-by-file grep exploration — a **99.2% reduction**.
 
+### Real-World Example: A Bash/Config-Heavy Ops-Tooling Repo
+
+The benchmarks above are measured on large polyglot application codebases (Linux kernel, Django). It's worth showing what "Excellent"-tier Bash parsing (see [Language Support](#language-support)) translates to for a different repo shape: infra/ops-tooling repos that are mostly shell scripts, YAML/JSON config, and Markdown docs — not a typical multi-language application.
+
+One real session on an internal dev-tooling repo (bash + JSON + Markdown, ~14.9k indexed nodes / ~20.5k edges): a coding agent's single `search_code` call reproduced — ranked and deduplicated — the full list of consumers of a shared JSON config file in **~375ms**. The same task, done by fanning out a grep-based sub-agent instead, took **~131s across 12 tool calls** to assemble the equivalent answer by hand. Shell functions indexed as first-class graph nodes with `CALLS` edges made this possible on plain tree-sitter extraction alone — no Hybrid LSP tier needed.
+
+*(One real-world measurement from an actual agent session, not a controlled multi-trial benchmark — offered as a data point for teams wondering whether the token-efficiency value proposition holds outside typical application codebases.)*
+
 ## Troubleshooting & Diagnostics
 
 codebase-memory-mcp runs **100% locally and collects no telemetry** — your code, queries, environment, and usage never leave your machine. That privacy guarantee also means that when you hit something we can't reproduce on our side (a slow memory climb over hours, a performance regression, a leak that only appears after days of real use), **we have no data at all unless you choose to send it.** Here is how to capture it yourself.


### PR DESCRIPTION
## What does this PR do?

Adds a small "Real-World Example" subsection to the Performance section of the README.

The existing Performance benchmarks (Linux kernel, Django) are measured on large polyglot application codebases. Bash already scores in the "Excellent" parsing tier under Language Support, but there's no worked example of what that translates to for a different repo shape: infra/ops-tooling repos that are mostly shell scripts, YAML/JSON config, and Markdown docs rather than a typical multi-language application.

This adds one real session's measurement on an internal dev-tooling repo (bash + JSON + Markdown, ~14.9k indexed nodes / ~20.5k edges): a single `search_code` call reproducing a config-file consumer inventory in ~375ms vs. a grep-based sub-agent fan-out taking ~131s across 12 tool calls for the same result. It's explicitly labeled as one real-world data point, not a controlled multi-trial benchmark, to keep it honest alongside the hardware-benchmarked numbers above it.

Docs-only change — no source touched.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test`) — N/A, docs-only change, no C source touched
- [x] Lint passes (`make -f Makefile.cbm lint-ci`) — N/A, docs-only change, no C source touched
- [x] New behavior is covered by a test (reproduce-first for bug fixes) — N/A, not new behavior, a README addition