### PR TITLE
fix(pipeline): reject non-file-like IMPORTS targets in fallback strategies

### DIFF
--- a/src/pipeline/pass_pkgmap.c
+++ b/src/pipeline/pass_pkgmap.c
@@ -1328,8 +1328,9 @@ static const cbm_gbuf_node_t *resolve_sibling_file(const cbm_pipeline_ctx_t *ctx
         }
         const cbm_gbuf_node_t *n = cbm_gbuf_find_by_qn(ctx->gbuf, qn);
         free(qn);
-        if (n && (!source_file_qn || !n->qualified_name ||
-                  strcmp(n->qualified_name, source_file_qn) != 0)) {
+        if (n && import_targetable_label(n->label) &&
+            (!source_file_qn || !n->qualified_name ||
+             strcmp(n->qualified_name, source_file_qn) != 0)) {
             found = n;
             break;
         }
@@ -1347,7 +1348,13 @@ const cbm_gbuf_node_t *cbm_pipeline_resolve_import_node(const cbm_pipeline_ctx_t
         return NULL;
     }
 
-    /* Strategy 1: module-path resolution → existing node (Python/TS/Go). */
+    /* Strategy 1: module-path resolution → existing node (Python/TS/Go).
+     * No label filter here: directory-module languages (Go/Java packages)
+     * legitimately resolve straight to a Folder node -- that's the intended,
+     * correct import target, not a collision. The Folder-collision problem
+     * (#767) only shows up downstream, in Strategy 4's retry-with-truncated-
+     * path loop, which re-enters resolve_module with a DIFFERENT, shortened
+     * string that the original import never named. */
     char *target_qn = cbm_pipeline_resolve_module(ctx, source_rel, imp->module_path);
     const cbm_gbuf_node_t *target = target_qn ? cbm_gbuf_find_by_qn(ctx->gbuf, target_qn) : NULL;
     free(target_qn);
@@ -1571,8 +1578,9 @@ const cbm_gbuf_node_t *cbm_pipeline_resolve_import_node(const cbm_pipeline_ctx_t
                 char *rqn = cbm_pipeline_resolve_module(ctx, source_rel, work);
                 const cbm_gbuf_node_t *n = rqn ? cbm_gbuf_find_by_qn(ctx->gbuf, rqn) : NULL;
                 free(rqn);
-                if (n && (!source_file_qn || !n->qualified_name ||
-                          strcmp(n->qualified_name, source_file_qn) != 0)) {
+                if (n && import_targetable_label(n->label) &&
+                    (!source_file_qn || !n->qualified_name ||
+                     strcmp(n->qualified_name, source_file_qn) != 0)) {
                     return n;
                 }
                 char *sl = strrchr(work, '/');

--- a/tests/test_lang_contract.c
+++ b/tests/test_lang_contract.c
@@ -1158,6 +1158,50 @@ TEST(contract_edge_workspaces_imports_issue408) {
     PASS();
 }
 
+/* #767: a wildcard tsconfig alias for the "@lib" prefix (mapped to ./src/lib)
+ * shares that prefix with an unrelated scoped npm package ("@lib/external-pkg",
+ * meant to resolve normally from node_modules). The engine has no such file
+ * and must NOT invent an edge to the "src/lib" Folder node via a later
+ * fallback strategy that re-tries the truncated "@lib" prefix against the
+ * tsconfig's other, bare alias entry. Zero IMPORTS edges in the whole project
+ * is the correct outcome: the same as any other unresolved external import. */
+TEST(contract_edge_imports_alias_no_phantom_folder_edge_issue767) {
+    LangProj lp;
+    static const LangFile f[] = {
+        {"tsconfig.json", "{\n  \"compilerOptions\": {\n    \"paths\": {\n"
+                          "      \"@lib\": [\"./src/lib\"],\n"
+                          "      \"@lib/*\": [\"./src/lib/*\"]\n    }\n  }\n}\n"},
+        {"src/lib/thing.ts", "export const Thing = {};\n"},
+        {"src/consumer.ts",
+         "import { ClientC } from '@lib/external-pkg';\n\n"
+         "export function useClient() {\n  return new ClientC();\n}\n"}};
+    cbm_store_t *store = lang_index_files(&lp, f, 3);
+    int got = store ? cbm_store_count_edges_by_type(store, lp.project, "IMPORTS") : -1;
+    if (got != 0) {
+        fprintf(stderr, "  [EDGE] FAIL IMPORTS count=%d expected=0 (phantom Folder edge)\n", got);
+    }
+    ASSERT_EQ(got, 0);
+    lang_cleanup(&lp, store);
+    PASS();
+}
+
+/* #767 regression guard: a wildcard tsconfig alias resolving to a REAL,
+ * indexed file must still produce its IMPORTS edge — the import-targetable
+ * label filter must reject Folder/Project/etc. matches without rejecting
+ * legitimate File/Module matches. */
+TEST(contract_edge_imports_alias_resolves_real_file_issue767) {
+    static const LangFile f[] = {
+        {"tsconfig.json", "{\n  \"compilerOptions\": {\n    \"paths\": {\n"
+                          "      \"@lib\": [\"./src/lib\"],\n"
+                          "      \"@lib/*\": [\"./src/lib/*\"]\n    }\n  }\n}\n"},
+        {"src/lib/thing.ts", "export const Thing = {};\n"},
+        {"src/consumer.ts",
+         "import { Thing } from '@lib/thing';\n\n"
+         "export function useThing() {\n  return Thing;\n}\n"}};
+    ASSERT_TRUE(edge_present(f, 3, "IMPORTS", 1));
+    PASS();
+}
+
 /* DEPENDS_ON — Helm Chart.yaml `dependencies:` -> per-dependency Chart node.
  * Basename must be exactly "Chart.yaml"; pass_k8s runs in both pipeline paths. */
 TEST(contract_edge_depends_on) {
@@ -1365,6 +1409,8 @@ SUITE(lang_contract) {
      * FILE_CHANGES_WITH (git co-change). Completes 25-edge-type coverage. */
     RUN_TEST(contract_edge_tests);
     RUN_TEST(contract_edge_workspaces_imports_issue408);
+    RUN_TEST(contract_edge_imports_alias_no_phantom_folder_edge_issue767);
+    RUN_TEST(contract_edge_imports_alias_resolves_real_file_issue767);
     RUN_TEST(contract_edge_depends_on);
     RUN_TEST(contract_edge_parallel_service_edges);
     RUN_TEST(contract_edge_file_changes_with);


### PR DESCRIPTION
## What does this PR do?

Closes #767: a wildcard tsconfig path alias (e.g. `"@lib/*": ["./src/lib/*"]`)
shares its prefix with an unrelated scoped npm package meant to resolve
normally from `node_modules`. The engine invented an `IMPORTS` edge into the
local `src/lib` **Folder** node instead of leaving the import unresolved.

The direct match already failed cleanly today: `cbm_pipeline_resolve_module`
resolves `@lib/external-pkg` to a QN that doesn't correspond to any real
file, and `cbm_gbuf_find_by_qn` correctly finds nothing. The phantom edge
actually comes from **Strategy 4** in `cbm_pipeline_resolve_import_node`
(`src/pipeline/pass_pkgmap.c`) — a generic "strip a trailing path segment and
retry" fallback applied to *every* language (not just its intended Rust
`crate::`/`self::`/`super::` case). Truncating `@lib/external-pkg` down to
`@lib` hits the tsconfig's *other*, bare (non-wildcard) alias entry that maps
straight to a directory. The resulting QN collides with that directory's real
Folder node (`cbm_pipeline_fqn_module` and `cbm_pipeline_fqn_folder` both
dot-join path segments with no type tag to distinguish them), and Strategy 4
accepted whatever node it found there.

Strategy 3 (symbol-name fallback) already guards its matches with
`import_targetable_label()`, which excludes `Folder`/`Project`/etc. Strategy
1b (`resolve_sibling_file`, used only for markup/build-tool sibling imports —
SCSS/Just/BitBake/Meson/Pony, none of which are directory-module languages)
and Strategy 4 lacked the same guard; both now use it too.

Strategy 1 (the primary, direct resolution path) intentionally keeps **no**
such filter: Go and Java are directory-module languages in this pipeline
(`cbm_lang_module_is_dir`), so a bare package import correctly and
deliberately resolves straight to a Folder node there. I initially added the
guard to Strategy 1 as well and it broke Go/Java import resolution — caught
by the existing `test_edge_imports.c` integration suite (`ei_go_same_module_import`,
a documented GREEN-guard test) — before scoping the fix down to just the two
fallback strategies where the collision actually originates.

## Checklist

- [x] Every commit is signed off (`git commit -s`)
- [x] Tests pass locally (`make -f Makefile.cbm test`) — full suite green
      except one pre-existing, unrelated RSS-ceiling test in
      `test_incremental.c` (~2.6GB vs 2048MB limit) on this machine
- [x] Lint passes (`make -f Makefile.cbm lint-ci`) — could not verify
      locally, cppcheck/clang-format are not installed in this
      environment; relying on CI
- [x] New behavior is covered by a test: added
      `contract_edge_imports_alias_no_phantom_folder_edge_issue767` (asserts
      zero `IMPORTS` edges for the collision case) and
      `contract_edge_imports_alias_resolves_real_file_issue767` (regression
      guard: a wildcard alias resolving to a real file must still produce its
      edge) in `tests/test_lang_contract.c`