### PR TITLE
test(graph-ui): fix locale-dependent number-format assertion in GraphTab.test.ts

### DIFF
--- a/graph-ui/src/components/GraphTab.tsx
+++ b/graph-ui/src/components/GraphTab.tsx
@@ -31,7 +31,7 @@ interface GraphTabProps {
 
 export function formatGraphLimitNotice(data: GraphData | null): string | null {
   if (!data || data.total_nodes <= data.nodes.length) return null;
-  return `Showing ${data.nodes.length.toLocaleString()} of ${data.total_nodes.toLocaleString()} nodes. Use filters to narrow.`;
+  return `Showing ${data.nodes.length.toLocaleString("en-US")} of ${data.total_nodes.toLocaleString("en-US")} nodes. Use filters to narrow.`;
 }
 
 export function GraphTab({ project }: GraphTabProps) {


### PR DESCRIPTION
## What does this PR do?

Pins the number formatting in `formatGraphLimitNotice` to the `'en-US'` locale. 

Previously, the use of `toLocaleString()` without specifying a locale caused numbers to format according to the host machine's system locale (e.g., `2.000` under German locales like `de-DE` instead of `2,000`). This caused the unit test in `GraphTab.test.ts` to fail on any developer machine configured with a non-`en_US` locale. Explicitly pinning this to `'en-US'` ensures consistent, environment-independent formatting for tests and the English UI message.

Fixes #825

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test` / `npm run test` in `graph-ui`)
- [x] Lint/Build passes (`npm run build` in `graph-ui`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)
