### PR TITLE
Sync MCP server version with binary version

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -521,6 +521,7 @@ int main(int argc, char **argv) {
      * below opens sqlite early), else sqlite3_config returns SQLITE_MISUSE and
      * the bind is silently ignored. No-op in the test build. */
     cbm_alloc_init();
+    cbm_cli_set_version(CBM_VERSION);
     cbm_profile_init(); /* reads CBM_PROFILE env var, gates all prof macros */
     /* CBM_LOG_LEVEL support — distilled from #414 (closes #413). Apply before
      * the first log statement so the configured level governs all output. */

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -657,7 +657,7 @@ char *cbm_mcp_initialize_response(const char *params_json) {
 
     yyjson_mut_val *impl = yyjson_mut_obj(doc);
     yyjson_mut_obj_add_str(doc, impl, "name", "codebase-memory-mcp");
-    yyjson_mut_obj_add_str(doc, impl, "version", "0.10.0");
+    yyjson_mut_obj_add_str(doc, impl, "version", cbm_cli_get_version());
     yyjson_mut_obj_add_val(doc, root, "serverInfo", impl);
 
     yyjson_mut_val *caps = yyjson_mut_obj(doc);

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -7,6 +7,7 @@
 #include "../src/foundation/compat_fs.h" /* cbm_unlink / cbm_rmdir */
 #include "../src/foundation/log.h"
 #include "test_framework.h"
+#include <cli/cli.h>
 #include <mcp/mcp.h>
 #include <store/store.h>
 #include <yyjson/yyjson.h>
@@ -146,10 +147,13 @@ TEST(jsonrpc_format_error) {
  * ══════════════════════════════════════════════════════════════════ */
 
 TEST(mcp_initialize_response) {
+    cbm_cli_set_version("9.8.7-test");
+
     /* Default (no params): returns latest supported version */
     char *json = cbm_mcp_initialize_response(NULL);
     ASSERT_NOT_NULL(json);
     ASSERT_NOT_NULL(strstr(json, "codebase-memory-mcp"));
+    ASSERT_NOT_NULL(strstr(json, "\"version\":\"9.8.7-test\""));
     ASSERT_NOT_NULL(strstr(json, "capabilities"));
     ASSERT_NOT_NULL(strstr(json, "tools"));
     ASSERT_NOT_NULL(strstr(json, "\"listChanged\":false"));
@@ -172,6 +176,7 @@ TEST(mcp_initialize_response) {
     ASSERT_NOT_NULL(json);
     ASSERT_NOT_NULL(strstr(json, "2025-11-25"));
     free(json);
+    cbm_cli_set_version("dev");
     PASS();
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the MCP initialize response so `serverInfo.version` comes from the same version source used by the binary instead of a hard-coded `0.10.0` string.

This also initializes the shared CLI version state from `CBM_VERSION` during startup, so release builds stamped with `scripts/build.sh --version ...` report the same version through `--version`, update checks, and MCP `initialize`.

## Checklist

- [x] Every commit is signed off (`git commit -s`) - required, CI rejects unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Tests pass locally (`make -f Makefile.cbm test`) - not run: this Windows environment has no `make`/`gcc`, and WSL fails to mount its distro VHDX.
- [ ] Lint passes (`make -f Makefile.cbm lint-ci`) - not run for the same local toolchain limitation.
- [x] New behavior is covered by a test (reproduce-first for bug fixes)

Local checks run:

- `git diff --check -- src/main.c src/mcp/mcp.c tests/test_mcp.c`