### PR TITLE
fix(mcp): exit promptly on stdin EOF over a FIFO; smoke tools-list follows pagination

### DIFF
--- a/scripts/smoke-invariants.sh
+++ b/scripts/smoke-invariants.sh
@@ -454,28 +454,48 @@ inv_tools_list() {
         fail "tools-list" "server not alive"
         return
     fi
-    local req='{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
-    if ! mcp_send_recv "$req" 15; then
-        fail "tools-list" "no response within 15s (hang)"
-        return
-    fi
-    if ! printf '%s' "$MCP_RESP" | is_json; then
-        fail "tools-list" "response not valid JSON"
-        return
-    fi
-    # Extract tool names from result.tools[].name.
-    local got_names got_count
-    got_names="$(printf '%s' "$MCP_RESP" | "$PY" -c '
+    # tools/list is cursor-paginated (MCP spec): the server returns a page of
+    # tools plus result.nextCursor. Follow the cursor across pages and accumulate
+    # the advertised tools — exactly what a compliant client does — then assert the
+    # union covers all expected tools.
+    local got_names="" cursor="" page=0
+    while :; do
+        page=$((page + 1))
+        if [ "$page" -gt 20 ]; then
+            fail "tools-list" "pagination did not terminate after 20 pages"
+            return
+        fi
+        local params='{}'
+        [ -n "$cursor" ] && params="{\"cursor\":\"$cursor\"}"
+        local req="{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":$params}"
+        if ! mcp_send_recv "$req" 15; then
+            fail "tools-list" "no response within 15s (page $page, hang)"
+            return
+        fi
+        if ! printf '%s' "$MCP_RESP" | is_json; then
+            fail "tools-list" "response not valid JSON (page $page)"
+            return
+        fi
+        # Line 1 = space-joined names on this page; line 2 = nextCursor ("" if last).
+        local parsed
+        parsed="$(printf '%s' "$MCP_RESP" | "$PY" -c '
 import sys,json
 try:
     d=json.load(sys.stdin)
 except Exception:
-    sys.exit(0)
-tools=(d.get("result") or {}).get("tools") or []
-print(" ".join(sorted(t.get("name","") for t in tools)))' 2>/dev/null)"
-    got_count="$(printf '%s' "$got_names" | tr ' ' '\n' | grep -c . )"
+    print(""); print(""); sys.exit(0)
+r=d.get("result") or {}
+print(" ".join(t.get("name","") for t in (r.get("tools") or [])))
+print(r.get("nextCursor") or "")' 2>/dev/null)"
+        got_names="$got_names $(printf '%s' "$parsed" | sed -n '1p')"
+        local next; next="$(printf '%s' "$parsed" | sed -n '2p')"
+        [ -z "$next" ] && break
+        cursor="$next"
+    done
+    local got_count
+    got_count="$(printf '%s' "$got_names" | tr ' ' '\n' | grep -c .)"
     if [ "${got_count:-0}" -ne "$EXPECTED_TOOL_COUNT" ]; then
-        fail "tools-list" "got $got_count tools, expected $EXPECTED_TOOL_COUNT; names=[$got_names]"
+        fail "tools-list" "got $got_count tools across $page page(s), expected $EXPECTED_TOOL_COUNT; names=[$got_names]"
         return
     fi
     local missing=""

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -5563,8 +5563,9 @@ static int poll_for_input_unix(cbm_mcp_server_t *srv, int fd, FILE *in) {
     /* Phase 2: peek FILE* buffer */
     int saved_flags = fcntl(fd, F_GETFL);
     if (saved_flags < 0) {
-        /* fcntl failed — fall through to blocking poll */
-        pr = poll(&pfd, SKIP_ONE, STORE_IDLE_TIMEOUT_S * MCP_TIMEOUT_MS);
+        /* fcntl failed — fall through to a short blocking poll (see the Phase-3
+         * note below on why the interval is bounded, not the full idle timeout) */
+        pr = poll(&pfd, SKIP_ONE, MCP_TIMEOUT_MS);
         if (pr < 0) {
             return CBM_NOT_FOUND;
         }
@@ -5584,8 +5585,15 @@ static int poll_for_input_unix(cbm_mcp_server_t *srv, int fd, FILE *in) {
             return CBM_NOT_FOUND; /* true EOF */
         }
         clearerr(in);
-        /* Phase 3: blocking poll */
-        pr = poll(&pfd, SKIP_ONE, STORE_IDLE_TIMEOUT_S * MCP_TIMEOUT_MS);
+        /* Phase 3: blocking poll, bounded to a SHORT interval (not the full idle
+         * timeout). macOS poll()/select() do NOT report POLLIN/POLLHUP when a
+         * FIFO's last writer closes — only read() returns 0 there (verified). A
+         * 60s poll would therefore leave the server blocked up to a full idle
+         * timeout after stdin EOF (a client that closes the pipe would appear to
+         * hang). Waking every MCP_TIMEOUT_MS lets the Phase-2 read() above detect
+         * the EOF within ~1s. Idle-store eviction (threshold STORE_IDLE_TIMEOUT_S)
+         * is idempotent, so checking it on each short tick is harmless. */
+        pr = poll(&pfd, SKIP_ONE, MCP_TIMEOUT_MS);
         if (pr < 0) {
             return CBM_NOT_FOUND;
         }


### PR DESCRIPTION
Two smoke-battery de-flakes, both reproduce-first:

1. **macOS FIFO EOF hang (real server bug):** the stdio server's input loop blocked in a single poll() for the full 60s idle timeout. On macOS, poll()/select() do NOT report POLLIN/POLLHUP when a FIFO's last writer closes — only read() returns 0 (verified with a standalone probe). A client closing stdin over a named FIFO left the server apparently hung for up to a minute. Fix: bound the blocking poll to ~1s so the existing read()-based EOF check runs promptly; idle-store eviction is idempotent so the short tick is harmless. Pipes (real MCP clients) were unaffected. Repro: the smoke clean-eof-exit invariant was deterministically RED (>12s hang, stack captured in poll()) and is GREEN after (exit 0 within bound); battery went 28/2 → 30/0.

2. **tools-list smoke test follows MCP cursor pagination:** tools/list is cursor-paginated (page size 8 + nextCursor); the invariant read only the first page and expected all 14 tools, failing against a correct server. It now accumulates pages like a compliant client.