### PR TITLE
fix(win): harden artifact.c git shell-outs against unquoted/unvalidated repo paths

### DIFF
--- a/src/pipeline/artifact.c
+++ b/src/pipeline/artifact.c
@@ -21,6 +21,7 @@ enum {
 #include "foundation/compat_fs.h"
 #include "foundation/compat.h"
 #include "foundation/log.h"
+#include "foundation/str_util.h" /* cbm_validate_shell_arg — git shell-out hardening */
 
 #include "zstd_store.h"
 
@@ -201,10 +202,45 @@ static int write_file_atomic(const char *path, const char *data, size_t len,
     return 0;
 }
 
+#ifdef _WIN32
+#define ARTIFACT_NULL_DEV "NUL"
+#else
+#define ARTIFACT_NULL_DEV "/dev/null"
+#endif
+
+/* See artifact.h. Mirrors git_context.c's git_validate_repo_path (the best-hardened
+ * git shell-out): cbm_validate_shell_arg rejects quote / backslash / substitution
+ * metacharacters, and on Windows we also reject the cmd.exe expansion metacharacters
+ * % ! ^. Callers then use DOUBLE quotes (honored by both POSIX sh and cmd.exe, unlike
+ * single quotes on cmd.exe), so a repo path may legitimately contain spaces. */
+bool cbm_artifact_repo_path_is_shell_safe(const char *repo_path) {
+    if (!cbm_validate_shell_arg(repo_path)) {
+        return false;
+    }
+#ifdef _WIN32
+    for (const char *p = repo_path; *p; p++) {
+        if (*p == '%' || *p == '!' || *p == '^') {
+            return false;
+        }
+    }
+#endif
+    return true;
+}
+
 /* Get current git HEAD hash. buf must be >= CBM_SZ_64. Returns false on error. */
 static bool git_head_hash(const char *repo_path, char *buf, size_t bufsz) {
     char cmd[CBM_SZ_1K];
-    snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse HEAD 2>/dev/null", repo_path);
+    if (!cbm_artifact_repo_path_is_shell_safe(repo_path)) {
+        buf[0] = '\0';
+        return false;
+    }
+    int n =
+        snprintf(cmd, sizeof(cmd), "git -C \"%s\" rev-parse HEAD 2>" ARTIFACT_NULL_DEV, repo_path);
+    if (n < 0 || (size_t)n >= sizeof(cmd)) {
+        buf[0] = '\0'; /* truncated command → don't run a malformed shell string (parity with
+                          git_context.c) */
+        return false;
+    }
     FILE *fp = cbm_popen(cmd, "r");
     if (!fp) {
         buf[0] = '\0';
@@ -357,8 +393,15 @@ static void ensure_gitattributes(const char *repo_path) {
     }
 
     /* Best-effort: configure merge driver */
+    if (!cbm_artifact_repo_path_is_shell_safe(repo_path)) {
+        return;
+    }
     char cmd[CBM_SZ_1K];
-    snprintf(cmd, sizeof(cmd), "git -C '%s' config merge.ours.driver true 2>/dev/null", repo_path);
+    int n = snprintf(cmd, sizeof(cmd),
+                     "git -C \"%s\" config merge.ours.driver true 2>" ARTIFACT_NULL_DEV, repo_path);
+    if (n < 0 || (size_t)n >= sizeof(cmd)) {
+        return; /* truncated command → skip (parity with git_context.c) */
+    }
     FILE *p = cbm_popen(cmd, "r");
     if (p) {
         (void)cbm_pclose(p);

--- a/src/pipeline/artifact.h
+++ b/src/pipeline/artifact.h
@@ -53,4 +53,12 @@ bool cbm_artifact_exists(const char *repo_path);
  * Returns NULL if artifact doesn't exist or has no commit field. */
 char *cbm_artifact_commit(const char *repo_path);
 
+/* Whether repo_path is safe to interpolate into a double-quoted `git -C "…"` shell
+ * command (as artifact.c does via cbm_popen). Rejects quote / backslash / shell
+ * substitution metacharacters (cbm_validate_shell_arg); on Windows also rejects the
+ * cmd.exe expansion metacharacters % ! ^. Spaces ARE allowed — double quotes handle
+ * them on both POSIX sh and cmd.exe (single quotes, which cmd.exe does not honor,
+ * were the pre-existing bug). Exposed so the shell-safety contract is unit-tested. */
+bool cbm_artifact_repo_path_is_shell_safe(const char *repo_path);
+
 #endif /* CBM_ARTIFACT_H */

--- a/tests/test_artifact.c
+++ b/tests/test_artifact.c
@@ -318,7 +318,53 @@ TEST(artifact_null_safety) {
     PASS();
 }
 
+/* ── git shell-out path safety ────────────────────────────────────────────────
+ *
+ * artifact.c shells out to git via cbm_popen with the repo path interpolated into
+ * the command. It previously used single quotes (`git -C '%s'`) with NO validation
+ * — but cmd.exe does not honor single quotes, so on Windows a repo path with a space
+ * broke argument grouping, and an embedded quote/metacharacter could break out of the
+ * intended argument entirely. The hardening validates the path and switches to double
+ * quotes; cbm_artifact_repo_path_is_shell_safe() is the guard. Rejecting quotes and
+ * shell/cmd.exe metacharacters is the contract; spaces must stay allowed (double
+ * quotes handle them) — that is the concrete regression the single-quote form caused. */
+TEST(artifact_repo_path_shell_safe_accepts_plain_and_spaced) {
+    ASSERT_TRUE(cbm_artifact_repo_path_is_shell_safe("/home/user/repo"));
+    ASSERT_TRUE(cbm_artifact_repo_path_is_shell_safe("C:/Users/me/repo"));
+    ASSERT_TRUE(cbm_artifact_repo_path_is_shell_safe("/home/user/my repo")); /* space OK */
+    PASS();
+}
+
+TEST(artifact_repo_path_shell_safe_rejects_injection) {
+    ASSERT_FALSE(cbm_artifact_repo_path_is_shell_safe(NULL));
+    ASSERT_FALSE(cbm_artifact_repo_path_is_shell_safe("it's"));        /* single quote */
+    ASSERT_FALSE(cbm_artifact_repo_path_is_shell_safe("a\"b"));        /* double quote */
+    ASSERT_FALSE(cbm_artifact_repo_path_is_shell_safe("x; rm -rf /")); /* command sep */
+    ASSERT_FALSE(cbm_artifact_repo_path_is_shell_safe("$(whoami)"));   /* substitution */
+    ASSERT_FALSE(cbm_artifact_repo_path_is_shell_safe("a`id`b"));      /* backtick */
+    ASSERT_FALSE(cbm_artifact_repo_path_is_shell_safe("a|b"));         /* pipe */
+    PASS();
+}
+
+TEST(artifact_repo_path_shell_safe_rejects_cmd_metachars_on_windows) {
+#ifdef _WIN32
+    /* cmd.exe expands %VAR%, delayed !VAR!, and escapes with ^ even inside double
+     * quotes — git_context.c rejects these on Windows and this must match. */
+    ASSERT_FALSE(cbm_artifact_repo_path_is_shell_safe("C:/a%USERPROFILE%b"));
+    ASSERT_FALSE(cbm_artifact_repo_path_is_shell_safe("C:/a!b"));
+    ASSERT_FALSE(cbm_artifact_repo_path_is_shell_safe("C:/a^b"));
+#else
+    /* POSIX shells treat % ! ^ literally inside double quotes — allowed. */
+    ASSERT_TRUE(cbm_artifact_repo_path_is_shell_safe("/a%b"));
+    ASSERT_TRUE(cbm_artifact_repo_path_is_shell_safe("/a^b"));
+#endif
+    PASS();
+}
+
 SUITE(artifact) {
+    RUN_TEST(artifact_repo_path_shell_safe_accepts_plain_and_spaced);
+    RUN_TEST(artifact_repo_path_shell_safe_rejects_injection);
+    RUN_TEST(artifact_repo_path_shell_safe_rejects_cmd_metachars_on_windows);
     RUN_TEST(artifact_export_fast_roundtrip);
     RUN_TEST(artifact_export_best_roundtrip);
     RUN_TEST(artifact_exists_check);


### PR DESCRIPTION
## Summary

Follow-up to #881 (split out per review). Hardens the **git shell-outs in `pipeline/artifact.c`** — a *different* bug class from #881's `CreateProcess` argv-quoting: this is `popen`/shell command-string quoting.

## The bug

`artifact.c` shells out to git twice via `cbm_popen`, interpolating the repo path with **single quotes** and **no validation**:

```c
git -C '%s' rev-parse HEAD 2>/dev/null                 // git_head_hash
git -C '%s' config merge.ours.driver true 2>/dev/null  // ensure_gitattributes
```

- **`cmd.exe` does not honor single quotes**, so on Windows a repo path containing a **space** breaks argument grouping — the artifact commit hash and merge-driver config silently fail for any spaced repo path.
- An embedded quote or shell metacharacter in `repo_path` could break out of the intended argument.

This was the only unvalidated git shell interpolation left in the tree (every other git shell-out — `git_context.c`, `pass_githistory.c`, `watcher.c`, `mcp.c` — already validates and double-quotes).

## Fix

- Validate `repo_path` with `cbm_artifact_repo_path_is_shell_safe()` and switch to **double quotes** + a per-platform null device, matching `git_context.c` (the best-hardened git shell-out).
- `cbm_validate_shell_arg` rejects quote / backslash / substitution metacharacters; on Windows we additionally reject the `cmd.exe` expansion metacharacters `% ! ^`.
- Double quotes are honored by **both** POSIX `sh` and `cmd.exe`, so a legitimate **spaced** repo path now works — the concrete regression the single-quote form caused.

## Test

New guard suite in `tests/test_artifact.c` for the exposed `cbm_artifact_repo_path_is_shell_safe()`:

- plain and **spaced** paths accepted (the regression),
- quote / `;` / `$()` / backtick / pipe injection rejected,
- `cmd.exe` metacharacters `% ! ^` rejected on Windows (allowed on POSIX, where they are literal inside double quotes).

## Scope

Atomic to the artifact.c shell-quoting hardening. No behavior change on valid paths except that spaced paths now work on Windows.

Refs #881.
