### PR TITLE
ci(pr): light smoke on PRs (build prod + smoke, 3 native platforms, path-gated)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # A new push to the PR supersedes the running validation — cancel it
 # instead of stacking zombie pipelines.
@@ -35,10 +36,91 @@ jobs:
       # dry runs and releases where a flaky red does not block a merge.
       skip_perf: true
 
+  # ── Which files changed? Gate the (heavier) build+smoke on product code so
+  #    docs / CI / test-only PRs stay fast. ──
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      product: ${{ steps.f.outputs.product }}
+    steps:
+      - name: Detect product-code changes
+        id: f
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          FILES=$(gh pr diff "$PR" --repo "$REPO" --name-only)
+          printf '%s\n' "$FILES"
+          if printf '%s\n' "$FILES" | grep -qE '^(src/|internal/|scripts/build\.sh|scripts/smoke-test\.sh|scripts/env\.sh|Makefile\.cbm)'; then
+            echo "product=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "product=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ── Light smoke: build the PRODUCTION binary and run the core smoke on the
+  #    three RELIABLE NATIVE platforms. Catches built-binary regressions at PR
+  #    time (e.g. the Windows CreateProcess argv-quoting class that previously
+  #    only surfaced in the release dry run). The full broad/emulated smoke stays
+  #    in the dry run. Only product-code PRs pay this; every leg gates.
+  #    SMOKE_DOWNLOAD_URL is intentionally unset — the download/update phases of
+  #    smoke-test.sh self-skip; the core index/search/trace phases still run. ──
+  pr-smoke:
+    needs: [changes]
+    if: ${{ !cancelled() && needs.changes.outputs.product == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install deps (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev
+
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
+        if: matrix.os == 'windows-latest'
+        with:
+          msystem: CLANG64
+          path-type: inherit
+          install: >-
+            mingw-w64-clang-x86_64-clang
+            mingw-w64-clang-x86_64-zlib
+            mingw-w64-clang-x86_64-python3
+            make
+            coreutils
+
+      - name: Build prod + smoke (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          scripts/build.sh CC=gcc CXX=g++
+          scripts/smoke-test.sh "$(pwd)/build/c/codebase-memory-mcp"
+
+      - name: Build prod + smoke (macOS)
+        if: matrix.os == 'macos-14'
+        run: |
+          scripts/build.sh CC=cc CXX=c++
+          codesign --sign - --force build/c/codebase-memory-mcp
+          scripts/smoke-test.sh "$(pwd)/build/c/codebase-memory-mcp"
+
+      - name: Build prod + smoke (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: msys2 {0}
+        run: |
+          scripts/build.sh CC=clang CXX=clang++
+          BIN="$(pwd)/build/c/codebase-memory-mcp"
+          [ -f "${BIN}.exe" ] && BIN="${BIN}.exe"
+          scripts/smoke-test.sh "$BIN"
+
   ci-ok:
     # The one required context (besides dco) — fails unless every PR stage
-    # succeeded, so matrix renames can never silently deadlock merges.
-    needs: [security, lint, test]
+    # succeeded, so matrix renames can never silently deadlock merges. `skipped`
+    # is OK: pr-smoke skips on docs/CI/test-only PRs (changes.product == false).
+    needs: [security, lint, test, changes, pr-smoke]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -50,7 +132,7 @@ jobs:
           echo "$RESULTS" | python3 -c "
           import json, sys
           needs = json.load(sys.stdin)
-          bad = {k: v['result'] for k, v in needs.items() if v['result'] != 'success'}
+          bad = {k: v['result'] for k, v in needs.items() if v['result'] not in ('success', 'skipped')}
           if bad:
               print('CI NOT OK:', bad)
               sys.exit(1)

--- a/src/.ci-pr-smoke-validation
+++ b/src/.ci-pr-smoke-validation
@@ -1,2 +1,0 @@
-Temporary marker to force the pr-smoke path filter (product=true) so the new
-build+smoke job runs on this PR for one validation pass. Dropped before merge.

--- a/src/.ci-pr-smoke-validation
+++ b/src/.ci-pr-smoke-validation
@@ -1,0 +1,2 @@
+Temporary marker to force the pr-smoke path filter (product=true) so the new
+build+smoke job runs on this PR for one validation pass. Dropped before merge.


### PR DESCRIPTION
## Motivation
PR CI runs `test` but never **builds** the binary or **smoke-tests** it — so built-binary regressions only surface at the *release* dry run. The Windows `CreateProcess` argv-quoting bug (worker got mangled JSON) slipped all the way to the release gate for exactly this reason.

## What this adds
A **path-gated light smoke**:
- **`changes`** job classifies the PR via `gh pr diff --name-only` (no new action dependency). Product code = `src/ · internal/ · Makefile.cbm · scripts/build.sh · scripts/smoke-test.sh · scripts/env.sh`.
- **`pr-smoke`** (only when product code changed): builds the **production** binary and runs `scripts/smoke-test.sh` on **ubuntu-latest + macos-14 + windows-latest** — the reliable *native* platforms (not the flaky broad/emulated legs, which stay in the dry run). `fail-fast: false`; **every leg gates**.
- **`ci-ok`** now treats `skipped` as OK, so docs/CI/test-only PRs (which skip smoke) still pass.

`SMOKE_DOWNLOAD_URL` is intentionally unset → `smoke-test.sh`'s download/update phases self-skip; the core `index_repository`/search/trace phases (which catch the CreateProcess class) still run. Build steps replicate the proven `_build.yml` per-OS patterns (ubuntu apt-zlib, macOS ad-hoc codesign, Windows msys2 CLANG64).

## Scope / CI-sensitivity
- `.github/workflows/pr.yml` only. Adds a **gating** build+smoke on **product-code PRs** (docs/CI/test PRs unaffected + fast). Windows is billed 2×, so product PRs get slower — the deliberate cost of catching regressions at PR time. The full broad smoke stays in the dry run/release.
- Validated locally: YAML parses; path-filter matches product vs docs/CI/test correctly.

## ⚠️ Validation note
This PR touches only `pr.yml` → `changes` sees it as non-product → **`pr-smoke` skips on this very PR** (chicken-and-egg). So the build+smoke legs are not self-validated here. Before merge we should exercise them once (a throwaway `src/` touch, or the first real product PR). Independent of the in-flight release fixes; can merge anytime after that validation.