### PR TITLE
chore(release): compute grammar count in SBOM + complete non-MIT license summary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,8 @@ jobs:
       - name: Generate SBOM
         run: |
           python3 -c "
-          import json
+          import json, glob, os
+          n_grammars = len([d for d in glob.glob('internal/cbm/vendored/grammars/*') if os.path.isdir(d)])
           sbom = {
             'spdxVersion': 'SPDX-2.3',
             'dataLicense': 'CC0-1.0',
@@ -131,7 +132,7 @@ jobs:
               {'SPDXID': 'SPDXRef-Package-verstable', 'name': 'verstable', 'versionInfo': '2.2.1', 'licenseDeclared': 'MIT', 'downloadLocation': 'https://github.com/JacksonAllan/Verstable', 'filesAnalyzed': False},
               {'SPDXID': 'SPDXRef-Package-wyhash', 'name': 'wyhash', 'versionInfo': 'final-4.3', 'licenseDeclared': 'Unlicense', 'downloadLocation': 'https://github.com/wangyi-fudan/wyhash', 'filesAnalyzed': False},
               {'SPDXID': 'SPDXRef-Package-nomic-embed-code', 'name': 'nomic-embed-code-token-embeddings', 'versionInfo': '1.0', 'licenseDeclared': 'Apache-2.0', 'downloadLocation': 'https://huggingface.co/nomic-ai/nomic-embed-code', 'filesAnalyzed': False, 'comment': 'Derived int8 token embeddings; see vendored/nomic/NOTICE'},
-              {'SPDXID': 'SPDXRef-Package-tree-sitter-grammars', 'name': 'tree-sitter-grammars-aggregate', 'versionInfo': '158-grammars', 'licenseDeclared': 'MIT', 'downloadLocation': 'NOASSERTION', 'filesAnalyzed': False, 'comment': 'Aggregate of 158 vendored tree-sitter grammars. Predominantly MIT; exceptions: clojure CC0-1.0, jinja2 + just Apache-2.0, first-party grammars (c) DeusData MIT. Per-grammar provenance: internal/cbm/vendored/grammars/MANIFEST.md; full texts ship in THIRD_PARTY_NOTICES.md inside each archive.'}
+              {'SPDXID': 'SPDXRef-Package-tree-sitter-grammars', 'name': 'tree-sitter-grammars-aggregate', 'versionInfo': f'{n_grammars}-grammars', 'licenseDeclared': 'MIT', 'downloadLocation': 'NOASSERTION', 'filesAnalyzed': False, 'comment': f'Aggregate of {n_grammars} vendored tree-sitter grammars, compiled statically. Predominantly MIT; non-MIT families present include CC0-1.0 (clojure, fennel), Apache-2.0 (elixir, erlang, gleam, hcl, ini, jinja2, just, pkl, sway, wit), ISC (pine, templ), Unlicense (fish); first-party grammars (c) DeusData, MIT. This summary is non-exhaustive; the authoritative complete per-grammar license list is internal/cbm/vendored/grammars/MANIFEST.md, and full license texts ship in THIRD_PARTY_NOTICES.md inside each archive.'}
             ]
           }
           json.dump(sbom, open('sbom.json', 'w'), indent=2)


### PR DESCRIPTION
## What

Release-prep compliance fix for the generated SBOM (`release.yml` → `sbom.json`).

Two accuracy bugs in the `tree-sitter-grammars-aggregate` SPDX package:

1. **Stale grammar count.** The SBOM hardcoded `158-grammars`. The true count is **159** — Mojo and InterSystems ObjectScript were vendored, and nim was dropped, after that literal was last set. The shipped SBOM under-counted. Now the count is **computed** from the vendored grammar directories at generation time, so it can't drift again (this is the second time it drifted).

2. **Incomplete non-MIT summary.** The comment named only `clojure CC0-1.0, jinja2 + just Apache-2.0` — but the actual non-MIT set is: **CC0** (clojure, fennel), **Apache-2.0** (elixir, erlang, gleam, hcl, ini, jinja2, just, pkl, sway, wit), **Unlicense** (fish), **ISC** (pine, templ). The summary now lists the full non-MIT family set and is explicitly non-exhaustive, deferring to `MANIFEST.md` as the authoritative per-grammar source (as it already did).

## Why

The verified compliance state on `main` is already solid — license gate, provenance audit, and per-grammar LICENSE coverage all pass. This closes the one factual inaccuracy in a *shipped* release artifact (the SBOM) before we tag.

## Scope / CI sensitivity

- **Touches a workflow file (`.github/workflows/release.yml`)** — but only the inline SBOM-generation Python. **Data-only:** no job, trigger, matrix, cost, or gating change; only the contents of the generated `sbom.json` differ.
- Verified locally: the edited generator produces valid JSON, `versionInfo == '159-grammars'`, and `release.yml` still parses as valid YAML.
- No new dependency; all grammar licenses remain in `scripts/license-policy.json`'s allow-list (CC0-1.0 included).

Focused/atomic; merge-commit (not squash).