### PR TITLE
Fix CodeQL gate lookup for busy queues

### DIFF
--- a/.github/workflows/_security.yml
+++ b/.github/workflows/_security.yml
@@ -51,8 +51,8 @@ jobs:
           CURRENT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           echo "Waiting for CodeQL to complete on $CURRENT_SHA..."
           for attempt in $(seq 1 90); do
-            LATEST=$(gh api repos/${{ github.repository }}/actions/workflows/codeql.yml/runs?per_page=5 \
-              --jq '.workflow_runs[] | select(.head_sha == "'"$CURRENT_SHA"'") | "\(.conclusion) \(.status)"' 2>/dev/null | head -1 || echo "")
+            LATEST=$(gh api "repos/${{ github.repository }}/actions/workflows/codeql.yml/runs?head_sha=$CURRENT_SHA&per_page=1" \
+              --jq '.workflow_runs[] | "\(.conclusion) \(.status)"' 2>/dev/null | head -1 || echo "")
             if [ -z "$LATEST" ]; then
               echo "  $attempt/90: no run yet..."; sleep 30; continue
             fi


### PR DESCRIPTION
## Summary

- query CodeQL workflow runs with the REST API `head_sha` filter instead of scanning only the latest 5 runs
- keep the existing wait loop and success/failure handling unchanged

## Evidence

Several active PRs had `security / codeql-gate` time out with `no run yet...` while their CodeQL SAST run on the same head SHA had already completed successfully. In a busy Actions queue, the matching CodeQL run can fall out of the first 5 workflow runs before the gate sees it.

Verified the replacement query returns `success completed` for the affected head SHAs from #782, #784, and #812.

## Verification

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/_security.yml"); puts "yaml ok"'`
- `gh api "repos/DeusData/codebase-memory-mcp/actions/workflows/codeql.yml/runs?head_sha=<sha>&per_page=1" --jq '.workflow_runs[] | "\(.conclusion) \(.status)"'` for the affected SHA values
