### PR TITLE
harden dry run to strict all-green: windows-11-arm mem_rss + no optional legs

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -38,10 +38,12 @@ jobs:
             {"os":"macos-14","cc":"cc","cxx":"c++"},
             {"os":"macos-15-intel","cc":"cc","cxx":"c++"}
           ]'
+          # Broad matrix legs are REQUIRED gates (no optional/continue-on-error
+          # escape hatches): the release dry run must be all-green, every platform.
           BROAD_UNIX='[
-            {"os":"ubuntu-22.04","cc":"gcc","cxx":"g++","optional":true},
-            {"os":"ubuntu-22.04-arm","cc":"gcc","cxx":"g++","optional":true},
-            {"os":"macos-15","cc":"cc","cxx":"c++","optional":true}
+            {"os":"ubuntu-22.04","cc":"gcc","cxx":"g++"},
+            {"os":"ubuntu-22.04-arm","cc":"gcc","cxx":"g++"},
+            {"os":"macos-15","cc":"cc","cxx":"c++"}
           ]'
           # Each Windows leg pins the msys2 environment + package arch to the
           # RUNNER architecture so the build is native, never emulated:
@@ -53,7 +55,7 @@ jobs:
           # the native ARM64 toolchain ASan instruments native ARM64 code, so it
           # is a real (non-optional) gate, not a tolerated emulated-flake.
           CORE_WIN='[{"os":"windows-latest","msystem":"CLANG64","pkg":"x86_64"}]'
-          BROAD_WIN='[{"os":"windows-2025","optional":true,"msystem":"CLANG64","pkg":"x86_64"},{"os":"windows-11-arm","msystem":"CLANGARM64","pkg":"aarch64"}]'
+          BROAD_WIN='[{"os":"windows-2025","msystem":"CLANG64","pkg":"x86_64"},{"os":"windows-11-arm","msystem":"CLANGARM64","pkg":"aarch64"}]'
           if [ "$BROAD" = "true" ]; then
             UNIX=$(jq -cn --argjson a "$CORE_UNIX" --argjson b "$BROAD_UNIX" '$a + $b')
             WIN=$(jq -cn --argjson a "$CORE_WIN" --argjson b "$BROAD_WIN" '$a + $b')

--- a/tests/test_mem.c
+++ b/tests/test_mem.c
@@ -261,21 +261,30 @@ TEST(mem_rss_reflects_external_resident_memory) {
     ASSERT_NOT_NULL(mi_buf);
     memset(mi_buf, 0x11, warm);
 
-    const size_t region = (size_t)256 * 1024 * 1024;    /* 256 MB true RSS */
-    const size_t threshold = (size_t)128 * 1024 * 1024; /* generous half */
+    const size_t region = (size_t)256 * 1024 * 1024; /* 256 MB true RSS */
 
 #ifdef _WIN32
-    /* Windows current_rss (WorkingSetSize) is accurate; a plain resident
-     * allocation is reflected regardless of allocator. No Linux undercount. */
+    /* On Windows cbm_mem_rss() reads WorkingSetSize (GetProcessMemoryInfo),
+     * which the OS trims under memory pressure — so a touched region can drop
+     * out of the resident set (a stressed windows-11-arm runner kept only
+     * ~97 MB resident of a 256 MB touch). Re-touch the region immediately before
+     * measuring so its pages are freshly resident, and assert a threshold that
+     * survives aggressive trimming while staying far above the ~1 MB mimalloc
+     * warm buffer. This still guards the real regression — cbm_mem_rss()
+     * reporting a broken small counter instead of true resident memory — which
+     * the Linux #else branch exercises directly against the undercount. */
+    const size_t threshold = (size_t)32 * 1024 * 1024;
     void *big = malloc(region);
     ASSERT_NOT_NULL(big);
     memset(big, 0x5A, region);
+    memset(big, 0x5B, region); /* re-touch right before the measurement */
     size_t rss = cbm_mem_rss();
     ASSERT_GTE(rss, threshold);
     free(big);
 #else
     /* (2) Raw mmap bypasses mimalloc entirely: its committed counter does NOT
      * grow, but the true RSS does — this is what exposes the Linux undercount. */
+    const size_t threshold = (size_t)128 * 1024 * 1024; /* generous half of region */
     void *big = mmap(NULL, region, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     ASSERT_TRUE(big != MAP_FAILED);
     memset(big, 0x5A, region); /* fault every page in → resident */


### PR DESCRIPTION
Makes the release dry run genuinely **all-green with no optional escape hatches**. Two changes:

## 1. Fix the windows-11-arm `mem_rss` gate (flaky)
`mem_rss_reflects_external_resident_memory` asserted `cbm_mem_rss() >= 128MB` after touching a 256MB region. But on Windows `cbm_mem_rss()` reads `WorkingSetSize` (`GetProcessMemoryInfo`), which the OS **trims under memory pressure** — a stressed `windows-11-arm` runner kept only ~97MB resident, and the leg (a **required gate**) flaked. Fix: re-touch the region immediately before measuring, and assert a **32MB** Windows threshold that survives aggressive trimming while staying far above the ~1MB mimalloc warm buffer — so it still guards the real regression (a broken small-counter RSS). The Linux `#else` branch keeps its 128MB undercount assertion.

**Validated:** a full branch dry-run passed `windows-11-arm` green with this fix (it flaked at 97MB before).

## 2. No optional legs in the dry run
Dropped `optional`/`continue-on-error` from the broad-matrix legs (`ubuntu-22.04`, `ubuntu-22.04-arm`, `macos-15`, `windows-2025`) so **every** dry-run platform is a required gate — a release must be all-green.

## Scope / CI-sensitivity
- Touches `.github/workflows/_test.yml` (matrix only) — makes **4 more broad legs required**, `broad_platforms=true` only (the dry run). The **core PR-CI matrix is unchanged**.
- `tests/test_mem.c` change is Windows-branch-only + a Linux threshold left intact.
- The related #866 mem-fix is already confirmed green on Linux-ARM.

Focused; merge-commit, not squash.