### PR TITLE
graph-ui: auto-rotation toggle + silent auto-refresh

### DIFF
--- a/graph-ui/src/components/GraphScene.tsx
+++ b/graph-ui/src/components/GraphScene.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Canvas, useThree, useFrame } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import type { OrbitControls as OrbitControlsImpl } from "three-stdlib";
@@ -42,47 +42,10 @@ function CameraAnimator({ target }: { target: CameraTarget | null }) {
   return null;
 }
 
-/* ── Idle auto-rotation ──────────────────────────────────── */
+/* ── Render tuning ── */
 
-const IDLE_TIMEOUT_MS = 60_000;
 export const GRAPH_CANVAS_DPR: [number, number] = [1, 1.5];
 export const GRAPH_COMPOSER_MULTISAMPLING = 0;
-
-function IdleAutoRotate({
-  controlsRef,
-}: {
-  controlsRef: React.RefObject<OrbitControlsImpl | null>;
-}) {
-  const lastInteraction = useRef(Date.now());
-
-  /* Reset timer on any pointer/wheel event */
-  const resetTimer = useCallback(() => {
-    lastInteraction.current = Date.now();
-    if (controlsRef.current) {
-      controlsRef.current.autoRotate = false;
-    }
-  }, [controlsRef]);
-
-  useEffect(() => {
-    const canvas = document.querySelector("canvas");
-    if (!canvas) return;
-
-    canvas.addEventListener("pointerdown", resetTimer);
-    canvas.addEventListener("wheel", resetTimer);
-    return () => {
-      canvas.removeEventListener("pointerdown", resetTimer);
-      canvas.removeEventListener("wheel", resetTimer);
-    };
-  }, [resetTimer]);
-
-  useFrame(() => {
-    if (!controlsRef.current) return;
-    const idle = Date.now() - lastInteraction.current > IDLE_TIMEOUT_MS;
-    controlsRef.current.autoRotate = idle;
-  });
-
-  return null;
-}
 
 /* ── Main scene ─────────────────────────────────────────── */
 
@@ -91,6 +54,7 @@ interface GraphSceneProps {
   highlightedIds: Set<number> | null;
   cameraTarget: CameraTarget | null;
   showLabels: boolean;
+  autoRotate: boolean;
   onNodeClick: (node: GraphNode) => void;
 }
 
@@ -101,6 +65,7 @@ export function GraphScene({
   highlightedIds,
   cameraTarget,
   showLabels,
+  autoRotate,
   onNodeClick,
 }: GraphSceneProps) {
   const [hovered, setHovered] = useState<GraphNode | null>(null);
@@ -180,7 +145,6 @@ export function GraphScene({
       {hovered && <NodeTooltip node={hovered} />}
 
       <CameraAnimator target={cameraTarget} />
-      <IdleAutoRotate controlsRef={controlsRef} />
 
       <EffectComposer multisampling={GRAPH_COMPOSER_MULTISAMPLING}>
         <Bloom
@@ -194,6 +158,7 @@ export function GraphScene({
 
       <OrbitControls
         ref={controlsRef}
+        autoRotate={autoRotate}
         enableDamping
         dampingFactor={0.08}
         rotateSpeed={0.5}

--- a/graph-ui/src/components/GraphTab.tsx
+++ b/graph-ui/src/components/GraphTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { useGraphData } from "../hooks/useGraphData";
 import {
@@ -29,6 +29,9 @@ interface GraphTabProps {
   project: string | null;
 }
 
+/* How often the graph silently re-fetches to pick up re-index changes. */
+export const GRAPH_AUTO_REFRESH_MS = 15_000;
+
 export function formatGraphLimitNotice(data: GraphData | null): string | null {
   if (!data || data.total_nodes <= data.nodes.length) return null;
   return `Showing ${data.nodes.length.toLocaleString()} of ${data.total_nodes.toLocaleString()} nodes. Use filters to narrow.`;
@@ -41,6 +44,8 @@ export function GraphTab({ project }: GraphTabProps) {
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
   const [cameraTarget, setCameraTarget] = useState<CameraTarget | null>(null);
   const [showLabels, setShowLabels] = useState(true);
+  const [autoRotate, setAutoRotate] = useState(false);
+  const filterSig = useRef<string>("");
   const [leftWidth, setLeftWidth] = useState(() => loadWidth("cbm-left-w", 260));
   const [rightWidth, setRightWidth] = useState(() => loadWidth("cbm-right-w", 280));
   const limitNotice = formatGraphLimitNotice(data);
@@ -49,7 +54,10 @@ export function GraphTab({ project }: GraphTabProps) {
   const [enabledLabels, setEnabledLabels] = useState<Set<string>>(new Set());
   const [enabledEdgeTypes, setEnabledEdgeTypes] = useState<Set<string>>(new Set());
 
-  /* Initialize filters when data loads */
+  /* Initialize filters when the graph's label/edge-type universe changes.
+   * Guarding on the signature (not just `data`) means a silent auto-refresh —
+   * which returns the same universe — preserves the user's filter selection
+   * instead of resetting it every poll. */
   useEffect(() => {
     if (!data) return;
     const labels = new Set(data.nodes.map((n) => n.label));
@@ -59,6 +67,10 @@ export function GraphTab({ project }: GraphTabProps) {
       for (const e of lp.edges) types.add(e.type);
       for (const e of lp.cross_edges) types.add(e.type);
     }
+    const sig =
+      [...labels].sort().join("|") + "::" + [...types].sort().join("|");
+    if (sig === filterSig.current) return;
+    filterSig.current = sig;
     setEnabledLabels(labels);
     setEnabledEdgeTypes(types);
   }, [data]);
@@ -99,6 +111,17 @@ export function GraphTab({ project }: GraphTabProps) {
       setHighlightedIds(null);
       setSelectedPath(null);
     }
+  }, [project, fetchOverview]);
+
+  /* Silent auto-refresh: pick up re-index changes without blanking the graph
+   * or disturbing the current selection/filters. */
+  useEffect(() => {
+    if (!project) return;
+    const id = setInterval(
+      () => fetchOverview(project, true),
+      GRAPH_AUTO_REFRESH_MS,
+    );
+    return () => clearInterval(id);
   }, [project, fetchOverview]);
 
   const handleSelectPath = useCallback(
@@ -273,6 +296,7 @@ export function GraphTab({ project }: GraphTabProps) {
             highlightedIds={highlightedIds}
             cameraTarget={cameraTarget}
             showLabels={showLabels}
+            autoRotate={autoRotate}
             onNodeClick={handleNodeClick}
           />
         </ErrorBoundary>
@@ -312,6 +336,14 @@ export function GraphTab({ project }: GraphTabProps) {
               Clear
             </Button>
           )}
+          <Button
+            variant={autoRotate ? "default" : "outline"}
+            size="sm"
+            onClick={() => setAutoRotate((v) => !v)}
+            title="Toggle graph auto-rotation"
+          >
+            {autoRotate ? "Auto-rotate: on" : "Auto-rotate: off"}
+          </Button>
           <Button
             variant="outline"
             size="sm"

--- a/graph-ui/src/hooks/useGraphData.ts
+++ b/graph-ui/src/hooks/useGraphData.ts
@@ -5,7 +5,7 @@ interface UseGraphDataResult {
   data: GraphData | null;
   loading: boolean;
   error: string | null;
-  fetchOverview: (project: string) => void;
+  fetchOverview: (project: string, silent?: boolean) => void;
   fetchDetail: (project: string, centerNode: string) => void;
 }
 
@@ -31,18 +31,25 @@ export function useGraphData(): UseGraphDataResult {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchOverview = useCallback(async (project: string) => {
-    setLoading(true);
-    setError(null);
-    try {
-      const result = await fetchLayout(project);
-      setData(result);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to fetch layout");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const fetchOverview = useCallback(
+    async (project: string, silent = false) => {
+      if (!silent) setLoading(true);
+      setError(null);
+      try {
+        const result = await fetchLayout(project);
+        setData(result);
+      } catch (e) {
+        /* On a background poll keep the last good graph instead of blanking
+         * it with an error banner. */
+        if (!silent) {
+          setError(e instanceof Error ? e.message : "Failed to fetch layout");
+        }
+      } finally {
+        if (!silent) setLoading(false);
+      }
+    },
+    [],
+  );
 
   const fetchDetail = useCallback(
     async (project: string, _centerNode: string) => {


### PR DESCRIPTION
## Summary

Three small, self-contained UX changes to the 3D graph UI (`graph-ui/`):

1. **Idle auto-rotation → explicit toggle.** Today the graph starts spinning on its own after 60s of inactivity (`IdleAutoRotate`). This removes that component and replaces it with an **off-by-default** `Auto-rotate` toggle button in the graph toolbar, wired to `OrbitControls.autoRotate`. Rotation now only happens when the user asks for it.

2. **Silent auto-refresh.** The graph only updated on a manual **Refresh**. This adds a background poll every `GRAPH_AUTO_REFRESH_MS` (15s) that silently re-fetches the layout so the view reflects re-index changes on its own. The poll skips the loading spinner and the error banner, so it never blanks the graph and keeps the last good render on a transient fetch failure.

3. **Filter preservation across refresh.** The filter-init effect previously reset the user's label/edge-type selection on every `data` change — which the new auto-refresh would trigger every 15s. It now re-initializes only when the graph's label/edge-type *universe* changes (new project / schema change), so a refresh preserves the current filter selection.

## Notes

- Auto-rotation is off by default, so default behavior changes only in that the graph no longer self-rotates when left idle.
- `OrbitControls` already carried `autoRotateSpeed={0.4}`; only the `autoRotate` flag is now controlled.

## Test plan

- [x] `npm run build` (tsc -b + vite build) — clean
- [x] `npm test` (vitest) — 8/8 pass
- [ ] Manual: toggle button flips rotation on/off; graph refreshes ~15s without spinner; filters survive a refresh