### PR TITLE
fix(cypher): enforce variable-length path semantics

### DIFF
--- a/src/cypher/cypher.c
+++ b/src/cypher/cypher.c
@@ -3129,9 +3129,14 @@ static void expand_var_length(cbm_store_t *store, cbm_rel_pattern_t *rel,
     cbm_traverse_result_t tr = {0};
     const char *dir = rel->direction ? rel->direction : "outbound";
     cbm_store_bfs(store, src->id, dir, rel->types, rel->type_count, max_depth, CBM_PERCENT, &tr);
+    cbm_node_t *bound_to = binding_get(b, to_var);
+    int64_t bound_to_id = bound_to ? bound_to->id : 0;
     for (int v = 0; v < tr.visited_count && *new_count < max_new; v++) {
         cbm_node_hop_t *hop = &tr.visited[v];
         if (hop->hop < rel->min_hops) {
+            continue;
+        }
+        if (bound_to && hop->node.id != bound_to_id) {
             continue;
         }
         if (target_node->label && !label_alt_matches(hop->node.label, target_node->label)) {

--- a/src/cypher/cypher.c
+++ b/src/cypher/cypher.c
@@ -3128,7 +3128,8 @@ static void expand_var_length(cbm_store_t *store, cbm_rel_pattern_t *rel,
     }
     cbm_traverse_result_t tr = {0};
     const char *dir = rel->direction ? rel->direction : "outbound";
-    cbm_store_bfs(store, src->id, dir, rel->types, rel->type_count, max_depth, CBM_PERCENT, &tr);
+    cbm_store_bfs_trail(store, src->id, dir, rel->types, rel->type_count, max_depth, CBM_PERCENT,
+                        &tr);
     cbm_node_t *bound_to = binding_get(b, to_var);
     int64_t bound_to_id = bound_to ? bound_to->id : 0;
     for (int v = 0; v < tr.visited_count && *new_count < max_new; v++) {

--- a/src/cypher/cypher.c
+++ b/src/cypher/cypher.c
@@ -3202,7 +3202,8 @@ static void expand_var_length(cbm_store_t *store, cbm_rel_pattern_t *rel,
     }
     cbm_traverse_result_t tr = {0};
     const char *dir = rel->direction ? rel->direction : "outbound";
-    cbm_store_bfs(store, src->id, dir, rel->types, rel->type_count, max_depth, CBM_PERCENT, &tr);
+    cbm_store_bfs_trail(store, src->id, dir, rel->types, rel->type_count, max_depth, CBM_PERCENT,
+                        &tr);
     cbm_node_t *bound_to = binding_get(b, to_var);
     int64_t bound_to_id = bound_to ? bound_to->id : 0;
     /* Same contract as process_edges: the budget caps materialisation, never

--- a/src/cypher/cypher.c
+++ b/src/cypher/cypher.c
@@ -3180,6 +3180,7 @@ static void process_edges(cbm_store_t *store, cbm_edge_t *edges, int edge_count,
 /* C11 _Thread_local directly: cypher.c stays windows.h-free (compat.h pulls
  * in windows.h, whose legacy `far` macro breaks this file's identifiers). */
 static _Thread_local int g_cypher_depth_clamped = 0;
+static _Thread_local int g_cypher_trail_truncated = 0;
 
 static void expand_var_length(cbm_store_t *store, cbm_rel_pattern_t *rel,
                               cbm_node_pattern_t *target_node, binding_t *b, cbm_node_t *src,
@@ -3204,6 +3205,9 @@ static void expand_var_length(cbm_store_t *store, cbm_rel_pattern_t *rel,
     const char *dir = rel->direction ? rel->direction : "outbound";
     cbm_store_bfs_trail(store, src->id, dir, rel->types, rel->type_count, max_depth, CBM_PERCENT,
                         &tr);
+    if (tr.truncated) {
+        g_cypher_trail_truncated = 1;
+    }
     cbm_node_t *bound_to = binding_get(b, to_var);
     int64_t bound_to_id = bound_to ? bound_to->id : 0;
     /* Same contract as process_edges: the budget caps materialisation, never
@@ -4894,6 +4898,7 @@ int cbm_cypher_execute(cbm_store_t *store, const char *query, const char *projec
                        cbm_cypher_result_t *out) {
     memset(out, 0, sizeof(*out));
     g_cypher_depth_clamped = 0;
+    g_cypher_trail_truncated = 0;
     cypher_deadline_arm(); /* #601: start the wall-clock budget for this query */
     if (max_rows <= 0) {
         max_rows = CYPHER_RESULT_CEILING;
@@ -4964,12 +4969,22 @@ int cbm_cypher_execute(cbm_store_t *store, const char *query, const char *projec
     out->col_count = rb.col_count;
     out->rows = rb.rows;
     out->row_count = rb.row_count;
-    if (g_cypher_depth_clamped > 0) {
+    if (g_cypher_depth_clamped > 0 || g_cypher_trail_truncated) {
         char wbuf[CBM_SZ_256];
-        snprintf(wbuf, sizeof(wbuf),
-                 "variable-length hop range clamped to the engine ceiling (%d) — an empty "
-                 "result may mean \"clamped\", not \"no such path\"",
-                 g_cypher_depth_clamped);
+        if (g_cypher_depth_clamped > 0 && g_cypher_trail_truncated) {
+            snprintf(wbuf, sizeof(wbuf),
+                     "variable-length hop range clamped to the engine ceiling (%d) and "
+                     "traversal budget was exhausted — results may be partial",
+                     g_cypher_depth_clamped);
+        } else if (g_cypher_depth_clamped > 0) {
+            snprintf(wbuf, sizeof(wbuf),
+                     "variable-length hop range clamped to the engine ceiling (%d) — an empty "
+                     "result may mean \"clamped\", not \"no such path\"",
+                     g_cypher_depth_clamped);
+        } else {
+            snprintf(wbuf, sizeof(wbuf),
+                     "variable-length traversal budget was exhausted — results may be partial");
+        }
         out->warning = heap_strdup(wbuf);
     }
 

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -61,6 +61,8 @@ enum {
     ST_METHOD_PROP_LEN = 8,
     ST_PATH_PROP_LEN = 6,
     ST_HANDLER_PROP_LEN = 9,
+    ST_BFS_CTE_ROW_MULTIPLIER = 8,
+    ST_BFS_MAX_CTE_ROWS = 4096,
 };
 
 #define SLEN(s) (sizeof(s) - 1)
@@ -3793,6 +3795,18 @@ static void bfs_build_types_clause(int edge_type_count, char *buf, int buf_sz) {
     }
 }
 
+static int bfs_cte_row_limit(int max_results) {
+    int result_budget = max_results > 0 ? max_results : ST_INIT_CAP_16;
+    long row_budget = (long)result_budget * ST_BFS_CTE_ROW_MULTIPLIER + SKIP_ONE;
+    if (row_budget > ST_BFS_MAX_CTE_ROWS) {
+        return ST_BFS_MAX_CTE_ROWS;
+    }
+    if (row_budget < ST_INIT_CAP_16) {
+        return ST_INIT_CAP_16;
+    }
+    return (int)row_budget;
+}
+
 int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const char **edge_types,
                   int edge_type_count, int max_depth, int max_results, cbm_traverse_result_t *out) {
     memset(out, 0, sizeof(*out));
@@ -3821,6 +3835,8 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
         next_id = "e.target_id";
     }
 
+    int cte_row_limit = bfs_cte_row_limit(max_results);
+
     snprintf(sql, sizeof(sql),
              "WITH RECURSIVE bfs(node_id, hop, edge_path) AS ("
              "  SELECT %lld, 0, ''"
@@ -3832,6 +3848,7 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
              "  JOIN edges e ON %s"
              "  WHERE e.type IN (%s) AND bfs.hop < %d"
              "    AND instr(',' || bfs.edge_path || ',', ',' || e.id || ',') = 0"
+             "  LIMIT %d"
              ")"
              "SELECT n.id, n.project, n.label, n.name, n.qualified_name, "
              "n.file_path, n.start_line, n.end_line, n.properties, MIN(bfs.hop) AS hop "
@@ -3843,7 +3860,8 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
               * watermarks and reproducible trace output depend on it. */
              "ORDER BY hop, n.id "
              "LIMIT %d;",
-             (long long)start_id, next_id, join_cond, types_clause, max_depth, max_results);
+             (long long)start_id, next_id, join_cond, types_clause, max_depth, cte_row_limit,
+             max_results);
 
     sqlite3_stmt *stmt = NULL;
     rc = sqlite3_prepare_v2(s->db, sql, CBM_NOT_FOUND, &stmt, NULL);

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -3822,19 +3822,16 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
     }
 
     snprintf(sql, sizeof(sql),
-             /* SHORTEST-PATH semantics: the UNION dedupes (node, hop) PAIRS,
-              * so a single self-loop minted every hop level for every node it
-              * could reach — walk-padding that fabricated *k..k Cypher matches
-              * of arbitrary length and exploded the row set to nodes x depth
-              * (#797). MIN(hop) GROUP BY node returns each node once at its
-              * minimal distance. */
-             "WITH RECURSIVE bfs(node_id, hop) AS ("
-             "  SELECT %lld, 0"
+             "WITH RECURSIVE bfs(node_id, hop, edge_path) AS ("
+             "  SELECT %lld, 0, ''"
              "  UNION"
-             "  SELECT %s, bfs.hop + 1"
+             "  SELECT %s, bfs.hop + 1,"
+             "         CASE WHEN bfs.edge_path = '' THEN CAST(e.id AS TEXT)"
+             "              ELSE bfs.edge_path || ',' || e.id END"
              "  FROM bfs"
              "  JOIN edges e ON %s"
              "  WHERE e.type IN (%s) AND bfs.hop < %d"
+             "    AND instr(',' || bfs.edge_path || ',', ',' || e.id || ',') = 0"
              ")"
              "SELECT n.id, n.project, n.label, n.name, n.qualified_name, "
              "n.file_path, n.start_line, n.end_line, n.properties, MIN(bfs.hop) AS hop "

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -23,6 +23,7 @@ enum {
     ST_COL_7 = 7,
     ST_COL_8 = 8,
     ST_COL_9 = 9,
+    ST_COL_10 = 10,
     ST_FOUND = -1,
     ST_BUF_16 = 16,
     ST_BUF_64 = 64,
@@ -3807,8 +3808,9 @@ static int bfs_cte_row_limit(int max_results) {
     return (int)row_budget;
 }
 
-int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const char **edge_types,
-                  int edge_type_count, int max_depth, int max_results, cbm_traverse_result_t *out) {
+static int store_bfs(cbm_store_t *s, int64_t start_id, const char *direction,
+                     const char **edge_types, int edge_type_count, int max_depth, int max_results,
+                     bool trail, cbm_traverse_result_t *out) {
     memset(out, 0, sizeof(*out));
 
     cbm_node_t root = {0};
@@ -3835,33 +3837,53 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
         next_id = "e.target_id";
     }
 
-    int cte_row_limit = bfs_cte_row_limit(max_results);
-
-    snprintf(sql, sizeof(sql),
-             "WITH RECURSIVE bfs(node_id, hop, edge_path) AS ("
-             "  SELECT %lld, 0, ''"
-             "  UNION"
-             "  SELECT %s, bfs.hop + 1,"
-             "         CASE WHEN bfs.edge_path = '' THEN CAST(e.id AS TEXT)"
-             "              ELSE bfs.edge_path || ',' || e.id END"
-             "  FROM bfs"
-             "  JOIN edges e ON %s"
-             "  WHERE e.type IN (%s) AND bfs.hop < %d"
-             "    AND instr(',' || bfs.edge_path || ',', ',' || e.id || ',') = 0"
-             "  LIMIT %d"
-             ")"
-             "SELECT n.id, n.project, n.label, n.name, n.qualified_name, "
-             "n.file_path, n.start_line, n.end_line, n.properties, MIN(bfs.hop) AS hop "
-             "FROM bfs "
-             "JOIN nodes n ON n.id = bfs.node_id "
-             "WHERE bfs.hop > 0 " /* exclude root at hop 0 (self via a loop still appears) */
-             "GROUP BY n.id "
-             /* (hop, id) is a unique total order — deterministic pagination
-              * watermarks and reproducible trace output depend on it. */
-             "ORDER BY hop, n.id "
-             "LIMIT %d;",
-             (long long)start_id, next_id, join_cond, types_clause, max_depth, cte_row_limit,
-             max_results);
+    int cte_row_limit = 0;
+    if (trail) {
+        cte_row_limit = bfs_cte_row_limit(max_results);
+        snprintf(sql, sizeof(sql),
+                 "WITH RECURSIVE bfs(node_id, hop, edge_path) AS ("
+                 "  SELECT %lld, 0, ''"
+                 "  UNION"
+                 "  SELECT %s, bfs.hop + 1,"
+                 "         CASE WHEN bfs.edge_path = '' THEN CAST(e.id AS TEXT)"
+                 "              ELSE bfs.edge_path || ',' || e.id END"
+                 "  FROM bfs"
+                 "  JOIN edges e ON %s"
+                 "  WHERE e.type IN (%s) AND bfs.hop < %d"
+                 "    AND instr(',' || bfs.edge_path || ',', ',' || e.id || ',') = 0"
+                 "  LIMIT %d"
+                 ")"
+                 "SELECT DISTINCT n.id, n.project, n.label, n.name, n.qualified_name, "
+                 "n.file_path, n.start_line, n.end_line, n.properties, bfs.hop, "
+                 "(SELECT count(*) FROM bfs) "
+                 "FROM bfs JOIN nodes n ON n.id = bfs.node_id "
+                 "WHERE bfs.hop > 0 ORDER BY bfs.hop LIMIT %d;",
+                 (long long)start_id, next_id, join_cond, types_clause, max_depth,
+                 cte_row_limit + SKIP_ONE, max_results);
+    } else {
+        snprintf(sql, sizeof(sql),
+                 /* SHORTEST-PATH semantics: the UNION dedupes (node, hop) pairs.
+                  * MIN(hop) GROUP BY node returns each node once at its minimal
+                  * distance, while relationship-trail state remains scoped to
+                  * Cypher variable-length expansion. */
+                 "WITH RECURSIVE bfs(node_id, hop) AS ("
+                 "  SELECT %lld, 0"
+                 "  UNION"
+                 "  SELECT %s, bfs.hop + 1"
+                 "  FROM bfs"
+                 "  JOIN edges e ON %s"
+                 "  WHERE e.type IN (%s) AND bfs.hop < %d"
+                 ")"
+                 "SELECT n.id, n.project, n.label, n.name, n.qualified_name, "
+                 "n.file_path, n.start_line, n.end_line, n.properties, MIN(bfs.hop) AS hop "
+                 "FROM bfs "
+                 "JOIN nodes n ON n.id = bfs.node_id "
+                 "WHERE bfs.hop > 0 "
+                 "GROUP BY n.id "
+                 "ORDER BY hop, n.id "
+                 "LIMIT %d;",
+                 (long long)start_id, next_id, join_cond, types_clause, max_depth, max_results);
+    }
 
     sqlite3_stmt *stmt = NULL;
     rc = sqlite3_prepare_v2(s->db, sql, CBM_NOT_FOUND, &stmt, NULL);
@@ -3881,6 +3903,7 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
 
     int cap = ST_INIT_CAP_16;
     int n = 0;
+    int cte_rows = 0;
     cbm_node_hop_t *visited = malloc(cap * sizeof(cbm_node_hop_t));
 
     int scan_rc15;
@@ -3891,6 +3914,9 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
         }
         scan_node(stmt, &visited[n].node);
         visited[n].hop = sqlite3_column_int(stmt, ST_COL_9);
+        if (trail) {
+            cte_rows = sqlite3_column_int(stmt, ST_COL_10);
+        }
         n++;
     }
     if (scan_rc15 != SQLITE_DONE) { /* SCANCHK:15:stmt */
@@ -3902,6 +3928,12 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
     }
 
     sqlite3_finalize(stmt);
+
+    if (trail && cte_rows > cte_row_limit) {
+        char limit_buf[16];
+        snprintf(limit_buf, sizeof(limit_buf), "%d", cte_row_limit);
+        cbm_log_warn("cypher.trail_truncated", "cte_rows", limit_buf, "result", "partial");
+    }
 
     out->visited = visited;
     out->visited_count = n;
@@ -3916,6 +3948,19 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
     }
 
     return CBM_STORE_OK;
+}
+
+int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const char **edge_types,
+                  int edge_type_count, int max_depth, int max_results, cbm_traverse_result_t *out) {
+    return store_bfs(s, start_id, direction, edge_types, edge_type_count, max_depth, max_results,
+                     false, out);
+}
+
+int cbm_store_bfs_trail(cbm_store_t *s, int64_t start_id, const char *direction,
+                        const char **edge_types, int edge_type_count, int max_depth,
+                        int max_results, cbm_traverse_result_t *out) {
+    return store_bfs(s, start_id, direction, edge_types, edge_type_count, max_depth, max_results,
+                     true, out);
 }
 
 /* Multi-source BFS: one recursive CTE anchored on ALL seeds (via a temp

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -65,7 +65,7 @@ enum {
     ST_PATH_PROP_LEN = 6,
     ST_HANDLER_PROP_LEN = 9,
     ST_BFS_CTE_ROW_MULTIPLIER = 8,
-    ST_BFS_MAX_CTE_ROWS = 4096,
+    ST_BFS_MAX_CTE_ROWS = 65536,
 };
 
 #define SLEN(s) (sizeof(s) - 1)
@@ -4688,6 +4688,20 @@ static int bfs_cte_row_limit(int max_results) {
     return (int)row_budget;
 }
 
+static int bfs_cte_row_limit_for_depth(int max_results, int max_depth) {
+    int base = bfs_cte_row_limit(max_results);
+    /* Reserve rows across the requested depth range.  A result-sized cap can
+     * be exhausted by a wide first hop before any deeper match is generated;
+     * scaling by depth keeps the bounded traversal useful for *N..N queries
+     * while the hard ceiling still protects the SQLite worker. */
+    long depth = max_depth > 0 ? max_depth : ST_INIT_CAP_16;
+    long scaled = (long)base * depth;
+    if (scaled > ST_BFS_MAX_CTE_ROWS) {
+        return ST_BFS_MAX_CTE_ROWS;
+    }
+    return (int)scaled;
+}
+
 static int store_bfs(cbm_store_t *s, int64_t start_id, const char *direction,
                      const char **edge_types, int edge_type_count, int max_depth, int max_results,
                      bool trail, cbm_traverse_result_t *out) {
@@ -4719,7 +4733,7 @@ static int store_bfs(cbm_store_t *s, int64_t start_id, const char *direction,
 
     int cte_row_limit = 0;
     if (trail) {
-        cte_row_limit = bfs_cte_row_limit(max_results);
+        cte_row_limit = bfs_cte_row_limit_for_depth(max_results, max_depth);
         snprintf(sql, sizeof(sql),
                  "WITH RECURSIVE bfs(node_id, hop, edge_path) AS ("
                  "  SELECT %lld, 0, ''"
@@ -4731,13 +4745,19 @@ static int store_bfs(cbm_store_t *s, int64_t start_id, const char *direction,
                  "  JOIN edges e ON %s"
                  "  WHERE e.type IN (%s) AND bfs.hop < %d"
                  "    AND instr(',' || bfs.edge_path || ',', ',' || e.id || ',') = 0"
+                 /* SQLite's recursive queue is breadth-first by default.  A
+                  * bounded trail budget must reach the requested depth before
+                  * a wide shallow layer consumes every row, so prioritize the
+                  * recursive hop (depth-first) while retaining deterministic
+                  * ordering in the outer result query. */
+                 "  ORDER BY 2 DESC"
                  "  LIMIT %d"
                  ")"
                  "SELECT DISTINCT n.id, n.project, n.label, n.name, n.qualified_name, "
                  "n.file_path, n.start_line, n.end_line, n.properties, bfs.hop, "
                  "(SELECT count(*) FROM bfs) "
                  "FROM bfs JOIN nodes n ON n.id = bfs.node_id "
-                 "WHERE bfs.hop > 0 ORDER BY bfs.hop LIMIT %d;",
+                 "WHERE bfs.hop > 0 ORDER BY bfs.hop, n.id LIMIT %d;",
                  (long long)start_id, next_id, join_cond, types_clause, max_depth,
                  cte_row_limit + SKIP_ONE, max_results);
     } else {
@@ -4810,6 +4830,7 @@ static int store_bfs(cbm_store_t *s, int64_t start_id, const char *direction,
     sqlite3_finalize(stmt);
 
     if (trail && cte_rows > cte_row_limit) {
+        out->truncated = true;
         char limit_buf[16];
         snprintf(limit_buf, sizeof(limit_buf), "%d", cte_row_limit);
         cbm_log_warn("cypher.trail_truncated", "cte_rows", limit_buf, "result", "partial");

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -4750,7 +4750,7 @@ static int store_bfs(cbm_store_t *s, int64_t start_id, const char *direction,
                   * a wide shallow layer consumes every row, so prioritize the
                   * recursive hop (depth-first) while retaining deterministic
                   * ordering in the outer result query. */
-                 "  ORDER BY 2 DESC"
+                 "  ORDER BY 2 DESC, 1 ASC, 3 ASC"
                  "  LIMIT %d"
                  ")"
                  "SELECT DISTINCT n.id, n.project, n.label, n.name, n.qualified_name, "

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -25,6 +25,7 @@ enum {
     ST_COL_7 = 7,
     ST_COL_8 = 8,
     ST_COL_9 = 9,
+    ST_COL_10 = 10,
     ST_FOUND = -1,
     ST_BUF_16 = 16,
     ST_BUF_64 = 64,
@@ -4687,8 +4688,9 @@ static int bfs_cte_row_limit(int max_results) {
     return (int)row_budget;
 }
 
-int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const char **edge_types,
-                  int edge_type_count, int max_depth, int max_results, cbm_traverse_result_t *out) {
+static int store_bfs(cbm_store_t *s, int64_t start_id, const char *direction,
+                     const char **edge_types, int edge_type_count, int max_depth, int max_results,
+                     bool trail, cbm_traverse_result_t *out) {
     memset(out, 0, sizeof(*out));
 
     cbm_node_t root = {0};
@@ -4715,33 +4717,53 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
         next_id = "e.target_id";
     }
 
-    int cte_row_limit = bfs_cte_row_limit(max_results);
-
-    snprintf(sql, sizeof(sql),
-             "WITH RECURSIVE bfs(node_id, hop, edge_path) AS ("
-             "  SELECT %lld, 0, ''"
-             "  UNION"
-             "  SELECT %s, bfs.hop + 1,"
-             "         CASE WHEN bfs.edge_path = '' THEN CAST(e.id AS TEXT)"
-             "              ELSE bfs.edge_path || ',' || e.id END"
-             "  FROM bfs"
-             "  JOIN edges e ON %s"
-             "  WHERE e.type IN (%s) AND bfs.hop < %d"
-             "    AND instr(',' || bfs.edge_path || ',', ',' || e.id || ',') = 0"
-             "  LIMIT %d"
-             ")"
-             "SELECT n.id, n.project, n.label, n.name, n.qualified_name, "
-             "n.file_path, n.start_line, n.end_line, n.properties, MIN(bfs.hop) AS hop "
-             "FROM bfs "
-             "JOIN nodes n ON n.id = bfs.node_id "
-             "WHERE bfs.hop > 0 " /* exclude root at hop 0 (self via a loop still appears) */
-             "GROUP BY n.id "
-             /* (hop, id) is a unique total order — deterministic pagination
-              * watermarks and reproducible trace output depend on it. */
-             "ORDER BY hop, n.id "
-             "LIMIT %d;",
-             (long long)start_id, next_id, join_cond, types_clause, max_depth, cte_row_limit,
-             max_results);
+    int cte_row_limit = 0;
+    if (trail) {
+        cte_row_limit = bfs_cte_row_limit(max_results);
+        snprintf(sql, sizeof(sql),
+                 "WITH RECURSIVE bfs(node_id, hop, edge_path) AS ("
+                 "  SELECT %lld, 0, ''"
+                 "  UNION"
+                 "  SELECT %s, bfs.hop + 1,"
+                 "         CASE WHEN bfs.edge_path = '' THEN CAST(e.id AS TEXT)"
+                 "              ELSE bfs.edge_path || ',' || e.id END"
+                 "  FROM bfs"
+                 "  JOIN edges e ON %s"
+                 "  WHERE e.type IN (%s) AND bfs.hop < %d"
+                 "    AND instr(',' || bfs.edge_path || ',', ',' || e.id || ',') = 0"
+                 "  LIMIT %d"
+                 ")"
+                 "SELECT DISTINCT n.id, n.project, n.label, n.name, n.qualified_name, "
+                 "n.file_path, n.start_line, n.end_line, n.properties, bfs.hop, "
+                 "(SELECT count(*) FROM bfs) "
+                 "FROM bfs JOIN nodes n ON n.id = bfs.node_id "
+                 "WHERE bfs.hop > 0 ORDER BY bfs.hop LIMIT %d;",
+                 (long long)start_id, next_id, join_cond, types_clause, max_depth,
+                 cte_row_limit + SKIP_ONE, max_results);
+    } else {
+        snprintf(sql, sizeof(sql),
+                 /* SHORTEST-PATH semantics: the UNION dedupes (node, hop) pairs.
+                  * MIN(hop) GROUP BY node returns each node once at its minimal
+                  * distance, while relationship-trail state remains scoped to
+                  * Cypher variable-length expansion. */
+                 "WITH RECURSIVE bfs(node_id, hop) AS ("
+                 "  SELECT %lld, 0"
+                 "  UNION"
+                 "  SELECT %s, bfs.hop + 1"
+                 "  FROM bfs"
+                 "  JOIN edges e ON %s"
+                 "  WHERE e.type IN (%s) AND bfs.hop < %d"
+                 ")"
+                 "SELECT n.id, n.project, n.label, n.name, n.qualified_name, "
+                 "n.file_path, n.start_line, n.end_line, n.properties, MIN(bfs.hop) AS hop "
+                 "FROM bfs "
+                 "JOIN nodes n ON n.id = bfs.node_id "
+                 "WHERE bfs.hop > 0 "
+                 "GROUP BY n.id "
+                 "ORDER BY hop, n.id "
+                 "LIMIT %d;",
+                 (long long)start_id, next_id, join_cond, types_clause, max_depth, max_results);
+    }
 
     sqlite3_stmt *stmt = NULL;
     rc = sqlite3_prepare_v2(s->db, sql, CBM_NOT_FOUND, &stmt, NULL);
@@ -4761,6 +4783,7 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
 
     int cap = ST_INIT_CAP_16;
     int n = 0;
+    int cte_rows = 0;
     cbm_node_hop_t *visited = malloc(cap * sizeof(cbm_node_hop_t));
 
     int scan_rc15;
@@ -4771,6 +4794,9 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
         }
         scan_node(stmt, &visited[n].node);
         visited[n].hop = sqlite3_column_int(stmt, ST_COL_9);
+        if (trail) {
+            cte_rows = sqlite3_column_int(stmt, ST_COL_10);
+        }
         n++;
     }
     if (scan_rc15 != SQLITE_DONE) { /* SCANCHK:15:stmt */
@@ -4782,6 +4808,12 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
     }
 
     sqlite3_finalize(stmt);
+
+    if (trail && cte_rows > cte_row_limit) {
+        char limit_buf[16];
+        snprintf(limit_buf, sizeof(limit_buf), "%d", cte_row_limit);
+        cbm_log_warn("cypher.trail_truncated", "cte_rows", limit_buf, "result", "partial");
+    }
 
     out->visited = visited;
     out->visited_count = n;
@@ -4796,6 +4828,19 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
     }
 
     return CBM_STORE_OK;
+}
+
+int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const char **edge_types,
+                  int edge_type_count, int max_depth, int max_results, cbm_traverse_result_t *out) {
+    return store_bfs(s, start_id, direction, edge_types, edge_type_count, max_depth, max_results,
+                     false, out);
+}
+
+int cbm_store_bfs_trail(cbm_store_t *s, int64_t start_id, const char *direction,
+                        const char **edge_types, int edge_type_count, int max_depth,
+                        int max_results, cbm_traverse_result_t *out) {
+    return store_bfs(s, start_id, direction, edge_types, edge_type_count, max_depth, max_results,
+                     true, out);
 }
 
 /* Multi-source BFS: one recursive CTE anchored on ALL seeds (via a temp

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -4702,19 +4702,16 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
     }
 
     snprintf(sql, sizeof(sql),
-             /* SHORTEST-PATH semantics: the UNION dedupes (node, hop) PAIRS,
-              * so a single self-loop minted every hop level for every node it
-              * could reach — walk-padding that fabricated *k..k Cypher matches
-              * of arbitrary length and exploded the row set to nodes x depth
-              * (#797). MIN(hop) GROUP BY node returns each node once at its
-              * minimal distance. */
-             "WITH RECURSIVE bfs(node_id, hop) AS ("
-             "  SELECT %lld, 0"
+             "WITH RECURSIVE bfs(node_id, hop, edge_path) AS ("
+             "  SELECT %lld, 0, ''"
              "  UNION"
-             "  SELECT %s, bfs.hop + 1"
+             "  SELECT %s, bfs.hop + 1,"
+             "         CASE WHEN bfs.edge_path = '' THEN CAST(e.id AS TEXT)"
+             "              ELSE bfs.edge_path || ',' || e.id END"
              "  FROM bfs"
              "  JOIN edges e ON %s"
              "  WHERE e.type IN (%s) AND bfs.hop < %d"
+             "    AND instr(',' || bfs.edge_path || ',', ',' || e.id || ',') = 0"
              ")"
              "SELECT n.id, n.project, n.label, n.name, n.qualified_name, "
              "n.file_path, n.start_line, n.end_line, n.properties, MIN(bfs.hop) AS hop "

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -63,6 +63,8 @@ enum {
     ST_METHOD_PROP_LEN = 8,
     ST_PATH_PROP_LEN = 6,
     ST_HANDLER_PROP_LEN = 9,
+    ST_BFS_CTE_ROW_MULTIPLIER = 8,
+    ST_BFS_MAX_CTE_ROWS = 4096,
 };
 
 #define SLEN(s) (sizeof(s) - 1)
@@ -4673,6 +4675,18 @@ static void bfs_build_types_clause(int edge_type_count, char *buf, int buf_sz) {
     }
 }
 
+static int bfs_cte_row_limit(int max_results) {
+    int result_budget = max_results > 0 ? max_results : ST_INIT_CAP_16;
+    long row_budget = (long)result_budget * ST_BFS_CTE_ROW_MULTIPLIER + SKIP_ONE;
+    if (row_budget > ST_BFS_MAX_CTE_ROWS) {
+        return ST_BFS_MAX_CTE_ROWS;
+    }
+    if (row_budget < ST_INIT_CAP_16) {
+        return ST_INIT_CAP_16;
+    }
+    return (int)row_budget;
+}
+
 int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const char **edge_types,
                   int edge_type_count, int max_depth, int max_results, cbm_traverse_result_t *out) {
     memset(out, 0, sizeof(*out));
@@ -4701,6 +4715,8 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
         next_id = "e.target_id";
     }
 
+    int cte_row_limit = bfs_cte_row_limit(max_results);
+
     snprintf(sql, sizeof(sql),
              "WITH RECURSIVE bfs(node_id, hop, edge_path) AS ("
              "  SELECT %lld, 0, ''"
@@ -4712,6 +4728,7 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
              "  JOIN edges e ON %s"
              "  WHERE e.type IN (%s) AND bfs.hop < %d"
              "    AND instr(',' || bfs.edge_path || ',', ',' || e.id || ',') = 0"
+             "  LIMIT %d"
              ")"
              "SELECT n.id, n.project, n.label, n.name, n.qualified_name, "
              "n.file_path, n.start_line, n.end_line, n.properties, MIN(bfs.hop) AS hop "
@@ -4723,7 +4740,8 @@ int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const
               * watermarks and reproducible trace output depend on it. */
              "ORDER BY hop, n.id "
              "LIMIT %d;",
-             (long long)start_id, next_id, join_cond, types_clause, max_depth, max_results);
+             (long long)start_id, next_id, join_cond, types_clause, max_depth, cte_row_limit,
+             max_results);
 
     sqlite3_stmt *stmt = NULL;
     rc = sqlite3_prepare_v2(s->db, sql, CBM_NOT_FOUND, &stmt, NULL);

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -65,7 +65,7 @@ enum {
     ST_PATH_PROP_LEN = 6,
     ST_HANDLER_PROP_LEN = 9,
     ST_BFS_CTE_ROW_MULTIPLIER = 8,
-    ST_BFS_MAX_CTE_ROWS = 65536,
+    ST_BFS_MAX_CTE_ROWS = 4096,
 };
 
 #define SLEN(s) (sizeof(s) - 1)

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -507,6 +507,11 @@ void cbm_store_search_free(cbm_search_output_t *out);
 int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const char **edge_types,
                   int edge_type_count, int max_depth, int max_results, cbm_traverse_result_t *out);
 
+/* Variable-length Cypher traversal with relationship-trail semantics. */
+int cbm_store_bfs_trail(cbm_store_t *s, int64_t start_id, const char *direction,
+                        const char **edge_types, int edge_type_count, int max_depth,
+                        int max_results, cbm_traverse_result_t *out);
+
 /* Multi-source BFS from ALL seed ids at once (one CTE, temp-table anchored).
  * Seeds are EXCLUDED from the result (impact semantics); MIN(hop) across the
  * seed set; canonical (hop,id) order; *truncated set when the max_results

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -603,6 +603,11 @@ void cbm_store_search_free(cbm_search_output_t *out);
 int cbm_store_bfs(cbm_store_t *s, int64_t start_id, const char *direction, const char **edge_types,
                   int edge_type_count, int max_depth, int max_results, cbm_traverse_result_t *out);
 
+/* Variable-length Cypher traversal with relationship-trail semantics. */
+int cbm_store_bfs_trail(cbm_store_t *s, int64_t start_id, const char *direction,
+                        const char **edge_types, int edge_type_count, int max_depth,
+                        int max_results, cbm_traverse_result_t *out);
+
 /* Multi-source BFS from ALL seed ids at once (one CTE, temp-table anchored).
  * Seeds are EXCLUDED from the result (impact semantics); MIN(hop) across the
  * seed set; canonical (hop,id) order; *truncated set when the max_results

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -211,6 +211,8 @@ typedef struct {
     int visited_count;
     cbm_edge_info_t *edges;
     int edge_count;
+    /* True when trail expansion hit its recursive-row safety budget. */
+    bool truncated;
 } cbm_traverse_result_t;
 
 /* ── Schema introspection ───────────────────────────────────────── */

--- a/tests/test_cypher.c
+++ b/tests/test_cypher.c
@@ -559,15 +559,24 @@ TEST(cypher_exec_varlength_path_semantics_issue797) {
     ASSERT_EQ(r1.row_count, 1);
     cbm_cypher_result_free(&r1);
 
-    /* Bug 2: *2..2 from loopy — only the REAL 2-chain (leaf); the self-loop
-     * must not be reused to pad paths (relationship uniqueness). */
+    /* Bug 2: *2..2 from loopy has two relationship-unique trails: the
+     * self-loop followed by e1 reaches mid, and e1 followed by e2 reaches leaf.
+     * Reusing the self-loop within one trail remains forbidden. */
     cbm_cypher_result_t r2 = {0};
     ASSERT_EQ(cbm_cypher_execute(s,
                                  "MATCH (a {name: \"loopy\"})-[:CALLS*2..2]->(b) "
                                  "RETURN DISTINCT b.name",
                                  "test", 0, &r2),
               0);
-    ASSERT_EQ(r2.row_count, 1); /* leaf only */
+    ASSERT_EQ(r2.row_count, 2);
+    bool saw_mid = false;
+    bool saw_leaf = false;
+    for (int i = 0; i < r2.row_count; i++) {
+        saw_mid |= strcmp(r2.rows[i][0], "mid") == 0;
+        saw_leaf |= strcmp(r2.rows[i][0], "leaf") == 0;
+    }
+    ASSERT_TRUE(saw_mid);
+    ASSERT_TRUE(saw_leaf);
     cbm_cypher_result_free(&r2);
 
     /* Bug 2 amplifier: no directed path of length 5 exists at all. */

--- a/tests/test_cypher.c
+++ b/tests/test_cypher.c
@@ -1170,6 +1170,48 @@ TEST(cypher_exec_var_length_explicit_bound_capped) {
     PASS();
 }
 
+TEST(cypher_exec_variable_length_repeated_node_var_unifies) {
+    cbm_store_t *s = setup_cypher_store();
+    cbm_cypher_result_t r = {0};
+
+    int rc = cbm_cypher_execute(s,
+                                "MATCH (f:Function)-[:CALLS*1..2]->(f:Function) "
+                                "RETURN f.name",
+                                "test", 0, &r);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(r.row_count, 0);
+
+    cbm_cypher_result_free(&r);
+    cbm_store_close(s);
+    PASS();
+}
+
+TEST(cypher_exec_var_length_no_reuse_self_loop) {
+    cbm_store_t *s = cbm_store_open_memory();
+    cbm_store_upsert_project(s, "test", "/tmp/test");
+
+    cbm_node_t n = {.project = "test",
+                    .label = "Function",
+                    .name = "Recursive",
+                    .qualified_name = "test.Recursive",
+                    .file_path = "recursive.go"};
+    int64_t id = cbm_store_upsert_node(s, &n);
+    cbm_edge_t e = {.project = "test", .source_id = id, .target_id = id, .type = "CALLS"};
+    cbm_store_insert_edge(s, &e);
+
+    cbm_cypher_result_t r = {0};
+    int rc = cbm_cypher_execute(s,
+                                "MATCH (f:Function {name: \"Recursive\"})-[:CALLS*2..2]"
+                                "->(g:Function) RETURN g.name",
+                                "test", 0, &r);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(r.row_count, 0);
+
+    cbm_cypher_result_free(&r);
+    cbm_store_close(s);
+    PASS();
+}
+
 TEST(cypher_exec_defines_edge) {
     cbm_store_t *s = setup_cypher_store();
     cbm_cypher_result_t r = {0};
@@ -3118,6 +3160,8 @@ SUITE(cypher) {
     RUN_TEST(cypher_exec_order_by);
     RUN_TEST(cypher_exec_variable_length);
     RUN_TEST(cypher_exec_var_length_explicit_bound_capped);
+    RUN_TEST(cypher_exec_variable_length_repeated_node_var_unifies);
+    RUN_TEST(cypher_exec_var_length_no_reuse_self_loop);
     RUN_TEST(cypher_exec_defines_edge);
     RUN_TEST(cypher_exec_no_results);
     RUN_TEST(cypher_exec_where_numeric);

--- a/tests/test_cypher.c
+++ b/tests/test_cypher.c
@@ -1171,15 +1171,24 @@ TEST(cypher_exec_varlength_path_semantics_issue797) {
     ASSERT_EQ(r1.row_count, 1);
     cbm_cypher_result_free(&r1);
 
-    /* Bug 2: *2..2 from loopy — only the REAL 2-chain (leaf); the self-loop
-     * must not be reused to pad paths (relationship uniqueness). */
+    /* Bug 2: *2..2 from loopy has two relationship-unique trails: the
+     * self-loop followed by e1 reaches mid, and e1 followed by e2 reaches leaf.
+     * Reusing the self-loop within one trail remains forbidden. */
     cbm_cypher_result_t r2 = {0};
     ASSERT_EQ(cbm_cypher_execute(s,
                                  "MATCH (a {name: \"loopy\"})-[:CALLS*2..2]->(b) "
                                  "RETURN DISTINCT b.name",
                                  "test", 0, &r2),
               0);
-    ASSERT_EQ(r2.row_count, 1); /* leaf only */
+    ASSERT_EQ(r2.row_count, 2);
+    bool saw_mid = false;
+    bool saw_leaf = false;
+    for (int i = 0; i < r2.row_count; i++) {
+        saw_mid |= strcmp(r2.rows[i][0], "mid") == 0;
+        saw_leaf |= strcmp(r2.rows[i][0], "leaf") == 0;
+    }
+    ASSERT_TRUE(saw_mid);
+    ASSERT_TRUE(saw_leaf);
     cbm_cypher_result_free(&r2);
 
     /* Bug 2 amplifier: no directed path of length 5 exists at all. */

--- a/tests/test_cypher.c
+++ b/tests/test_cypher.c
@@ -1798,6 +1798,48 @@ TEST(cypher_exec_var_length_explicit_bound_capped) {
     PASS();
 }
 
+TEST(cypher_exec_variable_length_repeated_node_var_unifies) {
+    cbm_store_t *s = setup_cypher_store();
+    cbm_cypher_result_t r = {0};
+
+    int rc = cbm_cypher_execute(s,
+                                "MATCH (f:Function)-[:CALLS*1..2]->(f:Function) "
+                                "RETURN f.name",
+                                "test", 0, &r);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(r.row_count, 0);
+
+    cbm_cypher_result_free(&r);
+    cbm_store_close(s);
+    PASS();
+}
+
+TEST(cypher_exec_var_length_no_reuse_self_loop) {
+    cbm_store_t *s = cbm_store_open_memory();
+    cbm_store_upsert_project(s, "test", "/tmp/test");
+
+    cbm_node_t n = {.project = "test",
+                    .label = "Function",
+                    .name = "Recursive",
+                    .qualified_name = "test.Recursive",
+                    .file_path = "recursive.go"};
+    int64_t id = cbm_store_upsert_node(s, &n);
+    cbm_edge_t e = {.project = "test", .source_id = id, .target_id = id, .type = "CALLS"};
+    cbm_store_insert_edge(s, &e);
+
+    cbm_cypher_result_t r = {0};
+    int rc = cbm_cypher_execute(s,
+                                "MATCH (f:Function {name: \"Recursive\"})-[:CALLS*2..2]"
+                                "->(g:Function) RETURN g.name",
+                                "test", 0, &r);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(r.row_count, 0);
+
+    cbm_cypher_result_free(&r);
+    cbm_store_close(s);
+    PASS();
+}
+
 TEST(cypher_exec_defines_edge) {
     cbm_store_t *s = setup_cypher_store();
     cbm_cypher_result_t r = {0};
@@ -4037,6 +4079,8 @@ SUITE(cypher) {
     RUN_TEST(cypher_exec_variable_length);
     RUN_TEST(cypher_exec_variable_length_repeated_node_var_unifies);
     RUN_TEST(cypher_exec_var_length_explicit_bound_capped);
+    RUN_TEST(cypher_exec_variable_length_repeated_node_var_unifies);
+    RUN_TEST(cypher_exec_var_length_no_reuse_self_loop);
     RUN_TEST(cypher_exec_defines_edge);
     RUN_TEST(cypher_exec_no_results);
     RUN_TEST(cypher_exec_where_numeric);

--- a/tests/test_cypher.c
+++ b/tests/test_cypher.c
@@ -1807,6 +1807,8 @@ TEST(cypher_exec_var_length_explicit_bound_capped) {
     PASS();
 }
 
+/* Pin the relationship-trail contract: a self-loop edge cannot be reused
+ * within one variable-length trail, so *2..2 yields no fabricated match. */
 TEST(cypher_exec_var_length_no_reuse_self_loop) {
     cbm_store_t *s = cbm_store_open_memory();
     cbm_store_upsert_project(s, "test", "/tmp/test");

--- a/tests/test_cypher.c
+++ b/tests/test_cypher.c
@@ -1849,6 +1849,46 @@ TEST(cypher_exec_var_length_no_reuse_self_loop) {
     PASS();
 }
 
+TEST(cypher_exec_var_length_truncation_surfaces_warning) {
+    cbm_store_t *s = cbm_store_open_memory();
+    cbm_store_upsert_project(s, "test", "/tmp/test");
+
+    int64_t ids[18];
+    for (int i = 0; i < 18; i++) {
+        char name[16];
+        snprintf(name, sizeof(name), "node-%d", i);
+        cbm_node_t node = {.project = "test",
+                           .label = "Function",
+                           .name = name,
+                           .qualified_name = name,
+                           .file_path = "graph.c"};
+        ids[i] = cbm_store_upsert_node(s, &node);
+    }
+    for (int source = 0; source < 17; source++) {
+        for (int target = source + 1; target < 18; target++) {
+            cbm_edge_t edge = {.project = "test",
+                               .source_id = ids[source],
+                               .target_id = ids[target],
+                               .type = "CALLS"};
+            cbm_store_insert_edge(s, &edge);
+        }
+    }
+
+    cbm_cypher_result_t result = {0};
+    int rc = cbm_cypher_execute(s,
+                                "MATCH (a:Function {name: \"node-0\"})-[:CALLS*10..10]->"
+                                "(b:Function) RETURN b.name",
+                                "test", 0, &result);
+    ASSERT_EQ(rc, 0);
+    ASSERT_NOT_NULL(result.warning);
+    ASSERT_TRUE(strstr(result.warning, "traversal budget") != NULL);
+    ASSERT_TRUE(result.row_count > 0);
+
+    cbm_cypher_result_free(&result);
+    cbm_store_close(s);
+    PASS();
+}
+
 TEST(cypher_exec_defines_edge) {
     cbm_store_t *s = setup_cypher_store();
     cbm_cypher_result_t r = {0};
@@ -4090,6 +4130,7 @@ SUITE(cypher) {
     RUN_TEST(cypher_exec_var_length_explicit_bound_capped);
     RUN_TEST(cypher_exec_variable_length_repeated_node_var_unifies);
     RUN_TEST(cypher_exec_var_length_no_reuse_self_loop);
+    RUN_TEST(cypher_exec_var_length_truncation_surfaces_warning);
     RUN_TEST(cypher_exec_defines_edge);
     RUN_TEST(cypher_exec_no_results);
     RUN_TEST(cypher_exec_where_numeric);

--- a/tests/test_cypher.c
+++ b/tests/test_cypher.c
@@ -1807,22 +1807,6 @@ TEST(cypher_exec_var_length_explicit_bound_capped) {
     PASS();
 }
 
-TEST(cypher_exec_variable_length_repeated_node_var_unifies) {
-    cbm_store_t *s = setup_cypher_store();
-    cbm_cypher_result_t r = {0};
-
-    int rc = cbm_cypher_execute(s,
-                                "MATCH (f:Function)-[:CALLS*1..2]->(f:Function) "
-                                "RETURN f.name",
-                                "test", 0, &r);
-    ASSERT_EQ(rc, 0);
-    ASSERT_EQ(r.row_count, 0);
-
-    cbm_cypher_result_free(&r);
-    cbm_store_close(s);
-    PASS();
-}
-
 TEST(cypher_exec_var_length_no_reuse_self_loop) {
     cbm_store_t *s = cbm_store_open_memory();
     cbm_store_upsert_project(s, "test", "/tmp/test");
@@ -4128,7 +4112,6 @@ SUITE(cypher) {
     RUN_TEST(cypher_exec_variable_length);
     RUN_TEST(cypher_exec_variable_length_repeated_node_var_unifies);
     RUN_TEST(cypher_exec_var_length_explicit_bound_capped);
-    RUN_TEST(cypher_exec_variable_length_repeated_node_var_unifies);
     RUN_TEST(cypher_exec_var_length_no_reuse_self_loop);
     RUN_TEST(cypher_exec_var_length_truncation_surfaces_warning);
     RUN_TEST(cypher_exec_defines_edge);

--- a/tests/test_store_search.c
+++ b/tests/test_store_search.c
@@ -4,6 +4,7 @@
  * Ported from internal/store/store_test.go (TestSearch, TestBFS, etc.)
  */
 #include "../src/foundation/compat.h"
+#include "../src/foundation/log.h"
 #include "test_framework.h"
 #include "test_helpers.h"
 #include <store/store.h>
@@ -12,6 +13,15 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+
+static char trail_log[1024];
+
+static void capture_trail_log(const char *line) {
+    size_t used = strlen(trail_log);
+    if (used < sizeof(trail_log) - 1) {
+        snprintf(trail_log + used, sizeof(trail_log) - used, "%s\n", line);
+    }
+}
 
 /* Helper: create a typical graph for search/traversal tests.
  *
@@ -993,7 +1003,7 @@ TEST(store_bfs_with_risk_labels) {
     PASS();
 }
 
-TEST(store_bfs_caps_recursive_cte_rows) {
+TEST(store_bfs_reachability_is_not_trail_capped) {
     cbm_store_t *s = cbm_store_open_memory();
     cbm_store_upsert_project(s, "test", "/tmp/test");
 
@@ -1019,8 +1029,48 @@ TEST(store_bfs_caps_recursive_cte_rows) {
     cbm_traverse_result_t result = {0};
     int rc = cbm_store_bfs(s, root_id, "outbound", types, 1, 1, 5000, &result);
     ASSERT_EQ(rc, CBM_STORE_OK);
-    ASSERT_TRUE(result.visited_count > 0);
-    ASSERT_TRUE(result.visited_count < NODE_COUNT);
+    ASSERT_EQ(result.visited_count, NODE_COUNT);
+
+    cbm_store_traverse_free(&result);
+    cbm_store_close(s);
+    PASS();
+}
+
+TEST(store_bfs_trail_warns_when_path_rows_are_truncated) {
+    cbm_store_t *s = cbm_store_open_memory();
+    cbm_store_upsert_project(s, "test", "/tmp/test");
+
+    int64_t ids[14];
+    for (int i = 0; i < 14; i++) {
+        char name[16];
+        snprintf(name, sizeof(name), "node-%d", i);
+        cbm_node_t node = {.project = "test",
+                           .label = "Function",
+                           .name = name,
+                           .qualified_name = name,
+                           .file_path = "graph.c"};
+        ids[i] = cbm_store_upsert_node(s, &node);
+    }
+    for (int source = 0; source < 13; source++) {
+        for (int target = source + 1; target < 14; target++) {
+            cbm_edge_t edge = {.project = "test",
+                               .source_id = ids[source],
+                               .target_id = ids[target],
+                               .type = "CALLS"};
+            cbm_store_insert_edge(s, &edge);
+        }
+    }
+
+    trail_log[0] = '\0';
+    cbm_log_set_sink(capture_trail_log);
+    const char *types[] = {"CALLS"};
+    cbm_traverse_result_t result = {0};
+    int rc = cbm_store_bfs_trail(s, ids[0], "outbound", types, 1, 10, 5000, &result);
+    cbm_log_set_sink(NULL);
+
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_TRUE(strstr(trail_log, "cypher.trail_truncated") != NULL);
+    ASSERT_TRUE(strstr(trail_log, "result=partial") != NULL);
 
     cbm_store_traverse_free(&result);
     cbm_store_close(s);
@@ -1544,7 +1594,8 @@ SUITE(store_search) {
     RUN_TEST(store_cross_service_detection);
     RUN_TEST(store_deduplicate_hops);
     RUN_TEST(store_bfs_with_risk_labels);
-    RUN_TEST(store_bfs_caps_recursive_cte_rows);
+    RUN_TEST(store_bfs_reachability_is_not_trail_capped);
+    RUN_TEST(store_bfs_trail_warns_when_path_rows_are_truncated);
     RUN_TEST(store_bfs_cross_service_summary);
     RUN_TEST(store_glob_to_like);
     RUN_TEST(store_extract_like_hints);

--- a/tests/test_store_search.c
+++ b/tests/test_store_search.c
@@ -8,6 +8,7 @@
 #include "test_helpers.h"
 #include <store/store.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -992,6 +993,40 @@ TEST(store_bfs_with_risk_labels) {
     PASS();
 }
 
+TEST(store_bfs_caps_recursive_cte_rows) {
+    cbm_store_t *s = cbm_store_open_memory();
+    cbm_store_upsert_project(s, "test", "/tmp/test");
+
+    cbm_node_t root = {.project = "test",
+                       .label = "Function",
+                       .name = "Root",
+                       .qualified_name = "test.Root"};
+    int64_t root_id = cbm_store_upsert_node(s, &root);
+
+    enum { NODE_COUNT = 4200 };
+    for (int i = 0; i < NODE_COUNT; i++) {
+        char name[32];
+        snprintf(name, sizeof(name), "Leaf%d", i);
+        cbm_node_t leaf = {
+            .project = "test", .label = "Function", .name = name, .qualified_name = name};
+        int64_t leaf_id = cbm_store_upsert_node(s, &leaf);
+        cbm_edge_t edge = {
+            .project = "test", .source_id = root_id, .target_id = leaf_id, .type = "CALLS"};
+        cbm_store_insert_edge(s, &edge);
+    }
+
+    const char *types[] = {"CALLS"};
+    cbm_traverse_result_t result = {0};
+    int rc = cbm_store_bfs(s, root_id, "outbound", types, 1, 1, 5000, &result);
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_TRUE(result.visited_count > 0);
+    ASSERT_TRUE(result.visited_count < NODE_COUNT);
+
+    cbm_store_traverse_free(&result);
+    cbm_store_close(s);
+    PASS();
+}
+
 /* ── BFS cross-service summary ─────────────────────────────────── */
 
 TEST(store_bfs_cross_service_summary) {
@@ -1509,6 +1544,7 @@ SUITE(store_search) {
     RUN_TEST(store_cross_service_detection);
     RUN_TEST(store_deduplicate_hops);
     RUN_TEST(store_bfs_with_risk_labels);
+    RUN_TEST(store_bfs_caps_recursive_cte_rows);
     RUN_TEST(store_bfs_cross_service_summary);
     RUN_TEST(store_glob_to_like);
     RUN_TEST(store_extract_like_hints);

--- a/tests/test_store_search.c
+++ b/tests/test_store_search.c
@@ -1078,6 +1078,69 @@ TEST(store_bfs_trail_warns_when_path_rows_are_truncated) {
     PASS();
 }
 
+TEST(store_bfs_trail_preserves_deeper_match_under_hub_budget) {
+    cbm_store_t *s = cbm_store_open_memory();
+    cbm_store_upsert_project(s, "test", "/tmp/test");
+
+    cbm_node_t root = {.project = "test",
+                       .label = "Function",
+                       .name = "root",
+                       .qualified_name = "test.root"};
+    cbm_node_t branch = {.project = "test",
+                         .label = "Function",
+                         .name = "branch",
+                         .qualified_name = "test.branch"};
+    cbm_node_t target = {.project = "test",
+                         .label = "Function",
+                         .name = "target",
+                         .qualified_name = "test.target"};
+    int64_t root_id = cbm_store_upsert_node(s, &root);
+    int64_t branch_id = cbm_store_upsert_node(s, &branch);
+    int64_t target_id = cbm_store_upsert_node(s, &target);
+
+    cbm_edge_t edge = {
+        .project = "test", .source_id = root_id, .target_id = branch_id, .type = "CALLS"};
+    cbm_store_insert_edge(s, &edge);
+    edge.source_id = branch_id;
+    edge.target_id = target_id;
+    cbm_store_insert_edge(s, &edge);
+
+    /* A high-fanout hub must not consume the bounded CTE before a deeper path
+     * is considered; the depth-first queue should still surface `target`. */
+    enum { LEAF_COUNT = 4100 };
+    for (int i = 0; i < LEAF_COUNT; i++) {
+        char name[32];
+        snprintf(name, sizeof(name), "leaf-%d", i);
+        cbm_node_t leaf = {.project = "test",
+                           .label = "Function",
+                           .name = name,
+                           .qualified_name = name};
+        int64_t leaf_id = cbm_store_upsert_node(s, &leaf);
+        edge.source_id = root_id;
+        edge.target_id = leaf_id;
+        cbm_store_insert_edge(s, &edge);
+    }
+
+    const char *types[] = {"CALLS"};
+    cbm_traverse_result_t result = {0};
+    int rc = cbm_store_bfs_trail(s, root_id, "outbound", types, 1, 2, 5000, &result);
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_TRUE(result.truncated);
+
+    bool saw_target = false;
+    for (int i = 0; i < result.visited_count; i++) {
+        if (result.visited[i].node.id == target_id) {
+            saw_target = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(saw_target);
+
+    cbm_store_traverse_free(&result);
+    cbm_store_close(s);
+    PASS();
+}
+
 /* ── BFS cross-service summary ─────────────────────────────────── */
 
 TEST(store_bfs_cross_service_summary) {
@@ -1597,6 +1660,7 @@ SUITE(store_search) {
     RUN_TEST(store_bfs_with_risk_labels);
     RUN_TEST(store_bfs_reachability_is_not_trail_capped);
     RUN_TEST(store_bfs_trail_warns_when_path_rows_are_truncated);
+    RUN_TEST(store_bfs_trail_preserves_deeper_match_under_hub_budget);
     RUN_TEST(store_bfs_cross_service_summary);
     RUN_TEST(store_glob_to_like);
     RUN_TEST(store_extract_like_hints);

--- a/tests/test_store_search.c
+++ b/tests/test_store_search.c
@@ -1040,8 +1040,8 @@ TEST(store_bfs_trail_warns_when_path_rows_are_truncated) {
     cbm_store_t *s = cbm_store_open_memory();
     cbm_store_upsert_project(s, "test", "/tmp/test");
 
-    int64_t ids[14];
-    for (int i = 0; i < 14; i++) {
+    int64_t ids[18];
+    for (int i = 0; i < 18; i++) {
         char name[16];
         snprintf(name, sizeof(name), "node-%d", i);
         cbm_node_t node = {.project = "test",
@@ -1051,8 +1051,8 @@ TEST(store_bfs_trail_warns_when_path_rows_are_truncated) {
                            .file_path = "graph.c"};
         ids[i] = cbm_store_upsert_node(s, &node);
     }
-    for (int source = 0; source < 13; source++) {
-        for (int target = source + 1; target < 14; target++) {
+    for (int source = 0; source < 17; source++) {
+        for (int target = source + 1; target < 18; target++) {
             cbm_edge_t edge = {.project = "test",
                                .source_id = ids[source],
                                .target_id = ids[target],
@@ -1069,6 +1069,7 @@ TEST(store_bfs_trail_warns_when_path_rows_are_truncated) {
     cbm_log_set_sink(NULL);
 
     ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_TRUE(result.truncated);
     ASSERT_TRUE(strstr(trail_log, "cypher.trail_truncated") != NULL);
     ASSERT_TRUE(strstr(trail_log, "result=partial") != NULL);
 


### PR DESCRIPTION
## What does this PR do?

Part of #797.

This fixes two variable-length Cypher path semantics and bounds the traversal expansion introduced by the trail check:

- repeated node variables now unify with an existing binding, so `MATCH (f)-[:CALLS*1..2]->(f)` only matches paths that return to the same node;
- variable-length traversal now rejects paths that reuse the same edge id, so a single self-loop cannot fabricate longer paths;
- `cbm_store_bfs_trail` caps rows admitted to its recursive CTE, so tracking edge ids cannot enumerate an unbounded number of simple paths before the outer `LIMIT` while shared BFS keeps its reachability behavior.

## Summary

Variable-length Cypher paths now follow the same binding and simple-path semantics as the fixed-length executor cases covered by the existing tests, while shared BFS keeps its node-reachability behavior and Cypher trail expansion has a hard recursive-row bound.

## Changes

- Enforce existing target-node bindings when expanding variable-length relationships.
- Track edge ids in recursive traversal and reject reusing the same edge within one path.
- Cap recursive CTE rows only inside `cbm_store_bfs_trail`.
- Add regressions for repeated node variables, self-loop edge reuse, uncapped shared BFS reachability, and the trail recursive row cap.

## Verification

```sh
make -f Makefile.cbm test
make -f Makefile.cbm lint-ci
```

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test`)
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)
