### PR TITLE
fix(discover): .cbmignore negation can un-skip built-in dirs (safety core excluded)

### DIFF
--- a/src/discover/discover.c
+++ b/src/discover/discover.c
@@ -473,6 +473,19 @@ static const char *local_rel_path(const char *rel_path, const char *local_prefix
     return rel_path;
 }
 
+/* Non-negatable safety core: built-in skip dirs that a .cbmignore negation
+ * can NEVER un-skip. A repo-committed .cbmignore must not be able to defeat
+ * OOM/safety skips: .git holds VCS internals (and the info/exclude sources,
+ * #489), node_modules explodes discovery, and the worktree-internal dirs
+ * (.worktrees / .claude-worktrees, the worktree entries in ALWAYS_SKIP_DIRS)
+ * contain parallel checkouts of the same repo whose indexing would duplicate
+ * the whole codebase (#802). */
+static bool is_safety_core_dir(const char *name) {
+    static const char *const SAFETY_CORE_DIRS[] = {".git", "node_modules", ".worktrees",
+                                                   ".claude-worktrees", NULL};
+    return str_in_list(name, SAFETY_CORE_DIRS);
+}
+
 /* Check if a directory entry should be skipped (hardcoded dirs + gitignore). */
 static bool should_skip_directory(const char *entry_name, const char *rel_path,
                                   const cbm_discover_opts_t *opts, const cbm_gitignore_t *gitignore,
@@ -480,7 +493,15 @@ static bool should_skip_directory(const char *entry_name, const char *rel_path,
                                   const cbm_gitignore_t *cbmignore, const cbm_gitignore_t *local_gi,
                                   const char *local_gi_prefix) {
     if (cbm_should_skip_dir(entry_name, opts ? opts->mode : CBM_MODE_FULL)) {
-        return true;
+        /* #500: a .cbmignore negation (e.g. "!obj/") whose rule is the last
+         * match for this dir un-skips a built-in skip-list dir — except the
+         * non-negatable safety core. Fall through so .gitignore/global/local
+         * rules still apply to the un-skipped dir. */
+        bool unskipped = cbmignore && !is_safety_core_dir(entry_name) &&
+                         cbm_gitignore_match_result(cbmignore, rel_path, true) < 0;
+        if (!unskipped) {
+            return true;
+        }
     }
     if (gitignore && cbm_gitignore_matches(gitignore, rel_path, true)) {
         return true;

--- a/tests/test_discover.c
+++ b/tests/test_discover.c
@@ -872,6 +872,176 @@ TEST(discover_cbmignore_no_git) {
     PASS();
 }
 
+/* ── .cbmignore negation vs built-in skip dirs (issue #500) ────── */
+
+static bool discover_excluded_contains(char **excluded, int count, const char *rel_path) {
+    for (int i = 0; i < count; i++) {
+        if (strcmp(excluded[i], rel_path) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* A "!obj/" negation in .cbmignore must un-skip the built-in ALWAYS_SKIP
+ * "obj" dir so files inside it get discovered — and the un-skipped dir must
+ * not be reported as an excluded subtree (#411 list stays coherent). */
+TEST(discover_cbmignore_negates_always_skip_dir) {
+    char *base = th_mktempdir("cbm_disc_cbmi_neg_obj");
+    ASSERT(base != NULL);
+
+    th_write_file(TH_PATH(base, ".cbmignore"), "!obj/\n");
+    th_write_file(TH_PATH(base, "main.go"), "package main\n");
+    th_write_file(TH_PATH(base, "obj/generated.go"), "package obj\n");
+
+    cbm_discover_opts_t opts = {0};
+    cbm_file_info_t *files = NULL;
+    int count = 0;
+    char **excluded = NULL;
+    int excluded_count = 0;
+
+    int rc = cbm_discover_ex(base, &opts, &files, &count, &excluded, &excluded_count);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(count, 2);
+    ASSERT_TRUE(discover_has_rel_path(files, count, "main.go"));
+    ASSERT_TRUE(discover_has_rel_path(files, count, "obj/generated.go"));
+    ASSERT_FALSE(discover_excluded_contains(excluded, excluded_count, "obj"));
+
+    cbm_discover_free_excluded(excluded, excluded_count);
+    cbm_discover_free(files, count);
+    th_cleanup(base);
+    PASS();
+}
+
+/* An anchored negation ("!src/target/") un-skips only that nested dir; other
+ * dirs with the same basename stay built-in-skipped. */
+TEST(discover_cbmignore_negates_only_nested_skip_dir) {
+    char *base = th_mktempdir("cbm_disc_cbmi_neg_nested");
+    ASSERT(base != NULL);
+
+    th_write_file(TH_PATH(base, ".cbmignore"), "!src/target/\n");
+    th_write_file(TH_PATH(base, "src/main.go"), "package src\n");
+    th_write_file(TH_PATH(base, "src/target/lib.go"), "package target\n");
+    th_write_file(TH_PATH(base, "other/target/lib.go"), "package other\n");
+    th_write_file(TH_PATH(base, "target/root.go"), "package root\n");
+
+    cbm_discover_opts_t opts = {0};
+    cbm_file_info_t *files = NULL;
+    int count = 0;
+
+    int rc = cbm_discover(base, &opts, &files, &count);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(count, 2);
+    ASSERT_TRUE(discover_has_rel_path(files, count, "src/main.go"));
+    ASSERT_TRUE(discover_has_rel_path(files, count, "src/target/lib.go"));
+    ASSERT_FALSE(discover_has_rel_path(files, count, "other/target/lib.go"));
+    ASSERT_FALSE(discover_has_rel_path(files, count, "target/root.go"));
+
+    cbm_discover_free(files, count);
+    th_cleanup(base);
+    PASS();
+}
+
+/* Negation also un-skips FAST-mode skip dirs ("docs" is in FAST_SKIP_DIRS). */
+TEST(discover_cbmignore_negates_fast_skip_dir) {
+    char *base = th_mktempdir("cbm_disc_cbmi_neg_fast");
+    ASSERT(base != NULL);
+
+    th_write_file(TH_PATH(base, ".cbmignore"), "!docs/\n");
+    th_write_file(TH_PATH(base, "main.go"), "package main\n");
+    th_write_file(TH_PATH(base, "docs/guide.go"), "package docs\n");
+
+    cbm_discover_opts_t opts = {.mode = CBM_MODE_FAST};
+    cbm_file_info_t *files = NULL;
+    int count = 0;
+
+    int rc = cbm_discover(base, &opts, &files, &count);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(count, 2);
+    ASSERT_TRUE(discover_has_rel_path(files, count, "main.go"));
+    ASSERT_TRUE(discover_has_rel_path(files, count, "docs/guide.go"));
+
+    cbm_discover_free(files, count);
+    th_cleanup(base);
+    PASS();
+}
+
+/* Last-match-wins ordering: "obj/" then "!obj/" un-skips; "!obj/" then
+ * "obj/" re-ignores, so the built-in skip stands. */
+TEST(discover_cbmignore_negation_last_match_wins) {
+    char *base = th_mktempdir("cbm_disc_cbmi_order1");
+    ASSERT(base != NULL);
+
+    th_write_file(TH_PATH(base, ".cbmignore"), "obj/\n!obj/\n");
+    th_write_file(TH_PATH(base, "main.go"), "package main\n");
+    th_write_file(TH_PATH(base, "obj/generated.go"), "package obj\n");
+
+    cbm_discover_opts_t opts = {0};
+    cbm_file_info_t *files = NULL;
+    int count = 0;
+
+    int rc = cbm_discover(base, &opts, &files, &count);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(count, 2);
+    ASSERT_TRUE(discover_has_rel_path(files, count, "obj/generated.go"));
+
+    cbm_discover_free(files, count);
+    th_cleanup(base);
+
+    base = th_mktempdir("cbm_disc_cbmi_order2");
+    ASSERT(base != NULL);
+
+    th_write_file(TH_PATH(base, ".cbmignore"), "!obj/\nobj/\n");
+    th_write_file(TH_PATH(base, "main.go"), "package main\n");
+    th_write_file(TH_PATH(base, "obj/generated.go"), "package obj\n");
+
+    files = NULL;
+    count = 0;
+
+    rc = cbm_discover(base, &opts, &files, &count);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(count, 1);
+    ASSERT_TRUE(discover_has_rel_path(files, count, "main.go"));
+    ASSERT_FALSE(discover_has_rel_path(files, count, "obj/generated.go"));
+
+    cbm_discover_free(files, count);
+    th_cleanup(base);
+    PASS();
+}
+
+/* Safety-core policy (#489, #802): .git, node_modules, and the
+ * worktree-internal dirs can never be un-skipped, even by an explicit
+ * .cbmignore negation. Green by construction; guards the policy. */
+TEST(discover_cbmignore_negation_cannot_unskip_safety_core) {
+    char *base = th_mktempdir("cbm_disc_cbmi_safety");
+    ASSERT(base != NULL);
+
+    th_write_file(TH_PATH(base, ".cbmignore"),
+                  "!.git/\n!node_modules/\n!.worktrees/\n!.claude-worktrees/\n");
+    th_write_file(TH_PATH(base, "main.go"), "package main\n");
+    th_write_file(TH_PATH(base, ".git/hooks/hook.go"), "package hooks\n");
+    th_write_file(TH_PATH(base, "node_modules/pkg/index.js"), "module.exports = 1;\n");
+    th_write_file(TH_PATH(base, ".worktrees/wt/dup.go"), "package dup\n");
+    th_write_file(TH_PATH(base, ".claude-worktrees/wt/dup.go"), "package dup\n");
+
+    cbm_discover_opts_t opts = {0};
+    cbm_file_info_t *files = NULL;
+    int count = 0;
+
+    int rc = cbm_discover(base, &opts, &files, &count);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(count, 1);
+    ASSERT_TRUE(discover_has_rel_path(files, count, "main.go"));
+    ASSERT_FALSE(discover_has_rel_path(files, count, ".git/hooks/hook.go"));
+    ASSERT_FALSE(discover_has_rel_path(files, count, "node_modules/pkg/index.js"));
+    ASSERT_FALSE(discover_has_rel_path(files, count, ".worktrees/wt/dup.go"));
+    ASSERT_FALSE(discover_has_rel_path(files, count, ".claude-worktrees/wt/dup.go"));
+
+    cbm_discover_free(files, count);
+    th_cleanup(base);
+    PASS();
+}
+
 /* ── .git/info/exclude tests (issue #489) ─────────────────────── */
 
 /* Per-clone excludes written to .git/info/exclude (not committed) must be
@@ -1167,6 +1337,13 @@ SUITE(discover) {
     RUN_TEST(discover_generic_dirs_fast_mode);
     RUN_TEST(discover_deploy_excluded_full_mode);
     RUN_TEST(discover_cbmignore_no_git);
+
+    /* .cbmignore negation vs built-in skip dirs (issue #500) */
+    RUN_TEST(discover_cbmignore_negates_always_skip_dir);
+    RUN_TEST(discover_cbmignore_negates_only_nested_skip_dir);
+    RUN_TEST(discover_cbmignore_negates_fast_skip_dir);
+    RUN_TEST(discover_cbmignore_negation_last_match_wins);
+    RUN_TEST(discover_cbmignore_negation_cannot_unskip_safety_core);
 
     /* .git/info/exclude support (issue #489) */
     RUN_TEST(discover_git_info_exclude);


### PR DESCRIPTION
# fix(discover): .cbmignore negation can un-skip built-in dirs (safety core excluded)

## Summary

A `.cbmignore` negation pattern (e.g. `!obj/`) can now un-skip a directory that the
built-in skip list (`ALWAYS_SKIP_DIRS` / `FAST_SKIP_DIRS`) would otherwise prune, so
projects whose real sources live under names like `obj/`, `target/`, or `docs/` can
opt them back into indexing.

This distills PR #543 (thanks @mvanhorn!) onto the current 3-state matcher API. The
original branch pre-dates `cbm_gitignore_match_result` and built a second
inverted-polarity matcher from a re-read of the ignore file; on today's `main` the
same behavior falls out of one extra check: inside `should_skip_directory`'s built-in
branch, if `cbm_gitignore_match_result(cbmignore, rel_path, true) < 0` (the last
matching rule is a negation) and the dir is not in the safety core, the built-in skip
is lifted and evaluation falls through so `.gitignore`/global/local rules still apply.
Loading continues to use the existing `cbm_gitignore_load` / `cbm_fopen` path — no raw
`fopen`, so non-ASCII paths keep working on Windows.

## Policy: non-negatable safety core

`.git`, `node_modules`, and the worktree-internal dirs (`.worktrees`,
`.claude-worktrees`) can **never** be un-skipped, even by an explicit negation. A
repo-committed `.cbmignore` must not be able to defeat OOM/safety skips: `.git` holds
VCS internals (and the info/exclude sources, #489), `node_modules` explodes discovery,
and the worktree dirs contain parallel checkouts of the same repo whose indexing would
duplicate the whole codebase (#802). Implemented as `is_safety_core_dir()` in
`src/discover/discover.c`.

Un-skipped dirs are walked normally and therefore no longer appear in the
excluded-subtree list (#411 coherence — asserted in the tests).

## Tests

Carries #543's test intents onto the new implementation (red-first verified: tests
1–4 fail on unfixed `main` with `count == 1, expected 2`; test 5 is green by
construction and guards the policy):

| # | Test | Intent | On unfixed main |
|---|------|--------|-----------------|
| 1 | `discover_cbmignore_negates_always_skip_dir` | `!obj/` un-skips built-in `obj/`; dir absent from excluded list | RED |
| 2 | `discover_cbmignore_negates_only_nested_skip_dir` | anchored `!src/target/` un-skips only that path; `other/target`, root `target` stay skipped | RED |
| 3 | `discover_cbmignore_negates_fast_skip_dir` | `!docs/` un-skips a FAST-mode skip dir under `CBM_MODE_FAST` | RED |
| 4 | `discover_cbmignore_negation_last_match_wins` | `obj/` then `!obj/` un-skips; `!obj/` then `obj/` re-ignores | RED |
| 5 | `discover_cbmignore_negation_cannot_unskip_safety_core` | `!.git/`, `!node_modules/`, `!.worktrees/`, `!.claude-worktrees/` never un-skip | GREEN (guard) |

Suites: `discover` 89 passed / 0 failed, `gitignore` 21 passed / 0 failed;
`make -f Makefile.cbm cbm` builds `-Werror` clean.

Closes #500.
