### PR TITLE
ci(smoke): every smoke leg gates + fix matrix collapse (no false-green)

### DIFF
--- a/.github/workflows/_smoke.yml
+++ b/.github/workflows/_smoke.yml
@@ -40,22 +40,24 @@ jobs:
           # Broad legs reuse existing goos/goarch artifacts on newer/older OS
           # versions (e.g. ubuntu-22.04 = older glibc) to widen the run-anywhere
           # signal without building new targets.
+          # Broad legs are REQUIRED gates (no optional / continue-on-error):
+          # every smoke leg must pass. No `optional` flags anywhere.
           BROAD_UNIX='[
-            {"os":"ubuntu-22.04","goos":"linux","goarch":"amd64","optional":true},
-            {"os":"ubuntu-22.04-arm","goos":"linux","goarch":"arm64","optional":true},
-            {"os":"macos-15","goos":"darwin","goarch":"arm64","optional":true}
+            {"os":"ubuntu-22.04","goos":"linux","goarch":"amd64"},
+            {"os":"ubuntu-22.04-arm","goos":"linux","goarch":"arm64"},
+            {"os":"macos-15","goos":"darwin","goarch":"arm64"}
           ]'
           CORE_WIN='[{"os":"windows-latest"}]'
           # windows-11-arm runs the shipped x86_64 binary under emulation —
           # verifies the Windows artifact still launches on ARM hardware.
-          BROAD_WIN='[{"os":"windows-2025","optional":true},{"os":"windows-11-arm","optional":true}]'
+          BROAD_WIN='[{"os":"windows-2025"},{"os":"windows-11-arm"}]'
           CORE_PORTABLE='[
             {"arch":"amd64","runner":"ubuntu-latest"},
             {"arch":"arm64","runner":"ubuntu-24.04-arm"}
           ]'
           BROAD_PORTABLE='[
-            {"arch":"amd64","runner":"ubuntu-22.04","optional":true},
-            {"arch":"arm64","runner":"ubuntu-22.04-arm","optional":true}
+            {"arch":"amd64","runner":"ubuntu-22.04"},
+            {"arch":"arm64","runner":"ubuntu-22.04-arm"}
           ]'
           if [ "$BROAD" = "true" ]; then
             UNIX=$(jq -cn --argjson a "$CORE_UNIX" --argjson b "$BROAD_UNIX" '$a + $b')
@@ -66,9 +68,19 @@ jobs:
             WIN=$(jq -cn --argjson a "$CORE_WIN" '$a')
             PORTABLE=$(jq -cn --argjson a "$CORE_PORTABLE" '$a')
           fi
-          echo "unix={\"variant\":[\"standard\",\"ui\"],\"include\":$UNIX}" >> "$GITHUB_OUTPUT"
-          echo "windows={\"variant\":[\"standard\",\"ui\"],\"include\":$WIN}" >> "$GITHUB_OUTPUT"
-          echo "portable={\"variant\":[\"standard\",\"ui\"],\"include\":$PORTABLE}" >> "$GITHUB_OUTPUT"
+          # Expand each OS entry over both variants into a FLAT include list so
+          # every {os,variant} runs as its own job. A {variant:[...],include:$LIST}
+          # matrix collapses under GitHub's include-merge (later os entries
+          # overwrite the variant combos last-wins), which silently dropped every
+          # OS except the last — e.g. only windows-11-arm ran, never windows-latest.
+          # Building the cartesian explicitly avoids that.
+          VARIANTS='["standard","ui"]'
+          UNIX_M=$(jq -cn --argjson a "$UNIX" --argjson v "$VARIANTS" '{include:[$a[] as $o | $v[] as $t | ($o + {variant:$t})]}')
+          WIN_M=$(jq -cn --argjson a "$WIN" --argjson v "$VARIANTS" '{include:[$a[] as $o | $v[] as $t | ($o + {variant:$t})]}')
+          PORTABLE_M=$(jq -cn --argjson a "$PORTABLE" --argjson v "$VARIANTS" '{include:[$a[] as $o | $v[] as $t | ($o + {variant:$t})]}')
+          echo "unix=$UNIX_M" >> "$GITHUB_OUTPUT"
+          echo "windows=$WIN_M" >> "$GITHUB_OUTPUT"
+          echo "portable=$PORTABLE_M" >> "$GITHUB_OUTPUT"
 
   smoke-unix:
     needs: setup-matrix
@@ -76,7 +88,6 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup-matrix.outputs.unix) }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.optional == true }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -153,7 +164,6 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup-matrix.outputs.windows) }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.optional == true }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -220,7 +230,6 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup-matrix.outputs.portable) }}
     runs-on: ${{ matrix.runner }}
-    continue-on-error: ${{ matrix.optional == true }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Fixes two defects that let the release dry run report **green despite real smoke-windows failures** (surfaced by the strict release dry run). Companion to #872 (which did the same for `_test.yml`).

## 1. Matrix collapse — native platforms silently weren't running
The smoke matrices used `{variant:[standard,ui], include:$OS_LIST}`. GitHub's `include`-merge overwrites the variant combos **last-wins** with each OS entry, so **only the last OS ran** (both variants) and the earlier ones were dropped. In broad mode:
- windows smoke → only `windows-11-arm` (emulated x86_64), **never `windows-latest` (native x86_64)**
- unix → only `macos-15`; portable → only `ubuntu-22.04-arm`

So the dry-run smoke was testing one OS per category. Rebuilt each matrix as an explicit **os × variant cartesian** (flat `include` list) so every leg runs. Windows smoke now = `windows-latest` + `windows-2025` + `windows-11-arm`, each × standard/ui.

## 2. Optional escape hatch — failures didn't gate
The broad legs carried `optional:true` + `continue-on-error: ${{ matrix.optional == true }}`, so a failing leg didn't fail `_smoke.yml` → didn't gate the dry run **or a release** (`release.yml` calls the same `_smoke.yml`, and `release-draft`'s `if: !failure()` was bypassed). Removed all `optional` flags + the `continue-on-error` lines. **Every product-smoke leg now gates.**

## Kept intentionally
- `smoke-packages` stays `continue-on-error: true` — it builds the external **Glama directory image** + brew tap, not the shipped product binary; a broken directory listing must not block a release.
- `fail-fast: false` kept so all legs still run for a complete picture on any failure.

## Scope / CI-sensitivity
- `.github/workflows/_smoke.yml` only. Makes native `windows-latest` (and windows-2025, and the broad unix/portable) smoke **required gates** for the dry run and release. `_test.yml` (#872) and `_soak.yml` (flat matrix, no collapse) already gate correctly.
- Verified: YAML parses; the jq cartesian yields 6 windows jobs (3 os × 2 variants); no `optional`/`continue-on-error` remain except `smoke-packages`.
- **Note:** once merged, the dry run correctly stays red until the Windows index-worker crash (#881) lands — which is the point.

Refs #872.