### PR TITLE
fix(build): gate libgit2 allocator support

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -33,7 +33,7 @@ jobs:
           BROAD: ${{ inputs.broad_platforms }}
         run: |
           CORE_UNIX='[
-            {"os":"ubuntu-latest","cc":"gcc","cxx":"g++"},
+            {"os":"ubuntu-latest","cc":"gcc","cxx":"g++","libgit2":true},
             {"os":"ubuntu-24.04-arm","cc":"gcc","cxx":"g++"},
             {"os":"macos-14","cc":"cc","cxx":"c++"},
             {"os":"macos-15-intel","cc":"cc","cxx":"c++"}
@@ -79,10 +79,15 @@ jobs:
 
       - name: Install deps (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev
+        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev ${{ matrix.libgit2 == true && 'libgit2-dev pkg-config' || '' }}
 
       - name: Test
-        run: scripts/test.sh CC=${{ matrix.cc }} CXX=${{ matrix.cxx }}
+        run: |
+          if [ "${{ matrix.libgit2 == true }}" = "true" ]; then
+            echo "REQUIRE_LIBGIT2=1"
+            pkg-config --modversion libgit2
+          fi
+          scripts/test.sh CC=${{ matrix.cc }} CXX=${{ matrix.cxx }} ${{ matrix.libgit2 == true && 'REQUIRE_LIBGIT2=1' || '' }}
         env:
           CBM_SKIP_PERF: ${{ inputs.skip_perf && '1' || '' }}
 

--- a/Makefile.cbm
+++ b/Makefile.cbm
@@ -35,12 +35,25 @@ TS_INCLUDE = $(CBM_DIR)/vendored/ts_runtime/include
 TS_SRC = $(CBM_DIR)/vendored/ts_runtime/src
 
 # ── Optional libgit2 (faster git history parsing) ────────────────
-# Auto-detected via pkg-config. Falls back to popen("git log ...") if absent.
-LIBGIT2_CFLAGS := $(shell pkg-config --cflags libgit2 2>/dev/null)
-LIBGIT2_LIBS := $(shell pkg-config --libs libgit2 2>/dev/null)
-ifneq ($(LIBGIT2_LIBS),)
+# Auto-detected via pkg-config. Falls back to popen("git log ...") if absent
+# or too old for the git_allocator ABI used by the production allocator bind.
+PKG_CONFIG ?= pkg-config
+LIBGIT2_MIN_VERSION := 1.7.0
+LIBGIT2_AVAILABLE := $(shell $(PKG_CONFIG) --atleast-version=$(LIBGIT2_MIN_VERSION) libgit2 >/dev/null 2>&1 && echo yes || echo no)
+
+ifeq ($(REQUIRE_LIBGIT2),1)
+ifneq ($(LIBGIT2_AVAILABLE),yes)
+LIBGIT2_VERSION := $(shell $(PKG_CONFIG) --modversion libgit2 2>/dev/null)
+$(error libgit2 >= $(LIBGIT2_MIN_VERSION) is required when REQUIRE_LIBGIT2=1; pkg-config found $(if $(LIBGIT2_VERSION),$(LIBGIT2_VERSION),none))
+endif
+endif
+
+ifeq ($(LIBGIT2_AVAILABLE),yes)
+LIBGIT2_CFLAGS := $(shell $(PKG_CONFIG) --cflags libgit2 2>/dev/null)
+LIBGIT2_LIBS := $(shell $(PKG_CONFIG) --libs libgit2 2>/dev/null)
 LIBGIT2_FLAGS = -DHAVE_LIBGIT2 $(LIBGIT2_CFLAGS)
 else
+LIBGIT2_CFLAGS =
 LIBGIT2_FLAGS =
 LIBGIT2_LIBS =
 endif

--- a/internal/cbm/cbm.c
+++ b/internal/cbm/cbm.c
@@ -26,7 +26,8 @@
 #error "HAVE_LIBGIT2 requires libgit2 >= 1.7.0 for git_allocator"
 #endif
 #elif defined(LIBGIT2_VER_MAJOR) && defined(LIBGIT2_VER_MINOR) && defined(LIBGIT2_VER_REVISION)
-#if ((LIBGIT2_VER_MAJOR * 1000000) + (LIBGIT2_VER_MINOR * 10000) + (LIBGIT2_VER_REVISION * 100)) < 1070000
+#if ((LIBGIT2_VER_MAJOR * 1000000) + (LIBGIT2_VER_MINOR * 10000) + (LIBGIT2_VER_REVISION * 100)) < \
+    1070000
 #error "HAVE_LIBGIT2 requires libgit2 >= 1.7.0 for git_allocator"
 #endif
 #else

--- a/internal/cbm/cbm.c
+++ b/internal/cbm/cbm.c
@@ -20,6 +20,18 @@
 #if defined(CBM_BIND_TS_ALLOCATOR) && CBM_BIND_TS_ALLOCATOR
 #include "sqlite3.h" // sqlite3_mem_methods, sqlite3_config, SQLITE_CONFIG_MALLOC — bind sqlite to mimalloc
 #if defined(HAVE_LIBGIT2)
+#include <git2/version.h>
+#if defined(LIBGIT2_VERSION_CHECK)
+#if !LIBGIT2_VERSION_CHECK(1, 7, 0)
+#error "HAVE_LIBGIT2 requires libgit2 >= 1.7.0 for git_allocator"
+#endif
+#elif defined(LIBGIT2_VER_MAJOR) && defined(LIBGIT2_VER_MINOR) && defined(LIBGIT2_VER_REVISION)
+#if ((LIBGIT2_VER_MAJOR * 1000000) + (LIBGIT2_VER_MINOR * 10000) + (LIBGIT2_VER_REVISION * 100)) < 1070000
+#error "HAVE_LIBGIT2 requires libgit2 >= 1.7.0 for git_allocator"
+#endif
+#else
+#error "HAVE_LIBGIT2 requires known libgit2 version macros for the >= 1.7.0 git_allocator guard"
+#endif
 #include <git2.h>           // git_libgit2_opts, GIT_OPT_SET_ALLOCATOR — bind libgit2 to mimalloc
 #include <git2/sys/alloc.h> // git_allocator — not pulled in by <git2.h> (it's a sys/ header)
 #endif
@@ -287,8 +299,8 @@ static void cbm_sqlite_memshutdown(void *appdata) {
 }
 
 #if defined(HAVE_LIBGIT2)
-/* libgit2 git_allocator backed by mimalloc. The struct (current libgit2) has
- * exactly three members: gmalloc(size_t,file,line), grealloc(ptr,size,file,line),
+/* libgit2 >= 1.7 git_allocator backed by mimalloc. The struct has exactly
+ * three members: gmalloc(size_t,file,line), grealloc(ptr,size,file,line),
  * gfree(ptr). The file/line args are ignored. */
 static void *cbm_git_malloc(size_t n, const char *file, int line) {
     (void)file;


### PR DESCRIPTION
## Summary
- Require libgit2 >= 1.7.0 before enabling the optional `HAVE_LIBGIT2` build path.
- Add `REQUIRE_LIBGIT2=1` so CI/proof builds fail clearly if the intended libgit2 path is missing or too old.
- Add a defensive header-version guard before binding `git_allocator`.
- Run one Ubuntu PR test matrix leg with `libgit2-dev` installed and required.

## Why
Fixes #801.

The allocator binding uses the libgit2 1.7+ shape, but the build previously enabled `HAVE_LIBGIT2` for any libgit2 pkg-config result. PR CI also did not intentionally cover the optional libgit2 path.

## Tests
- `make -f Makefile.cbm cbm REQUIRE_LIBGIT2=1`
- `make -f Makefile.cbm build/c/test-runner REQUIRE_LIBGIT2=1`
- Missing pkg-config fallback probe with `PKG_CONFIG=/bin/false`
- Fake libgit2 1.6.9 pkg-config probe: default fallback works, required mode fails clearly
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/_test.yml")'`
- `git diff --check`

## Scope
- Keeps missing or too-old libgit2 as a normal fallback unless `REQUIRE_LIBGIT2=1` is set.
- Does not vendor or build libgit2 from source.
- Does not expand every OS matrix leg.
- Does not change git-history parsing behavior.

## Caveats
- Full `scripts/test.sh`, `make -f Makefile.cbm test`, and `make -f Makefile.cbm lint-ci` were not run locally.
- `actionlint` was unavailable locally, so workflow validation used YAML parsing plus manual review.
- Old-version behavior is proven with pkg-config simulation and header-macro compatibility review, not by compiling against a real old libgit2 package.
