### PR TITLE
fix(ui): unwatch projects on UI delete; harden deferred-free OOM corner

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -676,6 +676,7 @@ int main(int argc, char **argv) {
     if (ui_cfg.ui_enabled && CBM_EMBEDDED_FILE_COUNT > 0) {
         g_http_server = cbm_http_server_new(ui_cfg.ui_port);
         if (g_http_server) {
+            cbm_http_server_set_watcher(g_http_server, g_watcher);
             if (cbm_thread_create(&http_tid, 0, http_thread, g_http_server) == 0) {
                 http_started = true;
             }

--- a/src/ui/http_server.c
+++ b/src/ui/http_server.c
@@ -19,6 +19,7 @@
 #include "ui/layout3d.h"
 #include "mcp/mcp.h"
 #include "store/store.h"
+#include "watcher/watcher.h"
 #include "cli/cli.h"
 /* pipeline.h no longer needed — indexing runs as subprocess */
 #include "foundation/log.h"
@@ -31,6 +32,7 @@
 #include <sqlite3/sqlite3.h>
 #include <yyjson/yyjson.h>
 
+#include <errno.h>
 #include <math.h>
 #include <stdatomic.h>
 #include <stdio.h>
@@ -114,6 +116,7 @@ static void handle_ui_config(cbm_http_conn_t *c, const cbm_http_req_t *req) {
 struct cbm_http_server {
     cbm_httpd_t *listener;
     cbm_mcp_server_t *mcp; /* own MCP server instance (read-only) */
+    struct cbm_watcher *watcher; /* external watcher ref (not owned) */
     atomic_int stop_flag;
     int port;
     bool listener_ok;
@@ -994,8 +997,15 @@ static void handle_index_status(cbm_http_conn_t *c) {
     cbm_http_replyf(c, 200, g_cors_json, "%s", buf);
 }
 
+static void unwatch_project(cbm_http_server_t *srv, const char *name) {
+    if (srv && srv->watcher) {
+        cbm_watcher_unwatch(srv->watcher, name);
+    }
+}
+
 /* DELETE /api/project?name=X — deletes the .db file */
-static void handle_delete_project(cbm_http_conn_t *c, const cbm_http_req_t *req) {
+static void handle_delete_project(cbm_http_server_t *srv, cbm_http_conn_t *c,
+                                  const cbm_http_req_t *req) {
     char name[256] = {0};
     if (!cbm_http_query_param(req->query, "name", name, (int)sizeof(name)) || name[0] == '\0') {
         cbm_http_replyf(c, 400, g_cors_json, "{\"error\":\"missing name\"}");
@@ -1004,13 +1014,17 @@ static void handle_delete_project(cbm_http_conn_t *c, const cbm_http_req_t *req)
 
     char db_path[1024];
     db_path_for_project(name, db_path, sizeof(db_path));
-
-    if (!cbm_file_exists(db_path)) {
+    if (db_path[0] == '\0') {
         cbm_http_replyf(c, 404, g_cors_json, "{\"error\":\"project not found\"}");
         return;
     }
 
     if (unlink(db_path) != 0) {
+        if (errno == ENOENT) {
+            unwatch_project(srv, name);
+            cbm_http_replyf(c, 404, g_cors_json, "{\"error\":\"project not found\"}");
+            return;
+        }
         cbm_http_replyf(c, 500, g_cors_json, "{\"error\":\"failed to delete\"}");
         return;
     }
@@ -1022,6 +1036,7 @@ static void handle_delete_project(cbm_http_conn_t *c, const cbm_http_req_t *req)
     (void)unlink(wal_path);
     (void)unlink(shm_path);
 
+    unwatch_project(srv, name);
     cbm_log_info("ui.project.deleted", "name", name);
     cbm_http_replyf(c, 200, g_cors_json, "{\"deleted\":true}");
 }
@@ -1419,7 +1434,7 @@ static void dispatch_request(cbm_http_server_t *srv, cbm_http_conn_t *c,
 
     /* DELETE /api/project → delete a project's .db file */
     if (is_delete && cbm_http_path_match(req->path, "/api/project*")) {
-        handle_delete_project(c, req);
+        handle_delete_project(srv, c, req);
         return;
     }
 
@@ -1583,5 +1598,11 @@ int cbm_http_server_port(const cbm_http_server_t *srv) {
 void cbm_http_server_set_recv_deadline_ms(cbm_http_server_t *srv, int ms) {
     if (srv && srv->listener_ok) {
         cbm_httpd_set_recv_deadline_ms(srv->listener, ms);
+    }
+}
+
+void cbm_http_server_set_watcher(cbm_http_server_t *srv, struct cbm_watcher *watcher) {
+    if (srv) {
+        srv->watcher = watcher;
     }
 }

--- a/src/ui/http_server.h
+++ b/src/ui/http_server.h
@@ -14,6 +14,7 @@
 #include <stddef.h>
 
 typedef struct cbm_http_server cbm_http_server_t;
+struct cbm_watcher;
 
 /* Create an HTTP server on the given port.
  * Creates its own cbm_mcp_server_t with a separate read-only SQLite connection.
@@ -38,6 +39,9 @@ int cbm_http_server_port(const cbm_http_server_t *srv);
 
 /* Override the per-connection receive deadline (tests use short values). */
 void cbm_http_server_set_recv_deadline_ms(cbm_http_server_t *srv, int ms);
+
+/* Set external watcher reference for UI project lifecycle actions. Not owned. */
+void cbm_http_server_set_watcher(cbm_http_server_t *srv, struct cbm_watcher *watcher);
 
 /* Initialize the log ring buffer mutex. Must be called once before any threads. */
 void cbm_ui_log_init(void);

--- a/src/watcher/watcher.c
+++ b/src/watcher/watcher.c
@@ -259,23 +259,24 @@ static void state_free(project_state_t *s) {
 
 /* Move a state onto the deferred-free list (caller holds projects_lock).
  * The state may still be referenced by a poll_once snapshot; poll_once
- * drains the list at the start of its next cycle. Falls back to an
- * immediate free only if growing the list fails. */
-static void defer_state_free(cbm_watcher_t *w, project_state_t *s) {
+ * drains the list at the start of its next cycle. Returns false when
+ * growing the list fails (OOM): the state is left untouched and the
+ * caller must keep it registered — freeing it immediately here could be
+ * a use-after-free against an in-flight poll snapshot. */
+static bool defer_state_free(cbm_watcher_t *w, project_state_t *s) {
     if (w->pending_free_count >= w->pending_free_cap) {
         int new_cap = w->pending_free_cap ? w->pending_free_cap * 2 : 8;
         project_state_t **tmp =
             realloc(w->pending_free, (size_t)new_cap * sizeof(project_state_t *));
-        if (tmp) {
-            w->pending_free = tmp;
-            w->pending_free_cap = new_cap;
+        if (!tmp) {
+            cbm_log_warn("watcher.unwatch.oom", "project", s->project_name);
+            return false;
         }
+        w->pending_free = tmp;
+        w->pending_free_cap = new_cap;
     }
-    if (w->pending_free_count < w->pending_free_cap) {
-        w->pending_free[w->pending_free_count++] = s;
-    } else {
-        state_free(s); /* realloc failed — fall back to immediate free */
-    }
+    w->pending_free[w->pending_free_count++] = s;
+    return true;
 }
 
 /* ── Stale-root pruning (#286) ──────────────────────────────────── */
@@ -444,12 +445,10 @@ void cbm_watcher_unwatch(cbm_watcher_t *w, const char *project_name) {
     bool removed = false;
     cbm_mutex_lock(&w->projects_lock);
     project_state_t *s = cbm_ht_get(w->projects, project_name);
-    if (s) {
+    if (s && defer_state_free(w, s)) {
+        /* The entry leaves the table only once its state is safely on
+         * the deferred-free list; on OOM the watch stays registered. */
         cbm_ht_delete(w->projects, project_name);
-        /* Defer free: the state may still be referenced by a poll_once
-         * snapshot taken before we acquired the lock.  poll_once will
-         * drain this list at the start of its next cycle. */
-        defer_state_free(w, s);
         removed = true;
     }
     cbm_mutex_unlock(&w->projects_lock);
@@ -548,12 +547,12 @@ static void prune_missing_project(cbm_watcher_t *w, project_state_t *s) {
     bool removed = false;
     cbm_mutex_lock(&w->projects_lock);
     project_state_t *current = cbm_ht_get(w->projects, project_name);
-    if (current == s) {
+    /* Deferred free (same discipline as cbm_watcher_unwatch): this state
+     * is referenced by the poll_once snapshot iterating us. On OOM the
+     * watch stays registered and pruning retries on the next cycle. */
+    if (current == s && defer_state_free(w, s)) {
         delete_cached_project_db(project_name);
         cbm_ht_delete(w->projects, project_name);
-        /* Deferred free (same discipline as cbm_watcher_unwatch): this
-         * state is referenced by the poll_once snapshot iterating us. */
-        defer_state_free(w, s);
         removed = true;
     }
     cbm_mutex_unlock(&w->projects_lock);

--- a/tests/test_httpd.c
+++ b/tests/test_httpd.c
@@ -21,6 +21,8 @@
 #include "test_helpers.h"
 #include "ui/httpd.h"
 #include "ui/http_server.h"
+#include <store/store.h>
+#include <watcher/watcher.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -413,10 +415,92 @@ static int th_server_start(th_server_t *ts) {
     return 0;
 }
 
+static int th_server_start_with_watcher(th_server_t *ts, cbm_watcher_t *watcher) {
+    ts->srv = cbm_http_server_new(0);
+    if (!ts->srv)
+        return -1;
+    cbm_http_server_set_watcher(ts->srv, watcher);
+    if (cbm_thread_create(&ts->tid, 0, th_server_thread, ts->srv) != 0) {
+        cbm_http_server_free(ts->srv);
+        return -1;
+    }
+    return 0;
+}
+
 static void th_server_stop(th_server_t *ts) {
     cbm_http_server_stop(ts->srv);
     cbm_thread_join(&ts->tid);
     cbm_http_server_free(ts->srv);
+}
+
+typedef struct {
+    char tmpdir[256];
+    char cache_dir[512];
+    char root_dir[512];
+    char *saved_cache_dir;
+    cbm_store_t *store;
+    cbm_watcher_t *watcher;
+} ui_delete_fixture_t;
+
+static int ui_delete_fixture_init(ui_delete_fixture_t *fx) {
+    memset(fx, 0, sizeof(*fx));
+    char *tmp = th_mktempdir("cbm_httpd_delete");
+    if (!tmp)
+        return -1;
+    snprintf(fx->tmpdir, sizeof(fx->tmpdir), "%s", tmp);
+    snprintf(fx->cache_dir, sizeof(fx->cache_dir), "%s/cache", fx->tmpdir);
+    snprintf(fx->root_dir, sizeof(fx->root_dir), "%s/root", fx->tmpdir);
+
+    const char *saved = getenv("CBM_CACHE_DIR");
+    fx->saved_cache_dir = saved ? strdup(saved) : NULL;
+    if (th_mkdir_p(fx->cache_dir) != 0 || th_mkdir_p(fx->root_dir) != 0) {
+        return -1;
+    }
+    cbm_setenv("CBM_CACHE_DIR", fx->cache_dir, 1);
+
+    fx->store = cbm_store_open_memory();
+    fx->watcher = cbm_watcher_new(fx->store, NULL, NULL);
+    return fx->store && fx->watcher ? 0 : -1;
+}
+
+static void ui_delete_fixture_cleanup(ui_delete_fixture_t *fx) {
+    if (fx->watcher)
+        cbm_watcher_free(fx->watcher);
+    if (fx->store)
+        cbm_store_close(fx->store);
+    if (fx->saved_cache_dir) {
+        cbm_setenv("CBM_CACHE_DIR", fx->saved_cache_dir, 1);
+        free(fx->saved_cache_dir);
+    } else {
+        cbm_unsetenv("CBM_CACHE_DIR");
+    }
+    th_cleanup(fx->tmpdir);
+}
+
+static void ui_delete_db_path(const ui_delete_fixture_t *fx, const char *project, char *out,
+                              size_t outsz) {
+    snprintf(out, outsz, "%s/%s.db", fx->cache_dir, project);
+}
+
+static int ui_delete_make_db_file(const ui_delete_fixture_t *fx, const char *project) {
+    char path[1024];
+    ui_delete_db_path(fx, project, path, sizeof(path));
+    return th_write_file(path, "test db");
+}
+
+static int ui_delete_make_sidecars(const ui_delete_fixture_t *fx, const char *project) {
+    char path[1024];
+    ui_delete_db_path(fx, project, path, sizeof(path));
+    char wal[1040], shm[1040];
+    snprintf(wal, sizeof(wal), "%s-wal", path);
+    snprintf(shm, sizeof(shm), "%s-shm", path);
+    return th_write_file(wal, "wal") == 0 && th_write_file(shm, "shm") == 0 ? 0 : -1;
+}
+
+static int ui_delete_request(th_server_t *ts, const char *target, char *resp, size_t respsz) {
+    char req[512];
+    snprintf(req, sizeof(req), "DELETE %s HTTP/1.1\r\n\r\n", target);
+    return th_http(cbm_http_server_port(ts->srv), req, resp, respsz);
 }
 
 TEST(ui_server_unknown_path_404) {
@@ -559,6 +643,145 @@ TEST(ui_server_browse_traversal_probe) {
     ASSERT_NOT_NULL(json);
     ASSERT_EQ(json[4], '{');
     th_server_stop(&ts);
+    PASS();
+}
+
+TEST(ui_server_delete_project_unwatches_after_delete) {
+    ui_delete_fixture_t fx;
+    ASSERT_EQ(ui_delete_fixture_init(&fx), 0);
+    ASSERT_EQ(ui_delete_make_db_file(&fx, "ui-delete-watch"), 0);
+    ASSERT_EQ(ui_delete_make_sidecars(&fx, "ui-delete-watch"), 0);
+    cbm_watcher_watch(fx.watcher, "ui-delete-watch", fx.root_dir);
+    ASSERT_EQ(cbm_watcher_watch_count(fx.watcher), 1);
+
+    th_server_t ts;
+    ASSERT_EQ(th_server_start_with_watcher(&ts, fx.watcher), 0);
+    char resp[4096];
+    int n =
+        ui_delete_request(&ts, "/api/project?name=ui-delete-watch", resp, sizeof(resp));
+    ASSERT_GT(n, 0);
+    ASSERT_EQ(th_status(resp), 200);
+    ASSERT_NOT_NULL(strstr(resp, "{\"deleted\":true}"));
+
+    char db[1024], wal[1040], shm[1040];
+    ui_delete_db_path(&fx, "ui-delete-watch", db, sizeof(db));
+    snprintf(wal, sizeof(wal), "%s-wal", db);
+    snprintf(shm, sizeof(shm), "%s-shm", db);
+    ASSERT_FALSE(cbm_file_exists(db));
+    ASSERT_FALSE(cbm_file_exists(wal));
+    ASSERT_FALSE(cbm_file_exists(shm));
+    ASSERT_EQ(cbm_watcher_watch_count(fx.watcher), 0);
+
+    th_server_stop(&ts);
+    ui_delete_fixture_cleanup(&fx);
+    PASS();
+}
+
+TEST(ui_server_delete_project_unwatches_missing_db) {
+    ui_delete_fixture_t fx;
+    ASSERT_EQ(ui_delete_fixture_init(&fx), 0);
+    cbm_watcher_watch(fx.watcher, "ui-delete-missing", fx.root_dir);
+    ASSERT_EQ(cbm_watcher_watch_count(fx.watcher), 1);
+
+    th_server_t ts;
+    ASSERT_EQ(th_server_start_with_watcher(&ts, fx.watcher), 0);
+    char resp[4096];
+    int n =
+        ui_delete_request(&ts, "/api/project?name=ui-delete-missing", resp, sizeof(resp));
+    ASSERT_GT(n, 0);
+    ASSERT_EQ(th_status(resp), 404);
+    ASSERT_NOT_NULL(strstr(resp, "{\"error\":\"project not found\"}"));
+    ASSERT_EQ(cbm_watcher_watch_count(fx.watcher), 0);
+
+    th_server_stop(&ts);
+    ui_delete_fixture_cleanup(&fx);
+    PASS();
+}
+
+TEST(ui_server_delete_project_no_watcher_still_deletes) {
+    ui_delete_fixture_t fx;
+    ASSERT_EQ(ui_delete_fixture_init(&fx), 0);
+    ASSERT_EQ(ui_delete_make_db_file(&fx, "ui-delete-no-watcher"), 0);
+
+    th_server_t ts;
+    ASSERT_EQ(th_server_start(&ts), 0);
+    char resp[4096];
+    int n =
+        ui_delete_request(&ts, "/api/project?name=ui-delete-no-watcher", resp, sizeof(resp));
+    ASSERT_GT(n, 0);
+    ASSERT_EQ(th_status(resp), 200);
+
+    char db[1024];
+    ui_delete_db_path(&fx, "ui-delete-no-watcher", db, sizeof(db));
+    ASSERT_FALSE(cbm_file_exists(db));
+
+    th_server_stop(&ts);
+    ui_delete_fixture_cleanup(&fx);
+    PASS();
+}
+
+TEST(ui_server_delete_project_missing_name_keeps_watch) {
+    ui_delete_fixture_t fx;
+    ASSERT_EQ(ui_delete_fixture_init(&fx), 0);
+    cbm_watcher_watch(fx.watcher, "ui-delete-still-watched", fx.root_dir);
+    ASSERT_EQ(cbm_watcher_watch_count(fx.watcher), 1);
+
+    th_server_t ts;
+    ASSERT_EQ(th_server_start_with_watcher(&ts, fx.watcher), 0);
+    char resp[4096];
+    int n = ui_delete_request(&ts, "/api/project", resp, sizeof(resp));
+    ASSERT_GT(n, 0);
+    ASSERT_EQ(th_status(resp), 400);
+    ASSERT_NOT_NULL(strstr(resp, "{\"error\":\"missing name\"}"));
+    ASSERT_EQ(cbm_watcher_watch_count(fx.watcher), 1);
+
+    th_server_stop(&ts);
+    ui_delete_fixture_cleanup(&fx);
+    PASS();
+}
+
+TEST(ui_server_delete_project_invalid_name_keeps_watch) {
+    ui_delete_fixture_t fx;
+    ASSERT_EQ(ui_delete_fixture_init(&fx), 0);
+    cbm_watcher_watch(fx.watcher, "bad/name", fx.root_dir);
+    ASSERT_EQ(cbm_watcher_watch_count(fx.watcher), 1);
+
+    th_server_t ts;
+    ASSERT_EQ(th_server_start_with_watcher(&ts, fx.watcher), 0);
+    char resp[4096];
+    int n = ui_delete_request(&ts, "/api/project?name=bad%2Fname", resp, sizeof(resp));
+    ASSERT_GT(n, 0);
+    ASSERT_EQ(th_status(resp), 404);
+    ASSERT_NOT_NULL(strstr(resp, "{\"error\":\"project not found\"}"));
+    ASSERT_EQ(cbm_watcher_watch_count(fx.watcher), 1);
+
+    th_server_stop(&ts);
+    ui_delete_fixture_cleanup(&fx);
+    PASS();
+}
+
+TEST(ui_server_delete_project_unlink_failure_keeps_watch) {
+    ui_delete_fixture_t fx;
+    ASSERT_EQ(ui_delete_fixture_init(&fx), 0);
+    char db[1024];
+    ui_delete_db_path(&fx, "ui-delete-unlink-fails", db, sizeof(db));
+    ASSERT_EQ(th_mkdir_p(db), 0);
+    cbm_watcher_watch(fx.watcher, "ui-delete-unlink-fails", fx.root_dir);
+    ASSERT_EQ(cbm_watcher_watch_count(fx.watcher), 1);
+
+    th_server_t ts;
+    ASSERT_EQ(th_server_start_with_watcher(&ts, fx.watcher), 0);
+    char resp[4096];
+    int n =
+        ui_delete_request(&ts, "/api/project?name=ui-delete-unlink-fails", resp, sizeof(resp));
+    ASSERT_GT(n, 0);
+    ASSERT_EQ(th_status(resp), 500);
+    ASSERT_NOT_NULL(strstr(resp, "{\"error\":\"failed to delete\"}"));
+    ASSERT_TRUE(cbm_file_exists(db));
+    ASSERT_EQ(cbm_watcher_watch_count(fx.watcher), 1);
+
+    th_server_stop(&ts);
+    ui_delete_fixture_cleanup(&fx);
     PASS();
 }
 
@@ -717,6 +940,12 @@ SUITE(httpd) {
     RUN_TEST(ui_server_encoded_slash_not_routed);
     RUN_TEST(ui_server_nul_in_target_rejected);
     RUN_TEST(ui_server_browse_traversal_probe);
+    RUN_TEST(ui_server_delete_project_unwatches_after_delete);
+    RUN_TEST(ui_server_delete_project_unwatches_missing_db);
+    RUN_TEST(ui_server_delete_project_no_watcher_still_deletes);
+    RUN_TEST(ui_server_delete_project_missing_name_keeps_watch);
+    RUN_TEST(ui_server_delete_project_invalid_name_keeps_watch);
+    RUN_TEST(ui_server_delete_project_unlink_failure_keeps_watch);
     RUN_TEST(ui_server_ui_config_detects_zh_accept_language);
     RUN_TEST(ui_server_ui_config_prefers_config_lang);
     RUN_TEST(ui_server_slow_request_hits_deadline);


### PR DESCRIPTION
# fix(ui): unwatch projects on UI delete; harden deferred-free OOM corner

Distilled from #830 (author: Dustin Persek <dustin.persek@protonmail.com>), rebased over the
`defer_state_free` refactor that landed with #817.

## Summary

`DELETE /api/project` removed the project's `.db` file but never told the watcher. The zombie
watch kept polling the repo and the next change reindexed it — silently resurrecting the DB the
user just deleted (#803).

- **main.c**: hand the watcher to the UI HTTP server (`cbm_http_server_set_watcher`) right after
  server creation. Lifecycle holds on current main: watcher is created (l.658) before the HTTP
  server (l.677); teardown stops/frees the HTTP server (l.702–705) before the watcher (l.709–712),
  so the non-owned reference can never dangle.
- **http_server.c/.h**: `handle_delete_project` now unwatches after a successful unlink **and** on
  `ENOENT` (clears an already-orphaned zombie watch, still 404). Invalid project name → 404 with
  no unwatch. Unlink failure (non-ENOENT) → 500 and the watch is kept. The `cbm_file_exists`
  pre-check is replaced by unlink-errno handling (removes the TOCTOU window).
- **watcher.c**: the OOM corner of the deferred-free path is hardened. Previously, if growing the
  `pending_free` list failed, the state was freed immediately — a potential use-after-free against
  an in-flight `poll_once` snapshot. `defer_state_free` now returns failure without freeing;
  callers keep the entry registered (`cbm_ht_delete` only happens once the state is safely on the
  deferred-free list) and emit `watcher.unwatch.oom`.

## Re-target rationale (why this differs from #830's watcher hunk)

#830 was audited CORRECT but written against pre-#817 code, where the pending-free logic lived
inline in `cbm_watcher_unwatch`. Main has since extracted it into `defer_state_free`, shared by
`cbm_watcher_unwatch` and the stale-root prune path (`prune_missing_project`) — and the UAF-prone
`state_free` fallback moved inside that helper. Applying #830's hunk verbatim would have hardened
only the unwatch path and left the same bug reachable via root-prune. The hardening therefore goes
into `defer_state_free` itself (fail → keep registered → warn), covering **both** call sites; the
prune path additionally retries on the next poll cycle.

## Tests (carried from #830, adapted to current main)

Six regressions in `tests/test_httpd.c` (suite `httpd`), driving the live UI server over a socket
with a real watcher wired in:

- `ui_server_delete_project_unwatches_after_delete` (core red-first case)
- `ui_server_delete_project_unwatches_missing_db` (ENOENT zombie-clear, still 404)
- `ui_server_delete_project_no_watcher_still_deletes`
- `ui_server_delete_project_missing_name_keeps_watch` (400)
- `ui_server_delete_project_invalid_name_keeps_watch` (404, no unwatch)
- `ui_server_delete_project_unlink_failure_keeps_watch` (500)

## Red/green evidence

RED — `src/ui/http_server.c` + `src/main.c` reverted to `origin/main` (plus a link-only no-op
`cbm_http_server_set_watcher` shim so the fixture compiles), rebuilt, `test-runner httpd`:

```
FAIL tests/test_httpd.c:673: cbm_watcher_watch_count(fx.watcher) == 1, expected 0 == 0
FAIL tests/test_httpd.c:694: cbm_watcher_watch_count(fx.watcher) == 1, expected 0 == 0
36 passed, 2 failed
```

GREEN — fix restored, rebuilt, `test-runner httpd watcher`:

```
96 passed
```

`make -f Makefile.cbm cbm` builds -Werror clean; `make -f Makefile.cbm lint-ci` passes.

Closes #803.
