### PR TITLE
fix(mcp): keep ADR reads nonblocking during reindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,8 @@ JSON arguments can also be piped on stdin. Inline JSON remains accepted for back
 | `manage_adr` | CRUD for Architecture Decision Records. Query modes do not wait behind a same-project reindex; writes remain serialized. |
 | `ingest_traces` | Ingest runtime traces to validate HTTP_CALLS edges. |
 
+`manage_adr` query modes (`get` and `sections`) use the server's cached query store so they can proceed while a same-project reindex is running. If another process publishes a replacement store during reindexing, they can return the pre-publication ADR until idle eviction refreshes that cache. Updates remain serialized through the project mutation guard.
+
 ## Graph Data Model
 
 ### Node Labels

--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ JSON arguments can also be piped on stdin. Inline JSON remains accepted for back
 | `get_code_snippet` | Read source code for a function by qualified name. |
 | `get_architecture` | Codebase overview: languages, packages, routes, hotspots, clusters, ADR. |
 | `search_code` | Grep-like text search within indexed project files. |
-| `manage_adr` | CRUD for Architecture Decision Records. |
+| `manage_adr` | CRUD for Architecture Decision Records. Query modes do not wait behind a same-project reindex; writes remain serialized. |
 | `ingest_traces` | Ingest runtime traces to validate HTTP_CALLS edges. |
 
 ## Graph Data Model

--- a/src/daemon/application.c
+++ b/src/daemon/application.c
@@ -1009,6 +1009,12 @@ static bool application_session_mutation_begin(void *context, const char *projec
            application_mutation_begin_internal(session->application, session, project, true);
 }
 
+static bool application_session_mutation_try_begin(void *context, const char *project) {
+    cbm_daemon_application_session_t *session = context;
+    return session &&
+           application_mutation_begin_internal(session->application, session, project, false);
+}
+
 static void application_session_mutation_end(void *context, const char *project) {
     cbm_daemon_application_session_t *session = context;
     if (session) {
@@ -2246,6 +2252,8 @@ static cbm_daemon_runtime_application_session_t *application_session_open(
     cbm_mcp_server_set_index_executor(session->mcp, application_index_execute, session);
     cbm_mcp_server_set_project_mutation_guard(session->mcp, application_session_mutation_begin,
                                               application_session_mutation_end, session);
+    cbm_mcp_server_set_project_mutation_try_guard(session->mcp,
+                                                  application_session_mutation_try_begin);
     session->tool_profile = CBM_MCP_TOOL_PROFILE_ALL;
     session->application = application;
     session->client_id = client_id;

--- a/src/main.c
+++ b/src/main.c
@@ -251,17 +251,21 @@ static bool main_test_worker_project_lock_marker(const main_local_cli_mutation_t
 }
 #endif
 
-static bool main_local_cli_mutation_begin(void *context, const char *project) {
+static bool main_local_cli_mutation_begin_internal(void *context, const char *project, bool wait) {
     main_local_cli_mutation_t *mutation = context;
     if (!mutation || !mutation->manager || !project || !project[0]) {
         return false;
     }
     for (;;) {
-        uint64_t now = cbm_now_ms();
-        uint64_t deadline = now > UINT64_MAX - 100U ? UINT64_MAX : now + 100U;
         cbm_project_lock_lease_t *lease = NULL;
-        cbm_private_file_lock_status_t status =
-            cbm_project_lock_acquire(mutation->manager, project, deadline, NULL, &lease);
+        cbm_private_file_lock_status_t status;
+        if (wait) {
+            uint64_t now = cbm_now_ms();
+            uint64_t deadline = now > UINT64_MAX - 100U ? UINT64_MAX : now + 100U;
+            status = cbm_project_lock_acquire(mutation->manager, project, deadline, NULL, &lease);
+        } else {
+            status = cbm_project_lock_try_acquire(mutation->manager, project, &lease);
+        }
         if (status == CBM_PRIVATE_FILE_LOCK_OK && lease) {
             main_local_cli_lease_t *held = calloc(1, sizeof(*held));
             if (held) {
@@ -292,6 +296,9 @@ static bool main_local_cli_mutation_begin(void *context, const char *project) {
                           "refuse_mutation");
             return false;
         }
+        if (!wait) {
+            return false;
+        }
         if (mutation->feedback && !mutation->waiting_reported) {
             (void)fprintf(mutation->feedback, "Waiting for another CBM mutation of %s...\n",
                           project);
@@ -299,6 +306,14 @@ static bool main_local_cli_mutation_begin(void *context, const char *project) {
             mutation->waiting_reported = true;
         }
     }
+}
+
+static bool main_local_cli_mutation_begin(void *context, const char *project) {
+    return main_local_cli_mutation_begin_internal(context, project, true);
+}
+
+static bool main_local_cli_mutation_try_begin(void *context, const char *project) {
+    return main_local_cli_mutation_begin_internal(context, project, false);
 }
 
 static void main_local_cli_mutation_end(void *context, const char *project) {
@@ -775,6 +790,8 @@ static int run_cli(int argc, char **argv, cbm_project_lock_manager_t *project_lo
             if (project_locks) {
                 cbm_mcp_server_set_project_mutation_guard(srv, main_local_cli_mutation_begin,
                                                           main_local_cli_mutation_end, &mutation);
+                cbm_mcp_server_set_project_mutation_try_guard(srv,
+                                                              main_local_cli_mutation_try_begin);
             }
         }
         maintenance_binding_failed = srv && !maintenance_context;

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -1528,6 +1528,7 @@ struct cbm_mcp_server {
     cbm_proc_log_cb index_log_callback;
     void *index_log_context;
     cbm_mcp_project_mutation_begin_fn mutation_begin;
+    cbm_mcp_project_mutation_try_begin_fn mutation_try_begin;
     cbm_mcp_project_mutation_end_fn mutation_end;
     void *mutation_context;
     cbm_mcp_quarantine_test_hook_fn quarantine_test_hook;
@@ -1678,12 +1679,25 @@ void cbm_mcp_server_set_project_mutation_guard(cbm_mcp_server_t *srv,
         return;
     }
     srv->mutation_begin = begin;
+    srv->mutation_try_begin = NULL;
     srv->mutation_end = end;
     srv->mutation_context = begin ? context : NULL;
 }
 
+void cbm_mcp_server_set_project_mutation_try_guard(
+    cbm_mcp_server_t *srv, cbm_mcp_project_mutation_try_begin_fn try_begin) {
+    if (srv && srv->mutation_begin) {
+        srv->mutation_try_begin = try_begin;
+    }
+}
+
 static bool mcp_project_mutation_begin(cbm_mcp_server_t *srv, const char *project) {
     return !srv->mutation_begin || srv->mutation_begin(srv->mutation_context, project);
+}
+
+static bool mcp_project_mutation_try_begin(cbm_mcp_server_t *srv, const char *project) {
+    return !srv->mutation_begin ||
+           (srv->mutation_try_begin && srv->mutation_try_begin(srv->mutation_context, project));
 }
 
 static void mcp_project_mutation_end(cbm_mcp_server_t *srv, const char *project) {
@@ -2041,8 +2055,18 @@ static bool quarantine_corrupt_store(cbm_mcp_server_t *srv, const char *project,
 /* Open the right project's .db file for query tools.
  * Caches the connection — reopens only when project changes.
  * Tracks last-access time so the event loop can evict idle stores. */
+typedef enum {
+    STORE_RECOVERY_NONE,
+    STORE_RECOVERY_BUSY,
+    STORE_RECOVERY_TRY_GUARD_UNAVAILABLE,
+} store_recovery_status_t;
+
 static cbm_store_t *resolve_store_internal(cbm_mcp_server_t *srv, const char *project,
-                                           bool mutation_already_held) {
+                                           bool mutation_already_held, bool nonblocking_recovery,
+                                           store_recovery_status_t *recovery_status) {
+    if (recovery_status) {
+        *recovery_status = STORE_RECOVERY_NONE;
+    }
     if (!project) {
         return NULL; /* project is required — no implicit fallback */
     }
@@ -2072,9 +2096,16 @@ static cbm_store_t *resolve_store_internal(cbm_mcp_server_t *srv, const char *pr
             srv->store = NULL;
             bool mutation_acquired = mutation_already_held;
             if (!mutation_acquired) {
-                mutation_acquired = mcp_project_mutation_begin(srv, project);
+                mutation_acquired = nonblocking_recovery
+                                        ? mcp_project_mutation_try_begin(srv, project)
+                                        : mcp_project_mutation_begin(srv, project);
             }
             if (!mutation_acquired) {
+                if (nonblocking_recovery && recovery_status) {
+                    *recovery_status = srv->mutation_try_begin
+                                           ? STORE_RECOVERY_BUSY
+                                           : STORE_RECOVERY_TRY_GUARD_UNAVAILABLE;
+                }
                 return NULL;
             }
 
@@ -2138,7 +2169,7 @@ static cbm_store_t *resolve_store_internal(cbm_mcp_server_t *srv, const char *pr
 }
 
 static cbm_store_t *resolve_store(cbm_mcp_server_t *srv, const char *project) {
-    return resolve_store_internal(srv, project, false);
+    return resolve_store_internal(srv, project, false, false, NULL);
 }
 
 /* Forward decl — definition lives below alongside list_projects. */
@@ -10365,6 +10396,28 @@ static char *adr_read_legacy_file(const char *root_path) {
     "then draft and store. Sections: PURPOSE, STACK, ARCHITECTURE, "               \
     "PATTERNS, TRADEOFFS, PHILOSOPHY."
 
+/* resolve_store opens file-backed projects query-only. A mutation must release
+ * that reader before opening a dedicated writer because atomic publication uses
+ * a self-contained DELETE-mode database that switches back to WAL on write. */
+static cbm_store_t *open_adr_store_for_write(cbm_mcp_server_t *srv, cbm_store_t *resolved,
+                                             cbm_store_t **owned_rw) {
+    if (!srv || !resolved || !owned_rw) {
+        return NULL;
+    }
+    const char *resolved_db_path = cbm_store_db_path(resolved);
+    if (!resolved_db_path) {
+        return resolved;
+    }
+    char *rw_path = heap_strdup(resolved_db_path);
+    if (!rw_path) {
+        return NULL;
+    }
+    invalidate_cached_store(srv);
+    *owned_rw = cbm_store_open_path(rw_path);
+    free(rw_path);
+    return *owned_rw;
+}
+
 static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
     char *project = get_project_arg(args);
     char *mode_str = cbm_mcp_get_string_arg(args, "mode");
@@ -10396,8 +10449,10 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
             true);
     }
 
+    bool write_request =
+        content && (strcmp(mode_str, "update") == 0 || strcmp(mode_str, "store") == 0);
     bool mutation_held = false;
-    if (project) {
+    if (write_request && project) {
         mutation_held = mcp_project_mutation_begin(srv, project);
         if (!mutation_held) {
             free(project);
@@ -10418,11 +10473,21 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
     /* ADRs are stored in the SQLite store (project_summaries), the SAME
      * backend the UI /api/adr endpoints use — so writes via the MCP tool and
      * the UI are visible to each other (#256). */
-    cbm_store_t *resolved = resolve_store_internal(srv, project, mutation_held);
+    store_recovery_status_t recovery_status = STORE_RECOVERY_NONE;
+    cbm_store_t *resolved =
+        resolve_store_internal(srv, project, mutation_held, !write_request, &recovery_status);
     if (!resolved) {
-        char *err = build_no_store_error(project);
-        char *res = cbm_mcp_text_result(err, true);
-        free(err);
+        char *res = NULL;
+        if (recovery_status == STORE_RECOVERY_BUSY) {
+            res = cbm_mcp_text_result("project is busy; retry after indexing", true);
+        } else if (recovery_status == STORE_RECOVERY_TRY_GUARD_UNAVAILABLE) {
+            res =
+                cbm_mcp_text_result("project recovery requires a nonblocking mutation guard", true);
+        } else {
+            char *err = build_no_store_error(project);
+            res = cbm_mcp_text_result(err, true);
+            free(err);
+        }
         if (mutation_held) {
             mcp_project_mutation_end(srv, project);
         }
@@ -10432,66 +10497,57 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
         return res;
     }
 
-    /* resolve_store opens file-backed projects READ-ONLY (query stores must
-     * not mutate the DB). manage_adr is the only resolve_store caller that
-     * WRITES, so it needs a writable handle. For a file-backed project open a
-     * dedicated read-write handle to the same DB file (the project is verified
-     * to exist via resolve_store, so cbm_store_open_path won't create a ghost
-     * DB). For an in-memory / embedded store (db_path == NULL) the resolved
-     * store is already writable — use it directly. */
     cbm_store_t *store = resolved;
     cbm_store_t *owned_rw = NULL;
-    const char *resolved_db_path = cbm_store_db_path(resolved);
-    if (resolved_db_path) {
-        /* Atomic publication leaves a self-contained DELETE-mode database.
-         * Opening the writer switches it back to WAL, which requires an
-         * exclusive lock and therefore fails while resolve_store's read-only
-         * handle is still open. Copy the ACTUAL resolved path first (it may be
-         * a drifted-filename fallback), then release that cached reader before
-         * opening the writer. Request-scoped queries reopen it when needed. */
-        char *rw_path = heap_strdup(resolved_db_path);
-        if (!rw_path) {
+    if (write_request) {
+        store = open_adr_store_for_write(srv, resolved, &owned_rw);
+        if (!store) {
             if (mutation_held) {
                 mcp_project_mutation_end(srv, project);
             }
             free(project);
             free(mode_str);
             free(content);
-            return cbm_mcp_text_result("failed to allocate ADR store path", true);
+            return cbm_mcp_text_result("failed to open writable ADR store", true);
         }
-        invalidate_cached_store(srv);
-        owned_rw = cbm_store_open_path(rw_path);
-        free(rw_path);
-        if (!owned_rw) {
-            char *err = build_no_store_error(project);
-            char *res = cbm_mcp_text_result(err, true);
-            free(err);
-            if (mutation_held) {
-                mcp_project_mutation_end(srv, project);
-            }
-            free(project);
-            free(mode_str);
-            free(content);
-            return res;
-        }
-        store = owned_rw;
     }
 
     /* One-time migration: older versions wrote ADRs to a file at
-     * <root>/.codebase-memory/adr.md. If the store has no ADR yet but that
-     * legacy file exists, import it so nothing is lost on upgrade. */
+     * <root>/.codebase-memory/adr.md. A read never waits for the project lease:
+     * it returns the legacy content immediately and attempts migration only if
+     * a nonblocking acquire succeeds. */
     cbm_adr_t adr;
     memset(&adr, 0, sizeof(adr));
     bool have_adr = (cbm_store_adr_get(store, project, &adr) == CBM_STORE_OK);
-    if (!have_adr) {
+    char *legacy = NULL;
+    if (!have_adr && !write_request) {
         char *root_path = project_root_from_store(store, project);
-        char *legacy = adr_read_legacy_file(root_path);
+        legacy = adr_read_legacy_file(root_path);
         free(root_path);
-        if (legacy) {
-            if (cbm_store_adr_store(store, project, legacy) == CBM_STORE_OK) {
-                have_adr = (cbm_store_adr_get(store, project, &adr) == CBM_STORE_OK);
+        if (legacy && mcp_project_mutation_try_begin(srv, project)) {
+            if (!mcp_request_cancelled(srv)) {
+                /* A publisher may have completed before the lease was granted.
+                 * File-backed stores must reopen after acquisition and trust
+                 * only that generation. Embedded stores have no publication
+                 * boundary, so retain their live handle. */
+                if (cbm_store_db_path(resolved)) {
+                    invalidate_cached_store(srv);
+                    resolved = NULL;
+                    store = NULL;
+                    resolved = resolve_store_internal(srv, project, true, false, NULL);
+                }
+                if (resolved) {
+                    store = open_adr_store_for_write(srv, resolved, &owned_rw);
+                    if (store) {
+                        have_adr = (cbm_store_adr_get(store, project, &adr) == CBM_STORE_OK);
+                        if (!have_adr &&
+                            cbm_store_adr_store(store, project, legacy) == CBM_STORE_OK) {
+                            have_adr = (cbm_store_adr_get(store, project, &adr) == CBM_STORE_OK);
+                        }
+                    }
+                }
             }
-            free(legacy);
+            mcp_project_mutation_end(srv, project);
         }
     }
 
@@ -10500,7 +10556,8 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
     yyjson_mut_doc_set_root(doc, root_obj);
 
     bool is_error = false;
-    if ((strcmp(mode_str, "update") == 0 || strcmp(mode_str, "store") == 0) && content) {
+    const char *adr_content = have_adr ? adr.content : legacy;
+    if (write_request) {
         if (cbm_store_adr_store(store, project, content) == CBM_STORE_OK) {
             yyjson_mut_obj_add_str(doc, root_obj, "status", "updated");
             yyjson_mut_obj_add_str(doc, root_obj, "semantics", "whole_document_replaced");
@@ -10509,10 +10566,10 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
             is_error = true;
         }
     } else if (strcmp(mode_str, "sections") == 0) {
-        adr_list_sections_from_content(doc, root_obj, have_adr ? adr.content : NULL);
+        adr_list_sections_from_content(doc, root_obj, adr_content);
     } else { /* get */
-        if (have_adr && adr.content) {
-            yyjson_mut_obj_add_strcpy(doc, root_obj, "content", adr.content);
+        if (adr_content) {
+            yyjson_mut_obj_add_strcpy(doc, root_obj, "content", adr_content);
         } else {
             yyjson_mut_obj_add_str(doc, root_obj, "content", "");
             yyjson_mut_obj_add_str(doc, root_obj, "status", "no_adr");
@@ -10531,6 +10588,7 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
     if (mutation_held) {
         mcp_project_mutation_end(srv, project);
     }
+    free(legacy);
     free(project);
     free(mode_str);
     free(content);

--- a/src/mcp/mcp.h
+++ b/src/mcp/mcp.h
@@ -134,6 +134,10 @@ typedef char *(*cbm_mcp_index_executor_fn)(void *context, const char *repo_path,
 typedef bool (*cbm_mcp_project_mutation_begin_fn)(void *context, const char *project);
 typedef void (*cbm_mcp_project_mutation_end_fn)(void *context, const char *project);
 
+/* Nonblocking counterpart for opportunistic writes during a read request. A
+ * successful call is released through the primary mutation guard's end hook. */
+typedef bool (*cbm_mcp_project_mutation_try_begin_fn)(void *context, const char *project);
+
 /* Create an MCP server. store_path is the SQLite database directory. */
 cbm_mcp_server_t *cbm_mcp_server_new(const char *store_path);
 
@@ -179,6 +183,12 @@ void cbm_mcp_server_set_index_log_callback(cbm_mcp_server_t *srv, cbm_proc_log_c
 void cbm_mcp_server_set_project_mutation_guard(cbm_mcp_server_t *srv,
                                                cbm_mcp_project_mutation_begin_fn begin,
                                                cbm_mcp_project_mutation_end_fn end, void *context);
+
+/* Configure an optional nonblocking acquire for the configured mutation
+ * guard. If no try hook is set, a read that requires recovery fails with a
+ * configuration error rather than invoking the blocking begin callback. */
+void cbm_mcp_server_set_project_mutation_try_guard(cbm_mcp_server_t *srv,
+                                                   cbm_mcp_project_mutation_try_begin_fn try_begin);
 
 /* Read one complete MCP message from in. Supports newline-delimited JSON and
  * Content-Length framing, including additional headers. Returns 1 on success,

--- a/src/ui/http_server.c
+++ b/src/ui/http_server.c
@@ -1984,4 +1984,5 @@ void cbm_http_server_set_project_mutation_guard(cbm_http_server_t *srv,
     srv->mutation_end = end;
     srv->mutation_context = begin ? context : NULL;
     cbm_mcp_server_set_project_mutation_guard(srv->mcp, begin, end, begin ? context : NULL);
+    cbm_mcp_server_set_project_mutation_try_guard(srv->mcp, begin);
 }

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -131,8 +131,10 @@ static void cleanup_project_db(const char *cache, const char *project) {
 
 typedef struct {
     int deny_begin_call;      /* one-based; zero allows every acquisition */
+    int deny_try_begin_call;  /* one-based; zero allows every try acquisition */
     int cancel_on_begin_call; /* one-based; zero never requests cancellation */
     int begin_count;
+    int try_begin_count;
     int end_count;
     cbm_mcp_server_t *cancel_server;
     bool cancel_attempted;
@@ -144,6 +146,7 @@ typedef struct {
     bool db_exists_at_end;
     bool backup_exists_at_end;
     char begin_projects[MCP_MUTATION_GUARD_MAX_EVENTS][CBM_SZ_256];
+    char try_begin_projects[MCP_MUTATION_GUARD_MAX_EVENTS][CBM_SZ_256];
     char end_projects[MCP_MUTATION_GUARD_MAX_EVENTS][CBM_SZ_256];
 } mcp_mutation_guard_probe_t;
 
@@ -301,6 +304,26 @@ static bool mcp_mutation_guard_probe_begin(void *context, const char *project) {
         probe->backup_exists_at_begin = cbm_file_exists(probe->observed_backup_path);
     }
     return probe->deny_begin_call == 0 || probe->begin_count != probe->deny_begin_call;
+}
+
+static bool mcp_mutation_guard_probe_try_begin(void *context, const char *project) {
+    mcp_mutation_guard_probe_t *probe = context;
+    if (!probe) {
+        return false;
+    }
+
+    int event = probe->try_begin_count++;
+    if (event < MCP_MUTATION_GUARD_MAX_EVENTS) {
+        snprintf(probe->try_begin_projects[event], sizeof(probe->try_begin_projects[event]), "%s",
+                 project ? project : "");
+    }
+    if (probe->observed_db_path) {
+        probe->db_exists_at_begin = cbm_file_exists(probe->observed_db_path);
+    }
+    if (probe->observed_backup_path) {
+        probe->backup_exists_at_begin = cbm_file_exists(probe->observed_backup_path);
+    }
+    return probe->deny_try_begin_call == 0 || probe->try_begin_count != probe->deny_try_begin_call;
 }
 
 static void mcp_mutation_guard_probe_end(void *context, const char *project) {
@@ -4318,7 +4341,47 @@ TEST(tool_manage_adr_mutation_guard_balances_success) {
     PASS();
 }
 
-TEST(tool_manage_adr_mutation_guard_releases_on_missing_store) {
+/* ADR reads must not wait behind the same project's mutation lease. A reindex
+ * can be expensive; existing SQLite data is a stable query snapshot, so get
+ * and sections must not invoke the blocking guard. */
+TEST(tool_manage_adr_read_paths_skip_blocking_mutation_guard) {
+    const char *project = "guard-adr-read";
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *store = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(store);
+    ASSERT_EQ(cbm_store_upsert_project(store, project, "/tmp/guard-adr-read"), CBM_STORE_OK);
+    ASSERT_EQ(
+        cbm_store_adr_store(store, project, "## PURPOSE\nNonblocking read.\n\n## STACK\nC.\n"),
+        CBM_STORE_OK);
+    cbm_mcp_server_set_project(srv, project);
+
+    mcp_mutation_guard_probe_t probe = {.deny_begin_call = 1};
+    cbm_mcp_server_set_project_mutation_guard(srv, mcp_mutation_guard_probe_begin,
+                                              mcp_mutation_guard_probe_end, &probe);
+
+    char *get_response =
+        cbm_mcp_handle_tool(srv, "manage_adr", "{\"project\":\"guard-adr-read\",\"mode\":\"get\"}");
+    char *sections_response = cbm_mcp_handle_tool(
+        srv, "manage_adr", "{\"project\":\"guard-adr-read\",\"mode\":\"sections\"}");
+    bool get_returned_adr = get_response && strstr(get_response, "Nonblocking read.") &&
+                            !strstr(get_response, "\"isError\":true");
+    bool sections_returned_adr = sections_response && strstr(sections_response, "## PURPOSE") &&
+                                 strstr(sections_response, "## STACK") &&
+                                 !strstr(sections_response, "\"isError\":true");
+
+    free(get_response);
+    free(sections_response);
+    cbm_mcp_server_free(srv);
+
+    ASSERT_TRUE(get_returned_adr);
+    ASSERT_TRUE(sections_returned_adr);
+    ASSERT_EQ(probe.begin_count, 0);
+    ASSERT_EQ(probe.end_count, 0);
+    PASS();
+}
+
+TEST(tool_manage_adr_read_missing_store_skips_mutation_guard) {
     char cache[256];
     snprintf(cache, sizeof(cache), "/tmp/cbm-mcp-adr-guard-XXXXXX");
     if (!cbm_mkdtemp(cache)) {
@@ -4340,10 +4403,8 @@ TEST(tool_manage_adr_mutation_guard_releases_on_missing_store) {
                                      "{\"project\":\"guard-adr-missing\",\"mode\":\"get\"}");
     ASSERT_NOT_NULL(resp);
     ASSERT_TRUE(strstr(resp, "not found") || strstr(resp, "not indexed"));
-    ASSERT_EQ(probe.begin_count, 1);
-    ASSERT_EQ(probe.end_count, 1);
-    ASSERT_STR_EQ(probe.begin_projects[0], project);
-    ASSERT_STR_EQ(probe.end_projects[0], project);
+    ASSERT_EQ(probe.begin_count, 0);
+    ASSERT_EQ(probe.end_count, 0);
     free(resp);
 
     cbm_mcp_server_free(srv);
@@ -4351,6 +4412,85 @@ TEST(tool_manage_adr_mutation_guard_releases_on_missing_store) {
     cbm_rmdir(cache);
     restore_cache_dir(saved_cache_copy);
     free(saved_cache_copy);
+    PASS();
+}
+
+TEST(tool_manage_adr_legacy_migration_tries_without_blocking) {
+    const char *project = "guard-adr-legacy";
+    char root[256];
+    char cache[256];
+    snprintf(root, sizeof(root), "%s/cbm-adr-legacy-XXXXXX", cbm_tmpdir());
+    snprintf(cache, sizeof(cache), "%s/cbm-adr-legacy-cache-XXXXXX", cbm_tmpdir());
+    ASSERT_NOT_NULL(cbm_mkdtemp(root));
+    ASSERT_NOT_NULL(cbm_mkdtemp(cache));
+
+    const char *saved_cache = getenv("CBM_CACHE_DIR");
+    char *saved_cache_copy = saved_cache ? strdup(saved_cache) : NULL;
+    ASSERT_EQ(cbm_setenv("CBM_CACHE_DIR", cache, 1), 0);
+
+    char adr_dir[CBM_SZ_1K];
+    char adr_path[CBM_SZ_1K];
+    snprintf(adr_dir, sizeof(adr_dir), "%s/.codebase-memory", root);
+    snprintf(adr_path, sizeof(adr_path), "%s/adr.md", adr_dir);
+    ASSERT_EQ(cbm_mkdir(adr_dir), 0);
+    FILE *fp = cbm_fopen(adr_path, "w");
+    ASSERT_NOT_NULL(fp);
+    ASSERT_TRUE(fputs("## PURPOSE\nLegacy ADR.\n", fp) >= 0);
+    ASSERT_EQ(fclose(fp), 0);
+
+    char db_path[CBM_SZ_1K];
+    snprintf(db_path, sizeof(db_path), "%s/%s.db", cache, project);
+    cbm_store_t *writer = cbm_store_open_path(db_path);
+    ASSERT_NOT_NULL(writer);
+    ASSERT_EQ(cbm_store_upsert_project(writer, project, root), CBM_STORE_OK);
+    cbm_store_close(writer);
+
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+
+    mcp_mutation_guard_probe_t probe = {.deny_try_begin_call = 1};
+    cbm_mcp_server_set_project_mutation_guard(srv, mcp_mutation_guard_probe_begin,
+                                              mcp_mutation_guard_probe_end, &probe);
+    cbm_mcp_server_set_project_mutation_try_guard(srv, mcp_mutation_guard_probe_try_begin);
+
+    char *busy_response = cbm_mcp_handle_tool(
+        srv, "manage_adr", "{\"project\":\"guard-adr-legacy\",\"mode\":\"get\"}");
+    char *migrated_response = cbm_mcp_handle_tool(
+        srv, "manage_adr", "{\"project\":\"guard-adr-legacy\",\"mode\":\"get\"}");
+    /* A successful migration invalidates the request-scoped query store; prove
+     * persistence through the next public read instead of retaining its former
+     * borrowed test handle. */
+    char *persisted_response = cbm_mcp_handle_tool(
+        srv, "manage_adr", "{\"project\":\"guard-adr-legacy\",\"mode\":\"get\"}");
+    bool busy_read_returned_legacy = busy_response && strstr(busy_response, "Legacy ADR.") &&
+                                     !strstr(busy_response, "\"isError\":true");
+    bool migrated_read_returned_legacy = migrated_response &&
+                                         strstr(migrated_response, "Legacy ADR.") &&
+                                         !strstr(migrated_response, "\"isError\":true");
+    bool migration_persisted = persisted_response && strstr(persisted_response, "Legacy ADR.") &&
+                               !strstr(persisted_response, "\"isError\":true");
+
+    free(busy_response);
+    free(migrated_response);
+    free(persisted_response);
+    cbm_mcp_server_free(srv);
+    cbm_unlink(adr_path);
+    cbm_rmdir(adr_dir);
+    cbm_rmdir(root);
+    cleanup_project_db(cache, project);
+    restore_cache_dir(saved_cache_copy);
+    free(saved_cache_copy);
+    cbm_rmdir(cache);
+
+    ASSERT_TRUE(busy_read_returned_legacy);
+    ASSERT_TRUE(migrated_read_returned_legacy);
+    ASSERT_TRUE(migration_persisted);
+    ASSERT_EQ(probe.begin_count, 0);
+    ASSERT_EQ(probe.try_begin_count, 2);
+    ASSERT_EQ(probe.end_count, 1);
+    ASSERT_STR_EQ(probe.try_begin_projects[0], project);
+    ASSERT_STR_EQ(probe.try_begin_projects[1], project);
+    ASSERT_STR_EQ(probe.end_projects[0], project);
     PASS();
 }
 
@@ -5052,9 +5192,9 @@ TEST(tool_cross_repo_honors_source_name_override) {
 }
 
 /* Corrupt-store quarantine renames/unlinks the project DB and sidecars, so it
- * is a mutation even when resolve_store() was reached by a query tool. The
- * query path needs one balanced lease; manage_adr already owns that project
- * lease and must not acquire a nested second lease during the same cleanup. */
+ * is a mutation even when resolve_store() was reached by a query tool. Generic
+ * queries use a blocking guard for that recovery, while manage_adr reads must
+ * use one nonblocking acquisition and never nest a blocking lease. */
 TEST(tool_corrupt_store_cleanup_guard_is_balanced_and_not_nested) {
     char cache[256];
     snprintf(cache, sizeof(cache), "%s/cbm-mcp-corrupt-guard-XXXXXX", cbm_tmpdir());
@@ -5099,6 +5239,7 @@ TEST(tool_corrupt_store_cleanup_guard_is_balanced_and_not_nested) {
     };
     cbm_mcp_server_set_project_mutation_guard(adr_srv, mcp_mutation_guard_probe_begin,
                                               mcp_mutation_guard_probe_end, &adr_probe);
+    cbm_mcp_server_set_project_mutation_try_guard(adr_srv, mcp_mutation_guard_probe_try_begin);
     resp = cbm_mcp_handle_tool(adr_srv, "manage_adr",
                                "{\"project\":\"guard-corrupt-project\",\"mode\":\"get\"}");
     free(resp);
@@ -5123,9 +5264,10 @@ TEST(tool_corrupt_store_cleanup_guard_is_balanced_and_not_nested) {
     ASSERT_TRUE(query_probe.db_exists_at_begin);
     ASSERT_FALSE(query_probe.db_exists_at_end);
     ASSERT_TRUE(adr_quarantined);
-    ASSERT_EQ(adr_probe.begin_count, 1);
+    ASSERT_EQ(adr_probe.begin_count, 0);
+    ASSERT_EQ(adr_probe.try_begin_count, 1);
     ASSERT_EQ(adr_probe.end_count, 1);
-    ASSERT_STR_EQ(adr_probe.begin_projects[0], project);
+    ASSERT_STR_EQ(adr_probe.try_begin_projects[0], project);
     ASSERT_STR_EQ(adr_probe.end_projects[0], project);
     ASSERT_TRUE(adr_probe.db_exists_at_begin);
     ASSERT_FALSE(adr_probe.db_exists_at_end);
@@ -5199,6 +5341,102 @@ TEST(tool_corrupt_store_cleanup_guard_denial_preserves_db_and_wal) {
     ASSERT_TRUE(wal_unchanged);
     ASSERT_EQ(backup_count, 0);
     ASSERT_EQ(artifact_count, 0);
+    PASS();
+}
+
+/* A read must not wait for corrupt-store recovery. When another process owns
+ * that lease, distinguish the retryable busy state from an absent project. */
+TEST(tool_manage_adr_corrupt_store_busy_is_retryable) {
+    char cache[256];
+    snprintf(cache, sizeof(cache), "%s/cbm-mcp-adr-corrupt-busy-XXXXXX", cbm_tmpdir());
+    ASSERT_NOT_NULL(cbm_mkdtemp(cache));
+
+    const char *saved_cache = getenv("CBM_CACHE_DIR");
+    char *saved_cache_copy = saved_cache ? strdup(saved_cache) : NULL;
+    cbm_setenv("CBM_CACHE_DIR", cache, 1);
+
+    const char *project = "guard-adr-corrupt-busy";
+    char db_path[CBM_SZ_1K];
+    snprintf(db_path, sizeof(db_path), "%s/%s.db", cache, project);
+    ASSERT_TRUE(mcp_make_corrupt_project_store(cache, project));
+
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    mcp_mutation_guard_probe_t probe = {.deny_try_begin_call = 1};
+    cbm_mcp_server_set_project_mutation_guard(srv, mcp_mutation_guard_probe_begin,
+                                              mcp_mutation_guard_probe_end, &probe);
+    cbm_mcp_server_set_project_mutation_try_guard(srv, mcp_mutation_guard_probe_try_begin);
+
+    char *resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                                     "{\"project\":\"guard-adr-corrupt-busy\",\"mode\":\"get\"}");
+    bool retryable_busy = resp && strstr(resp, "project is busy; retry after indexing") &&
+                          response_contains_json_fragment(resp, "\"isError\":true");
+    bool db_preserved = cbm_file_exists(db_path);
+    char unexpected_backup[CBM_SZ_1K];
+    int backup_count =
+        mcp_find_corrupt_backups(cache, project, unexpected_backup, sizeof(unexpected_backup));
+
+    free(resp);
+    cbm_mcp_server_free(srv);
+    mcp_cleanup_corrupt_backups(cache, project);
+    cleanup_project_db(cache, project);
+    restore_cache_dir(saved_cache_copy);
+    free(saved_cache_copy);
+    cbm_rmdir(cache);
+
+    ASSERT_TRUE(retryable_busy);
+    ASSERT_EQ(probe.begin_count, 0);
+    ASSERT_EQ(probe.try_begin_count, 1);
+    ASSERT_EQ(probe.end_count, 0);
+    ASSERT_TRUE(db_preserved);
+    ASSERT_EQ(backup_count, 0);
+    PASS();
+}
+
+TEST(tool_manage_adr_corrupt_store_missing_try_guard_reports_configuration) {
+    char cache[256];
+    snprintf(cache, sizeof(cache), "%s/cbm-mcp-adr-corrupt-config-XXXXXX", cbm_tmpdir());
+    ASSERT_NOT_NULL(cbm_mkdtemp(cache));
+
+    const char *saved_cache = getenv("CBM_CACHE_DIR");
+    char *saved_cache_copy = saved_cache ? strdup(saved_cache) : NULL;
+    cbm_setenv("CBM_CACHE_DIR", cache, 1);
+
+    const char *project = "guard-adr-corrupt-config";
+    char db_path[CBM_SZ_1K];
+    snprintf(db_path, sizeof(db_path), "%s/%s.db", cache, project);
+    ASSERT_TRUE(mcp_make_corrupt_project_store(cache, project));
+
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    mcp_mutation_guard_probe_t probe = {0};
+    cbm_mcp_server_set_project_mutation_guard(srv, mcp_mutation_guard_probe_begin,
+                                              mcp_mutation_guard_probe_end, &probe);
+
+    char *resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                                     "{\"project\":\"guard-adr-corrupt-config\",\"mode\":\"get\"}");
+    bool missing_try_guard =
+        resp && strstr(resp, "project recovery requires a nonblocking mutation guard") &&
+        response_contains_json_fragment(resp, "\"isError\":true");
+    bool db_preserved = cbm_file_exists(db_path);
+    char unexpected_backup[CBM_SZ_1K];
+    int backup_count =
+        mcp_find_corrupt_backups(cache, project, unexpected_backup, sizeof(unexpected_backup));
+
+    free(resp);
+    cbm_mcp_server_free(srv);
+    mcp_cleanup_corrupt_backups(cache, project);
+    cleanup_project_db(cache, project);
+    restore_cache_dir(saved_cache_copy);
+    free(saved_cache_copy);
+    cbm_rmdir(cache);
+
+    ASSERT_TRUE(missing_try_guard);
+    ASSERT_EQ(probe.begin_count, 0);
+    ASSERT_EQ(probe.try_begin_count, 0);
+    ASSERT_EQ(probe.end_count, 0);
+    ASSERT_TRUE(db_preserved);
+    ASSERT_EQ(backup_count, 0);
     PASS();
 }
 
@@ -9919,7 +10157,9 @@ SUITE(mcp_mutation_guard) {
     RUN_TEST(tool_delete_project_mutation_guard_blocks_then_releases);
     RUN_TEST(tool_index_repository_mutation_guard_blocks_before_local_worker);
     RUN_TEST(tool_manage_adr_mutation_guard_balances_success);
-    RUN_TEST(tool_manage_adr_mutation_guard_releases_on_missing_store);
+    RUN_TEST(tool_manage_adr_read_paths_skip_blocking_mutation_guard);
+    RUN_TEST(tool_manage_adr_read_missing_store_skips_mutation_guard);
+    RUN_TEST(tool_manage_adr_legacy_migration_tries_without_blocking);
     RUN_TEST(tool_raw_dispatch_cancel_is_scoped_non_mutating_and_next_request_clean);
     RUN_TEST(tool_outer_request_scope_preserves_predispatch_cancel);
     RUN_TEST(tool_index_repository_early_raw_cancel_survives_index_entry);
@@ -9932,6 +10172,8 @@ SUITE(mcp_mutation_guard) {
     RUN_TEST(tool_cross_repo_honors_source_name_override);
     RUN_TEST(tool_corrupt_store_cleanup_guard_is_balanced_and_not_nested);
     RUN_TEST(tool_corrupt_store_cleanup_guard_denial_preserves_db_and_wal);
+    RUN_TEST(tool_manage_adr_corrupt_store_busy_is_retryable);
+    RUN_TEST(tool_manage_adr_corrupt_store_missing_try_guard_reports_configuration);
     RUN_TEST(tool_corrupt_store_cleanup_rechecks_generation_after_guard_wait);
     RUN_TEST(tool_corrupt_store_cleanup_preserves_existing_backup_and_uses_unique_name);
     RUN_TEST(tool_corrupt_store_cleanup_publish_failure_preserves_db_and_wal);


### PR DESCRIPTION
## Summary
- keep `manage_adr(get|sections)` on query-only store access while a same-project reindex holds the mutation lease
- preserve serialized `manage_adr(update|store)` writes through the native project-lock manager
- return legacy-file ADR content immediately; migration attempts persistence only after a nonblocking lease and rechecks the current SQLite generation before writing
- forward the HTTP server nonblocking mutation callback to its embedded MCP server
- distinguish a retryable corrupt-store recovery lease conflict from an embedding that lacks a nonblocking callback
- document that cached ADR reads can temporarily return pre-publication content after an out-of-process reindex

## Environment observed
- macOS arm64
- multiple independent MCP/CLI processes sharing one `CBM_CACHE_DIR`

## Regression coverage
- stored ADR get and sections bypass a busy blocking mutation guard
- update remains serialized through the primary mutation guard
- a busy legacy migration returns readable content without blocking; a later successful try-acquire persists it
- corrupt-store ADR reads use the nonblocking path, preserve the live generation when busy, and report a missing try callback as a configuration error
- HTTP embeds the same nonblocking callback used by its existing mutation guard

## Verification
- `make -f Makefile.cbm test-focused TEST_SUITES=mcp_mutation_guard` (24 passed)
- `git diff --check`
- `bash scripts/lint.sh --ci`
- `bash scripts/test.sh` (6801 passed, 0 failed, 4 skipped across 120 suites; watchdog and security regressions passed)