### PR TITLE
fix(discover): use cbm_fopen for worktree gitlink + commondir reads

### DIFF
--- a/src/discover/discover.c
+++ b/src/discover/discover.c
@@ -778,8 +778,9 @@ static bool resolve_git_common_dir(const char *repo_path, char *common_dir, size
         return false;
     }
 
-    /* Linked worktree: parse "gitdir: <path>" from the gitlink file. */
-    FILE *f = fopen(dot_git, "r");
+    /* Linked worktree: parse "gitdir: <path>" from the gitlink file.
+     * cbm_fopen (not raw fopen) so non-ASCII repo paths open on Windows. */
+    FILE *f = cbm_fopen(dot_git, "r");
     if (!f) {
         return false;
     }
@@ -811,7 +812,7 @@ static bool resolve_git_common_dir(const char *repo_path, char *common_dir, size
      * (typically a relative path like "../.."). Absent in single-worktree gitdirs. */
     char commondir_path[CBM_SZ_4K];
     path_join(commondir_path, sizeof(commondir_path), git_dir, "commondir");
-    FILE *cf = fopen(commondir_path, "r");
+    FILE *cf = cbm_fopen(commondir_path, "r");
     if (cf) {
         char cbuf[CBM_SZ_4K];
         bool resolved = false;


### PR DESCRIPTION
Follow-up to #683 (@Naam) — a small consistency / Windows-correctness hardening.

## What
#683 added worktree `info/exclude` + `core.excludesFile` support by reading the `.git` gitlink file and its `commondir`. Those two reads used raw `fopen()`. On Windows raw `fopen` uses the ANSI code page, so a repo indexed under a **non-ASCII path** (e.g. CJK) fails to open `.git`/`commondir` → the worktree's excludes are silently not honored (fails gracefully, no crash).

## Fix
Swap both reads to **`cbm_fopen()`** — the UTF-8→`_wfopen` wrapper (`src/foundation/compat_fs.c`) — matching the rest of `discover.c` (e.g. `read_core_excludes_file`, line 248). `discover.c` now contains **no raw `fopen`**.

## Verification
This defect is **Windows-only**: on POSIX raw `fopen` already opens UTF-8 byte paths, so there is no local RED reproduction (a POSIX test would be vacuous). Verified by the **full suite staying green locally** (no regression) + **cross-platform CI** (incl. Windows). The existing `discover_worktree_info_exclude` test exercises the changed `resolve_git_common_dir` on all platforms.

Refs #682, #683
