### PR TITLE
fix(git): correct canonical_root for worktrees and subdirectory projects

### DIFF
--- a/Makefile.cbm
+++ b/Makefile.cbm
@@ -340,6 +340,7 @@ TEST_DISCOVER_SRCS = \
     tests/test_language.c \
     tests/test_userconfig.c \
     tests/test_gitignore.c \
+    tests/test_git_context.c \
     tests/test_discover.c
 
 TEST_GRAPH_BUFFER_SRCS = tests/test_graph_buffer.c

--- a/src/git/git_context.c
+++ b/src/git/git_context.c
@@ -126,50 +126,58 @@ static char *join_root_relative(const char *root, const char *rel) {
     return out;
 }
 
+/* Derive the canonical repo root.
+ *
+ * Preferred (git 2.31+): abs_common_dir is `git rev-parse --path-format=absolute
+ * --git-common-dir` — git's OWN absolute, canonical common-dir. Because a main
+ * repo and its linked worktree both ask the same git binary, they resolve to the
+ * IDENTICAL path, so canonical_root is consistent across worktrees AND platforms
+ * with no manual join or realpath/_fullpath — which diverged under msys vs native
+ * path representations (#659 root cause, and the worktree==main-root breakage in
+ * test_pipeline.c git_context_linked_worktree). git also resolves the relative
+ * ".." internally, so the subdirectory case (#659) is fixed here too.
+ *
+ * Fallback (git < 2.31, no --path-format → abs_common_dir empty): the relative
+ * --git-common-dir is relative to input_path (the -C dir), so join against it and
+ * realpath-normalize the "..". Unix only — on Windows git emits an absolute
+ * common-dir so this branch isn't reached in practice, and _fullpath there
+ * reintroduces the msys divergence. */
 static char *derive_canonical_root(const char *input_path, const char *worktree_root,
-                                   const char *git_common_dir) {
-    const char *src = git_common_dir && git_common_dir[0] ? git_common_dir : worktree_root;
-    if (!src) {
-        return git_strdup("");
-    }
-
-    /* git rev-parse --git-common-dir outputs a path relative to the directory
-     * passed via -C (input_path), NOT to worktree_root. Using worktree_root as
-     * the base was wrong when input_path is a subdirectory or a linked worktree
-     * sibling — e.g. "../.git" joined with worktree_root produced "workspace/.."
-     * instead of the actual repo root. */
-    char *root = path_is_absolute(src) ? git_strdup(src) : join_root_relative(input_path, src);
-    if (!root) {
-        return NULL;
-    }
-
-    /* Resolve ".." components before stripping the "/.git" suffix.
-     * Without this, "/workspace/scripts/../.git" would strip to
-     * "/workspace/scripts/.." instead of "/workspace". The .git directory
-     * must exist for a valid git repo, so realpath() / _fullpath() succeeds. */
+                                   const char *git_common_dir, const char *abs_common_dir) {
+    char *root = NULL;
+    if (abs_common_dir && abs_common_dir[0] && path_is_absolute(abs_common_dir)) {
+        root = git_strdup(abs_common_dir);
+        if (!root) {
+            return NULL;
+        }
+    } else {
+        const char *src = git_common_dir && git_common_dir[0] ? git_common_dir : worktree_root;
+        if (!src) {
+            return git_strdup("");
+        }
 #ifndef _WIN32
-    {
-        char resolved[4096];
-        if (realpath(root, resolved) != NULL) {
-            free(root);
-            root = git_strdup(resolved);
-            if (!root) {
-                return NULL;
+        root = path_is_absolute(src) ? git_strdup(src) : join_root_relative(input_path, src);
+        if (!root) {
+            return NULL;
+        }
+        {
+            char resolved[4096];
+            if (realpath(root, resolved) != NULL) {
+                free(root);
+                root = git_strdup(resolved);
+                if (!root) {
+                    return NULL;
+                }
             }
         }
-    }
 #else
-    {
-        char resolved[4096];
-        if (_fullpath(resolved, root, sizeof(resolved)) != NULL) {
-            free(root);
-            root = git_strdup(resolved);
-            if (!root) {
-                return NULL;
-            }
+        (void)input_path;
+        root = path_is_absolute(src) ? git_strdup(src) : join_root_relative(worktree_root, src);
+        if (!root) {
+            return NULL;
         }
-    }
 #endif
+    }
 
     size_t len = strlen(root);
     while (len > 1 && (root[len - 1] == '/' || root[len - 1] == '\\')) {
@@ -285,7 +293,13 @@ int cbm_git_context_resolve(const char *path, cbm_git_context_t *out) {
 
     out->is_worktree =
         out->git_dir && out->git_common_dir && strcmp(out->git_dir, out->git_common_dir) != 0;
-    out->canonical_root = derive_canonical_root(path, out->worktree_root, out->git_common_dir);
+    /* git 2.31+ canonical absolute common-dir (best-effort; NULL on older git,
+     * where derive_canonical_root falls back to the relative common-dir). */
+    char *abs_common_dir = NULL;
+    (void)git_capture(path, "rev-parse --path-format=absolute --git-common-dir", &abs_common_dir);
+    out->canonical_root =
+        derive_canonical_root(path, out->worktree_root, out->git_common_dir, abs_common_dir);
+    free(abs_common_dir);
     out->branch_slug = slug_from_branch(out->branch, out->is_detached);
     if (git_capture(path, "merge-base HEAD @{upstream}", &out->base_sha) != 0) {
         out->base_sha = git_strdup("");

--- a/src/git/git_context.c
+++ b/src/git/git_context.c
@@ -126,16 +126,50 @@ static char *join_root_relative(const char *root, const char *rel) {
     return out;
 }
 
-static char *derive_canonical_root(const char *worktree_root, const char *git_common_dir) {
+static char *derive_canonical_root(const char *input_path, const char *worktree_root,
+                                   const char *git_common_dir) {
     const char *src = git_common_dir && git_common_dir[0] ? git_common_dir : worktree_root;
     if (!src) {
         return git_strdup("");
     }
 
-    char *root = path_is_absolute(src) ? git_strdup(src) : join_root_relative(worktree_root, src);
+    /* git rev-parse --git-common-dir outputs a path relative to the directory
+     * passed via -C (input_path), NOT to worktree_root. Using worktree_root as
+     * the base was wrong when input_path is a subdirectory or a linked worktree
+     * sibling — e.g. "../.git" joined with worktree_root produced "workspace/.."
+     * instead of the actual repo root. */
+    char *root = path_is_absolute(src) ? git_strdup(src) : join_root_relative(input_path, src);
     if (!root) {
         return NULL;
     }
+
+    /* Resolve ".." components before stripping the "/.git" suffix.
+     * Without this, "/workspace/scripts/../.git" would strip to
+     * "/workspace/scripts/.." instead of "/workspace". The .git directory
+     * must exist for a valid git repo, so realpath() / _fullpath() succeeds. */
+#ifndef _WIN32
+    {
+        char resolved[4096];
+        if (realpath(root, resolved) != NULL) {
+            free(root);
+            root = git_strdup(resolved);
+            if (!root) {
+                return NULL;
+            }
+        }
+    }
+#else
+    {
+        char resolved[4096];
+        if (_fullpath(resolved, root, sizeof(resolved)) != NULL) {
+            free(root);
+            root = git_strdup(resolved);
+            if (!root) {
+                return NULL;
+            }
+        }
+    }
+#endif
 
     size_t len = strlen(root);
     while (len > 1 && (root[len - 1] == '/' || root[len - 1] == '\\')) {
@@ -251,7 +285,7 @@ int cbm_git_context_resolve(const char *path, cbm_git_context_t *out) {
 
     out->is_worktree =
         out->git_dir && out->git_common_dir && strcmp(out->git_dir, out->git_common_dir) != 0;
-    out->canonical_root = derive_canonical_root(out->worktree_root, out->git_common_dir);
+    out->canonical_root = derive_canonical_root(path, out->worktree_root, out->git_common_dir);
     out->branch_slug = slug_from_branch(out->branch, out->is_detached);
     if (git_capture(path, "merge-base HEAD @{upstream}", &out->base_sha) != 0) {
         out->base_sha = git_strdup("");

--- a/tests/test_git_context.c
+++ b/tests/test_git_context.c
@@ -34,6 +34,10 @@
 #include <limits.h>
 #endif
 
+/* These helpers shell out to git and are only used by the non-Windows test
+ * bodies below; on Windows every test SKIP_PLATFORMs, so guard them here too or
+ * they'd be unused-static functions and fail the -Werror build. */
+#ifndef _WIN32
 /* Run a git command inside dir, return 0 on success. */
 static int git_run(const char *dir, const char *args) {
     char cmd[1024];
@@ -55,6 +59,7 @@ static int make_git_repo(const char *dir) {
     if (git_run(dir, "commit -q -m init") != 0) return -1;
     return 0;
 }
+#endif /* _WIN32 */
 
 /* ── canonical_root: normal repo indexed from its root ──────────── */
 

--- a/tests/test_git_context.c
+++ b/tests/test_git_context.c
@@ -1,0 +1,236 @@
+/*
+ * test_git_context.c — Tests for cbm_git_context_resolve(), focusing on
+ * the canonical_root derivation for git worktrees and subdirectory projects.
+ *
+ * Issue #659: canonical_root was computed incorrectly for linked worktrees
+ * and projects indexed from a subdirectory of the repository root.
+ * git rev-parse --git-common-dir outputs a path relative to the -C directory
+ * (input_path), not to worktree_root. Joining it with worktree_root and then
+ * string-stripping "/.git" left unresolved ".." components in the result.
+ *
+ * These tests shell out to `git`, so they SKIP_PLATFORM on Windows (the CI
+ * shell there cannot init a repo via system()).
+ *
+ * Reproduce-first guard: canonical_root_subdir is the genuine RED-without-the-fix
+ * guard — a repo indexed from a subdirectory yields a relative --git-common-dir
+ * ("../.git"), so the unfixed code returns an un-normalized "<root>/subdir/.."
+ * (verified FAIL on the unfixed derive_canonical_root; GREEN with the realpath
+ * normalization). canonical_root_linked_worktree is a SUPPORTING INVARIANT, not
+ * the #659 reproducer: on git that emits an *absolute* --git-common-dir for a
+ * linked worktree (e.g. 2.48.x) the bug does not manifest there, so that test
+ * passes with or without the fix. It still enforces the worktree->main-root
+ * invariant and would catch the bug on git builds that emit a relative
+ * worktree common-dir. canonical_root_repo_root is a baseline (no `..` to
+ * normalize), not a guard.
+ */
+#include "test_framework.h"
+#include "test_helpers.h"
+#include "git/git_context.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#ifndef _WIN32
+#include <limits.h>
+#endif
+
+/* Run a git command inside dir, return 0 on success. */
+static int git_run(const char *dir, const char *args) {
+    char cmd[1024];
+    snprintf(cmd, sizeof(cmd), "git -C \"%s\" %s >/dev/null 2>&1", dir, args);
+    return system(cmd);
+}
+
+/* Create a minimal git repo at dir (init + empty commit so HEAD exists). */
+static int make_git_repo(const char *dir) {
+    if (th_mkdir_p(dir) != 0) return -1;
+    if (git_run(dir, "init -q") != 0) return -1;
+    if (git_run(dir, "config user.email test@example.com") != 0) return -1;
+    if (git_run(dir, "config user.name Test") != 0) return -1;
+    /* Create a file so HEAD points to a real commit. */
+    char path[1024];
+    snprintf(path, sizeof(path), "%s/.keep", dir);
+    th_write_file(path, "");
+    if (git_run(dir, "add .keep") != 0) return -1;
+    if (git_run(dir, "commit -q -m init") != 0) return -1;
+    return 0;
+}
+
+/* ── canonical_root: normal repo indexed from its root ──────────── */
+
+TEST(canonical_root_repo_root) {
+#ifdef _WIN32
+    SKIP_PLATFORM("git-based canonical_root test not supported on Windows CI");
+#else
+    char *tmp = th_mktempdir("cbm_gitctx");
+    if (!tmp) FAIL("th_mktempdir returned NULL");
+
+    if (make_git_repo(tmp) != 0) {
+        th_rmtree(tmp);
+        SKIP_PLATFORM("git not available to init a repo");
+    }
+
+    cbm_git_context_t ctx = {0};
+    int rc = cbm_git_context_resolve(tmp, &ctx);
+    if (rc != 0 || !ctx.is_git) {
+        cbm_git_context_free(&ctx);
+        th_rmtree(tmp);
+        FAIL("cbm_git_context_resolve failed or not a git repo");
+    }
+
+    char expected[4096];
+    if (realpath(tmp, expected) == NULL) {
+        cbm_git_context_free(&ctx);
+        th_rmtree(tmp);
+        FAIL("realpath(tmp) failed");
+    }
+
+    ASSERT_STR_EQ(ctx.canonical_root, expected);
+
+    cbm_git_context_free(&ctx);
+    th_rmtree(tmp);
+    PASS();
+#endif /* _WIN32 */
+}
+
+/* ── canonical_root: indexed from a subdirectory (issue #659) ─────
+ * THE reproduce-first guard: from a subdir, --git-common-dir is relative, so the
+ * unfixed derive_canonical_root joins it against worktree_root and strips "/.git"
+ * textually, leaving canonical_root = "<root>/subdir/.." (or "<root>/..") instead
+ * of "<root>". Verified RED on the unfixed code, GREEN with the realpath fix. */
+
+TEST(canonical_root_subdir) {
+#ifdef _WIN32
+    SKIP_PLATFORM("git-based canonical_root test not supported on Windows CI");
+#else
+    char *tmp = th_mktempdir("cbm_gitctx");
+    if (!tmp) FAIL("th_mktempdir returned NULL");
+
+    if (make_git_repo(tmp) != 0) {
+        th_rmtree(tmp);
+        SKIP_PLATFORM("git not available to init a repo");
+    }
+
+    /* Create a subdirectory inside the repo. */
+    char subdir[1024];
+    snprintf(subdir, sizeof(subdir), "%s/scripts", tmp);
+    if (th_mkdir_p(subdir) != 0) {
+        th_rmtree(tmp);
+        FAIL("failed to create subdir");
+    }
+
+    cbm_git_context_t ctx = {0};
+    int rc = cbm_git_context_resolve(subdir, &ctx);
+    if (rc != 0 || !ctx.is_git) {
+        cbm_git_context_free(&ctx);
+        th_rmtree(tmp);
+        FAIL("cbm_git_context_resolve on subdir failed or not a git repo");
+    }
+
+    /* canonical_root must equal the repo root, NOT "<repo>/.." or "<subdir>/..". */
+    char expected[4096];
+    if (realpath(tmp, expected) == NULL) {
+        cbm_git_context_free(&ctx);
+        th_rmtree(tmp);
+        FAIL("realpath(tmp) failed");
+    }
+
+    ASSERT_STR_EQ(ctx.canonical_root, expected);
+
+    /* Sanity: canonical_root must not contain ".." or end with a slash. */
+    ASSERT(strstr(ctx.canonical_root, "..") == NULL);
+    ASSERT(ctx.canonical_root[strlen(ctx.canonical_root) - 1] != '/');
+
+    cbm_git_context_free(&ctx);
+    th_rmtree(tmp);
+    PASS();
+#endif /* _WIN32 */
+}
+
+/* ── canonical_root: linked git worktree (supporting invariant) ────
+ * NOT the #659 reproducer on modern git: git that emits an *absolute*
+ * --git-common-dir for a linked worktree (e.g. 2.48.x) takes the path_is_absolute
+ * branch, so the bug does not manifest and this passes with or without the fix.
+ * It is kept as an invariant — canonical_root of a linked worktree must equal the
+ * MAIN repo root (never the worktree root or its parent) — and would fail on a git
+ * build that emits a *relative* worktree common-dir. The genuine RED-without-fix
+ * guard for #659 is canonical_root_subdir above. */
+
+TEST(canonical_root_linked_worktree) {
+#ifdef _WIN32
+    SKIP_PLATFORM("git worktree test not implemented for Windows");
+#else
+    /* th_mktempdir() returns a static buffer — copy before the second call. */
+    char main_tmp[256];
+    char *raw = th_mktempdir("cbm_main");
+    if (!raw) FAIL("th_mktempdir returned NULL");
+    strncpy(main_tmp, raw, sizeof(main_tmp) - 1);
+    main_tmp[sizeof(main_tmp) - 1] = '\0';
+
+    char wt_tmp[256];
+    raw = th_mktempdir("cbm_worktree");
+    if (!raw) FAIL("th_mktempdir returned NULL");
+    strncpy(wt_tmp, raw, sizeof(wt_tmp) - 1);
+    wt_tmp[sizeof(wt_tmp) - 1] = '\0';
+
+    /* Remove the worktree dir first — git worktree add creates it. */
+    th_rmtree(wt_tmp);
+
+    if (make_git_repo(main_tmp) != 0) {
+        th_rmtree(main_tmp);
+        SKIP_PLATFORM("git not available to init a repo");
+    }
+
+    /* Create a branch for the worktree. */
+    if (git_run(main_tmp, "branch wt-branch") != 0) {
+        th_rmtree(main_tmp);
+        FAIL("failed to create branch for worktree");
+    }
+
+    /* Add a linked worktree. */
+    char wt_cmd[1024];
+    snprintf(wt_cmd, sizeof(wt_cmd), "worktree add \"%s\" wt-branch", wt_tmp);
+    if (git_run(main_tmp, wt_cmd) != 0) {
+        th_rmtree(wt_tmp);
+        th_rmtree(main_tmp);
+        SKIP_PLATFORM("git worktree add unavailable (git 2.5+ required)");
+    }
+
+    cbm_git_context_t ctx = {0};
+    int rc = cbm_git_context_resolve(wt_tmp, &ctx);
+    if (rc != 0 || !ctx.is_git) {
+        cbm_git_context_free(&ctx);
+        git_run(main_tmp, "worktree prune");
+        th_rmtree(main_tmp);
+        th_rmtree(wt_tmp);
+        FAIL("cbm_git_context_resolve on linked worktree failed");
+    }
+
+    /* canonical_root must be the MAIN repo root, not the worktree root or its parent. */
+    char expected[4096];
+    if (realpath(main_tmp, expected) == NULL) {
+        cbm_git_context_free(&ctx);
+        git_run(main_tmp, "worktree prune");
+        th_rmtree(main_tmp);
+        th_rmtree(wt_tmp);
+        FAIL("realpath(main_tmp) failed");
+    }
+
+    ASSERT_STR_EQ(ctx.canonical_root, expected);
+    ASSERT(strstr(ctx.canonical_root, "..") == NULL);
+
+    cbm_git_context_free(&ctx);
+    git_run(main_tmp, "worktree prune");
+    th_rmtree(main_tmp);
+    th_rmtree(wt_tmp);
+    PASS();
+#endif /* _WIN32 */
+}
+
+/* ── Suite ──────────────────────────────────────────────────────── */
+
+SUITE(git_context) {
+    RUN_TEST(canonical_root_repo_root);
+    RUN_TEST(canonical_root_subdir);
+    RUN_TEST(canonical_root_linked_worktree);
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -58,6 +58,7 @@ extern void suite_mcp(void);
 extern void suite_language(void);
 extern void suite_userconfig(void);
 extern void suite_gitignore(void);
+extern void suite_git_context(void);
 extern void suite_discover(void);
 extern void suite_graph_buffer(void);
 extern void suite_registry(void);
@@ -173,6 +174,7 @@ int main(int argc, char **argv) {
     RUN_SELECTED_SUITE(language);
     RUN_SELECTED_SUITE(userconfig);
     RUN_SELECTED_SUITE(gitignore);
+    RUN_SELECTED_SUITE(git_context);
     RUN_SELECTED_SUITE(discover);
 
     /* Graph Buffer (M7) */


### PR DESCRIPTION
Distilled from #672 (thanks @anivaryam for diagnosing #659), reworked to be platform-agnostic.

## Bug (#659)
`detect_changes` returned an empty `impacted_symbols` for projects indexed inside a git worktree or from a repo subdirectory: `canonical_root` was computed wrong. `git rev-parse --git-common-dir` emits a path relative to the `-C` directory, and the `/.git` suffix was stripped textually without resolving `..`, so the derived root never matched the project's stored root path.

## Fix — let git canonicalize
Instead of manually joining the relative common-dir and normalizing it ourselves (`realpath`/`_fullpath`), capture git's own absolute canonical common-dir:

```
git rev-parse --path-format=absolute --git-common-dir
```

`--path-format=absolute` (git 2.31+) makes the path **absolute and canonical**. `derive_canonical_root` uses it directly (strip `/.git`). Why this is the right fix:
- **#659 fixed** — git resolves the relative `..` internally, so a subdirectory (or worktree) yields the real repo root.
- **Platform-agnostic & consistent** — a main repo and its linked worktree both ask the same git binary, so they resolve to the **identical** path. This preserves the `worktree == main-root` invariant (`test_pipeline.c git_context_linked_worktree`) on **all** platforms, including the MSYS2 Windows CI where our earlier `_fullpath` approach diverged (msys `/tmp` → `D:\a\_temp\msys64\tmp` vs git's native `D:\tmp` for the same directory).
- **No platform-specific path code** — no `realpath`/`_fullpath`/`#ifdef` on the primary path.

**Fallback:** for git < 2.31 (no `--path-format`, capture returns empty) it falls back to the relative-join derivation (Unix `realpath`).

## Reproduce-first (verified locally, git 2.48.1 / macOS)
`tests/test_git_context.c` — `canonical_root_subdir` is the genuine guard: a repo indexed from a subdirectory. **RED** without the fix (`"<root>/.." != "<root>"`), **GREEN** with it; full suite green. The git-based tests `SKIP_PLATFORM` on Windows (that CI shell can't `git init` via `system()` with a POSIX redirect); the cross-platform correctness is covered by the pre-existing `git_context_linked_worktree` invariant test, which now passes on Windows too.

## Why a distillation of #672
#672 diagnosed #659 correctly; its own fix (manual `input_path` join + `_fullpath`) couldn't pass the Windows CI leg because `_fullpath` canonicalizes msys paths inconsistently with git. This PR keeps the diagnosis and reproduce case but derives the path from git itself, which is correct on every platform. Supersedes #696 (incomplete). Co-authored with @anivaryam.

Closes #659

**Source:** [`git rev-parse --path-format`](https://git-scm.com/docs/git-rev-parse) (git 2.31+).
