### PR TITLE
fix(cli): overflow-safe ZIP bounds check; env-bash shebangs

### DIFF
--- a/scripts/benchmark-search-graph.sh
+++ b/scripts/benchmark-search-graph.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # benchmark-search-graph.sh — Time search_graph name_pattern= queries against a
 # codebase-memory-mcp binary to measure the regex / LIKE pre-filter performance.
 #

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # build.sh — Clean build of production binary (standard or with UI).
 #
 # Usage:

--- a/scripts/check-nolint-whitelist.sh
+++ b/scripts/check-nolint-whitelist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Verify NOLINT(misc-no-recursion) only appears on whitelisted functions.
 WHITELIST="src/foundation/recursion_whitelist.h"
 if [ ! -f "$WHITELIST" ]; then

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # clean.sh — Remove ALL build artifacts, caches, and generated files.
 #
 # Usage: scripts/clean.sh

--- a/scripts/embed-frontend.sh
+++ b/scripts/embed-frontend.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # embed-frontend.sh — Convert built frontend assets into linkable object files.
 #
 # Usage: scripts/embed-frontend.sh <dist_dir> <output_dir>

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # env.sh — Shared environment detection for all build scripts.
 #
 # Sourced by test.sh, build.sh, lint.sh. Not meant to run standalone.

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # lint.sh — Run all linters (clang-tidy + cppcheck + clang-format).
 #
 # Usage:

--- a/scripts/repro.sh
+++ b/scripts/repro.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # repro.sh — Build + run the cumulative BUG-REPRODUCTION suite (test-repro).
 #
 # Unlike test.sh (the gating suite, must be GREEN), this suite is RED by design:

--- a/scripts/soak-test.sh
+++ b/scripts/soak-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # soak-test.sh — Endurance test for codebase-memory-mcp.
 #
 # Runs compressed workload cycles: queries, file mutations, reindexes, idle periods.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # test.sh — Clean build + run all C tests with ASan + UBSan.
 #
 # Usage:

--- a/scripts/vendor-grammar.sh
+++ b/scripts/vendor-grammar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # vendor-grammar.sh: Vendor a single tree-sitter grammar into internal/cbm/vendored/grammars/<name>/
 # Usage: ./scripts/vendor-grammar.sh <repo_url> <name> [subdir]
 #   repo_url: GitHub repository URL (e.g., https://github.com/tree-sitter/tree-sitter-json)

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -80,6 +80,7 @@ enum {
 #endif
 #include <errno.h>  // EEXIST
 #include <fcntl.h>  // open, O_WRONLY, O_CREAT, O_TRUNC
+#include <limits.h> // UINT_MAX
 #include <stdint.h> // uintptr_t
 #include <stdio.h>
 #include <stdlib.h>
@@ -2485,12 +2486,22 @@ enum {
     ZIP_STORED = 0,
     ZIP_DEFLATE = 8
 };
-static const uint32_t ZIP_MAX_UNCOMP = 500U * 1024U * 1024U;
+static const size_t ZIP_MAX_UNCOMP = 500U * 1024U * 1024U;
+
+static uint16_t zip_read_u16le(const unsigned char *p) {
+    return (uint16_t)((uint16_t)p[0] | ((uint16_t)p[1] << BYTE_SHIFT));
+}
+
+static uint32_t zip_read_u32le(const unsigned char *p) {
+    return ((uint32_t)p[0]) | ((uint32_t)p[1] << BYTE_SHIFT) |
+           ((uint32_t)p[2] << (BYTE_SHIFT * CLI_PAIR_LEN)) |
+           ((uint32_t)p[3] << (BYTE_SHIFT * CLI_JSON_INDENT));
+}
 
 /* Decompress a single zip entry (stored or deflated). Returns malloc'd buffer
  * or NULL on failure. *out_len receives the decompressed size. */
 static unsigned char *zip_extract_entry(const unsigned char *file_data, uint16_t method,
-                                        uint32_t comp_size, uint32_t uncomp_size, int *out_len) {
+                                        size_t comp_size, size_t uncomp_size, int *out_len) {
     if (method == ZIP_STORED) {
         if (comp_size > ZIP_MAX_UNCOMP) {
             return NULL;
@@ -2507,15 +2518,18 @@ static unsigned char *zip_extract_entry(const unsigned char *file_data, uint16_t
         if (uncomp_size > ZIP_MAX_UNCOMP) {
             return NULL;
         }
+        if (comp_size > UINT_MAX || uncomp_size > UINT_MAX) {
+            return NULL;
+        }
         unsigned char *out = malloc(uncomp_size);
         if (!out) {
             return NULL;
         }
         z_stream strm = {0};
         strm.next_in = (unsigned char *)file_data;
-        strm.avail_in = comp_size;
+        strm.avail_in = (uInt)comp_size;
         strm.next_out = out;
-        strm.avail_out = uncomp_size;
+        strm.avail_out = (uInt)uncomp_size;
         if (inflateInit2(&strm, -MAX_WBITS) != Z_OK) {
             free(out);
             return NULL;
@@ -2545,28 +2559,14 @@ unsigned char *cbm_extract_binary_from_zip(const unsigned char *data, int data_l
             break;
         }
 
-        uint16_t method = (uint16_t)(data[pos + ZIP_OFF_METHOD] |
-                                     (data[pos + ZIP_OFF_METHOD + CLI_SKIP_ONE] << BYTE_SHIFT));
-        uint32_t comp_size =
-            (uint32_t)(data[pos + ZIP_OFF_COMP] |
-                       (data[pos + ZIP_OFF_COMP + CLI_SKIP_ONE] << BYTE_SHIFT) |
-                       (data[pos + ZIP_OFF_COMP + CLI_PAIR_LEN] << (BYTE_SHIFT * CLI_PAIR_LEN)) |
-                       (data[pos + ZIP_OFF_COMP + CLI_JSON_INDENT]
-                        << (BYTE_SHIFT * CLI_JSON_INDENT)));
-        uint32_t uncomp_size =
-            (uint32_t)(data[pos + ZIP_OFF_UNCOMP] |
-                       (data[pos + ZIP_OFF_UNCOMP + CLI_SKIP_ONE] << BYTE_SHIFT) |
-                       (data[pos + ZIP_OFF_UNCOMP + CLI_PAIR_LEN] << (BYTE_SHIFT * CLI_PAIR_LEN)) |
-                       (data[pos + ZIP_OFF_UNCOMP + CLI_JSON_INDENT]
-                        << (BYTE_SHIFT * CLI_JSON_INDENT)));
-        uint16_t name_len = (uint16_t)(data[pos + ZIP_OFF_NAMELEN] |
-                                       (data[pos + ZIP_OFF_NAMELEN + CLI_SKIP_ONE] << BYTE_SHIFT));
-        uint16_t extra_len =
-            (uint16_t)(data[pos + ZIP_OFF_EXTRALEN] |
-                       (data[pos + ZIP_OFF_EXTRALEN + CLI_SKIP_ONE] << BYTE_SHIFT));
+        uint16_t method = zip_read_u16le(data + pos + ZIP_OFF_METHOD);
+        uint32_t comp_size = zip_read_u32le(data + pos + ZIP_OFF_COMP);
+        uint32_t uncomp_size = zip_read_u32le(data + pos + ZIP_OFF_UNCOMP);
+        uint16_t name_len = zip_read_u16le(data + pos + ZIP_OFF_NAMELEN);
+        uint16_t extra_len = zip_read_u16le(data + pos + ZIP_OFF_EXTRALEN);
 
         int header_end = pos + ZIP_HDR_SZ + name_len + extra_len;
-        if (header_end + (int)comp_size > data_len) {
+        if (header_end > data_len || comp_size > (uint32_t)(data_len - header_end)) {
             break;
         }
 

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -2055,7 +2055,7 @@ void cbm_install_hook_gate_script(const char *home, const char *binary_path) {
         return;
     }
     (void)fprintf(f,
-                  "#!/bin/bash\n"
+                  "#!/usr/bin/env bash\n"
                   "# codebase-memory-mcp search augmenter (Claude Code PreToolUse).\n"
                   "# NOTE: the legacy filename is kept for zero-migration upgrades.\n"
                   "# Despite the name this NEVER blocks a tool call - it only adds\n"
@@ -2099,7 +2099,7 @@ static void cbm_install_session_reminder_script(const char *home) {
         return;
     }
     (void)fprintf(
-        f, "#!/bin/bash\n"
+        f, "#!/usr/bin/env bash\n"
            "# SessionStart hook: remind agent to use codebase-memory-mcp tools.\n"
            "# Installed by codebase-memory-mcp. Fires on startup/resume/clear/compact.\n"
            "cat << 'REMINDER'\n"
@@ -2187,7 +2187,7 @@ static void cbm_install_subagent_reminder_script(const char *home) {
      * backslashes, or newlines, so the JSON below is valid as written — no
      * runtime escaping (and no python3/jq dependency) is required. */
     (void)fprintf(f,
-                  "#!/bin/bash\n"
+                  "#!/usr/bin/env bash\n"
                   "# SubagentStart hook: tell subagents to use codebase-memory-mcp tools.\n"
                   "# Installed by codebase-memory-mcp. Fires when any subagent is spawned.\n"
                   "# SubagentStart injects context via JSON additionalContext, not plain stdout.\n"

--- a/src/cypher/cypher.c
+++ b/src/cypher/cypher.c
@@ -2441,11 +2441,11 @@ static bool eval_condition(const cbm_condition_t *c, binding_t *b) {
 
     /* IS NULL / IS NOT NULL */
     if (strcmp(c->op, "IS NULL") == 0) {
-        result = (!actual || actual[0] == '\0');
+        result = (actual[0] == '\0');
         return c->negated ? !result : result;
     }
     if (strcmp(c->op, "IS NOT NULL") == 0) {
-        result = (actual && actual[0] != '\0');
+        result = (actual[0] != '\0');
         return c->negated ? !result : result;
     }
 

--- a/test-infrastructure/run.sh
+++ b/test-infrastructure/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Local CI — test all platforms before pushing.
 #
 # Coverage:

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -14,6 +14,7 @@
 #include "test_helpers.h"
 #include <cli/cli.h>
 #include <foundation/yaml.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -1358,6 +1359,47 @@ TEST(cli_extract_binary_from_zip_invalid) {
     int out_len = 0;
     unsigned char *extracted = cbm_extract_binary_from_zip(bad_data, sizeof(bad_data), &out_len);
     ASSERT_NULL(extracted);
+    PASS();
+}
+
+TEST(cli_extract_binary_from_zip_rejects_truncated_deflate_size_over_int_max) {
+    const char *filename = "codebase-memory-mcp";
+    const unsigned char deflated[] = {0xAB, 0x00, 0x00}; /* raw DEFLATE for "x" */
+    size_t name_len = strlen(filename);
+    size_t zip_len = 30 + name_len + sizeof(deflated);
+    unsigned char *zip = calloc(1, zip_len);
+    ASSERT_NOT_NULL(zip);
+
+    uint32_t comp_size = 0xFFFF0000U;
+    uint32_t uncomp_size = 1U;
+    zip[0] = 0x50;
+    zip[1] = 0x4B;
+    zip[2] = 0x03;
+    zip[3] = 0x04;
+    zip[8] = 8;
+    zip[9] = 0;
+    zip[18] = (unsigned char)(comp_size & 0xFF);
+    zip[19] = (unsigned char)((comp_size >> 8) & 0xFF);
+    zip[20] = (unsigned char)((comp_size >> 16) & 0xFF);
+    zip[21] = (unsigned char)((comp_size >> 24) & 0xFF);
+    zip[22] = (unsigned char)(uncomp_size & 0xFF);
+    zip[23] = (unsigned char)((uncomp_size >> 8) & 0xFF);
+    zip[24] = (unsigned char)((uncomp_size >> 16) & 0xFF);
+    zip[25] = (unsigned char)((uncomp_size >> 24) & 0xFF);
+    zip[26] = (unsigned char)(name_len & 0xFF);
+    zip[27] = (unsigned char)((name_len >> 8) & 0xFF);
+    memcpy(zip + 30, filename, name_len);
+    memcpy(zip + 30 + name_len, deflated, sizeof(deflated));
+
+    int out_len = 0;
+    unsigned char *extracted = cbm_extract_binary_from_zip(zip, (int)zip_len, &out_len);
+    if (extracted) {
+        free(extracted);
+        free(zip);
+        FAIL("accepted a truncated deflated zip entry with a wrapped compressed size");
+    }
+    ASSERT_EQ(out_len, 0);
+    free(zip);
     PASS();
 }
 
@@ -2981,6 +3023,7 @@ SUITE(cli) {
     RUN_TEST(cli_extract_binary_from_zip_not_found);
     RUN_TEST(cli_extract_binary_from_zip_path_traversal);
     RUN_TEST(cli_extract_binary_from_zip_invalid);
+    RUN_TEST(cli_extract_binary_from_zip_rejects_truncated_deflate_size_over_int_max);
 
     /* Dry-run lifecycle (2 tests) */
     RUN_TEST(cli_install_dry_run);

--- a/tests/test_pipeline.c
+++ b/tests/test_pipeline.c
@@ -4669,7 +4669,7 @@ TEST(envscan_secret_value_exclusion) {
     write_temp_file(
         tmpdir, "deploy.sh",
         "#!/bin/bash\n"
-        "export GH_URL=\"https://ghp_abcdefghijklmnopqrstuvwxyz1234567890@github.com/repo\"\n"
+        "export GH_URL=\"https://ghp_FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE@github.com/repo\"\n"
         "export NORMAL_ENDPOINT=\"https://api.example.com/orders\"\n");
 
     cbm_env_binding_t bindings[32];


### PR DESCRIPTION
# distill: overflow-safe ZIP bounds check (#784) + env-bash shebangs (#674)

Two independent review distills sharing `src/cli/cli.c`, kept as two separate commits on one branch to avoid conflicts.

## Commit 1 — `7b93210` fix(cli): overflow-safe ZIP entry bounds check in self-update extraction

Distilled from #784 (thanks @SS-42, co-authored). Refs #784-review.

**The real fix (title, not buried):** the self-update ZIP truncation check

```c
if (header_end + (int)comp_size > data_len) { break; }
```

is bypassable for `comp_size >= 2^31`: the `int` cast turns the size negative, the sum drops below `data_len`, and the entry is accepted — authorizing `inflate` to read up to ~4 GB past the downloaded archive buffer (`strm.avail_in = comp_size`). Replaced with the overflow-safe, strictly tighter

```c
if (header_end > data_len || comp_size > (uint32_t)(data_len - header_end)) { break; }
```

**Regression guard (red-first, verified via temporary revert of the check):**
`cli_extract_binary_from_zip_rejects_truncated_deflate_size_over_int_max` builds a 52-byte archive whose only entry claims `comp_size = 0xFFFF0000` (DEFLATE, `uncomp_size = 1`, self-terminating 3-byte stream).

- RED on the old check (verbatim):
  ```
  cli_extract_binary_from_zip_rejects_truncated_deflate_size_over_int_max  FAIL tests/test_cli.c:1399: accepted a truncated deflated zip entry with a wrapped compressed size
  ```
  Pre-fix failure mode: the negative-int bypass admits the entry, zlib is handed `avail_in = 0xFFFF0000` (licensed to read ~4 GB past the buffer); the fixture's DEFLATE stream self-terminates, so extraction *succeeds* and returns non-NULL — a deterministic assertion failure rather than an ASan-dependent crash, in both directions: the fixed check rejects the entry (NULL), the old one accepts it (non-NULL).
- GREEN with the fix: `cli` + `cypher` suites 258 passed, 0 failed.

**Secondary cppcheck cleanups from the same review (audited behavior-neutral):**
- `zip_read_u16le`/`zip_read_u32le` little-endian helpers replacing the inline shift pyramids (behavior-identical).
- `zip_extract_entry` sizes widened to `size_t` with an explicit `UINT_MAX` guard before the zlib `uInt` narrowing.
- `cypher.c eval_condition`: removed genuinely unreachable `IS NULL` / `IS NOT NULL` null guards (`resolve_condition_value` result is early-returned on NULL just above); `cypher_*_is_null` tests unchanged and green.

## Commit 2 — `50392a4` fix(scripts): use /usr/bin/env bash shebangs (NixOS has no /bin/bash)

Distilled fresh from #674 (thanks @SuperSandro2000, co-authored). Refs #674-review.

- Converted `#!/bin/bash` → `#!/usr/bin/env bash` in the eleven `scripts/*.sh` holdouts, `test-infrastructure/run.sh`, and the **three** Claude Code hook scripts emitted by `src/cli/cli.c` (gate, session reminder, and the subagent reminder added since #674 was opened).
- **Parser-test coverage preserved** (deliberate divergence from #674): the `infra_parse_shell*` fixtures in `tests/test_pipeline.c` intentionally keep `#!/bin/bash`, so absolute-path shebang extraction (`r.shebang == "/bin/bash"`) stays covered. `tests/repro` fixtures untouched. No test asserts the emitted hook scripts' shebang, so no assertion updates were required.
- Replaced the GitHub-PAT-shaped fixture string flagged in the #674 thread with `ghp_FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE` — obviously fake, still `ghp_` + 36 alnum so the secret detector (`pass_infrascan.c`) keeps firing; `envscan_secret_value_exclusion` green.
- `bash -n` clean on all 12 changed scripts.

## Verification (after both commits)

- `make -f Makefile.cbm cbm` — `-Werror` clean.
- `make -f Makefile.cbm lint-ci` — cppcheck, clang-format, NOLINT check all green.
- `test-runner pipeline` — 209 passed, 0 failed.
- `test-runner cli cypher` — 258 passed, 0 failed.

Refs #784-review, refs #674-review.
