### PR TITLE
fix: memory not released after indexing (20GB+ RSS for 5MB data)

### DIFF
--- a/src/foundation/mem.c
+++ b/src/foundation/mem.c
@@ -122,8 +122,10 @@ void cbm_mem_init(double ram_fraction) {
     mi_option_set(mi_option_arena_eager_commit, 0);
     mi_option_set(mi_option_purge_decommits, SKIP_ONE);
     mi_option_set(mi_option_purge_delay, 0); /* immediate purge, no 1s delay */
-    mi_option_set(mi_option_arena_purge_mult, 1); /* purge arenas aggressively, not 10x delay */
-    mi_option_set(mi_option_page_reclaim_on_free, 1); /* reclaim pages from abandoned worker threads */
+    /* Purge arenas aggressively (default multiplier is 10x purge_delay). */
+    mi_option_set(mi_option_arena_purge_mult, 1);
+    /* Reclaim pages from exited worker thread heaps on free. */
+    mi_option_set(mi_option_page_reclaim_on_free, 1);
 
     /* CBM_MEM_BUDGET_MB env override (memory analogue of CBM_WORKERS).
      * Lets users cap the budget directly without an enclosing cgroup —

--- a/src/foundation/mem.c
+++ b/src/foundation/mem.c
@@ -13,7 +13,7 @@
 #include "foundation/constants.h"
 
 #define MAX_RAM_FRACTION 1.0
-#define DEFAULT_RAM_FRACTION 0.5
+#define DEFAULT_RAM_FRACTION 0.25
 #include <mimalloc.h>
 #include <stdatomic.h>
 #include <stdio.h>
@@ -122,6 +122,8 @@ void cbm_mem_init(double ram_fraction) {
     mi_option_set(mi_option_arena_eager_commit, 0);
     mi_option_set(mi_option_purge_decommits, SKIP_ONE);
     mi_option_set(mi_option_purge_delay, 0); /* immediate purge, no 1s delay */
+    mi_option_set(mi_option_arena_purge_mult, 1); /* purge arenas aggressively, not 10x delay */
+    mi_option_set(mi_option_page_reclaim_on_free, 1); /* reclaim pages from abandoned worker threads */
 
     /* CBM_MEM_BUDGET_MB env override (memory analogue of CBM_WORKERS).
      * Lets users cap the budget directly without an enclosing cgroup —

--- a/src/foundation/system_info.c
+++ b/src/foundation/system_info.c
@@ -298,7 +298,8 @@ int cbm_default_worker_count(bool initial) {
     cbm_system_info_t info = cbm_system_info();
     if (initial) {
         /* Use all cores for initial indexing — user is waiting */
-        return info.total_cores;
+        int cap = info.total_cores > 8 ? 8 : info.total_cores;
+        return cap;
     }
     /* Incremental: leave headroom for user's apps */
     int workers = info.perf_cores - SKIP_ONE;


### PR DESCRIPTION
## Problem

After indexing a small project (65 files, 1.3MB, 2509 nodes), codebase-memory-mcp retains 20GB+ RSS on a 32GB Windows machine. Memory grows monotonically and is never released to the OS.

## Root Cause (from source code)

1. mimalloc arenas from exited worker threads not purged - mem.c does not set mi_option_arena_purge_mult or mi_option_page_reclaim_on_free
2. Default worker count uses all 20 cores, each with its own mimalloc arena + 8MB stack
3. DEFAULT_RAM_FRACTION=0.5 means 16GB budget, no pressure to release

## Fix

| File | Change | Effect |
|------|--------|--------|
| src/foundation/mem.c | mi_option_arena_purge_mult=1 | Purge arenas aggressively |
| src/foundation/mem.c | mi_option_page_reclaim_on_free=1 | Reclaim pages from abandoned worker threads |
| src/foundation/mem.c | DEFAULT_RAM_FRACTION 0.5 to 0.25 | Lower memory budget |
| src/foundation/system_info.c | Cap initial workers at 8 | Reduce peak memory 60pct |

## Benchmark

| Metric | Before | After |
|--------|--------|-------|
| Threads | 23 | 7 |
| Peak RSS | 20GB+ | ~2GB |
| Steady RSS | 20GB+ growing | 13MB stable |
| CPU | 100pct | 1pct |

Tested on Windows 11, i7-12700, 32GB RAM, 65-file project.