### PR TITLE
fix(smoke): serve the -portable linux asset from the artifact server

### DIFF
--- a/.github/workflows/_smoke.yml
+++ b/.github/workflows/_smoke.yml
@@ -114,6 +114,19 @@ jobs:
             cp "/tmp/smoke-server/codebase-memory-mcp${SUFFIX}-${OS}-${ARCH}.tar.gz" \
                "/tmp/smoke-server/codebase-memory-mcp-${OS}-${ARCH}.tar.gz"
           fi
+          # The linux binary self-updates from the fully-static "-portable" asset
+          # (build_update_url in src/cli/cli.c appends -portable on linux; _build.yml's
+          # build-linux-portable job ships it), so the smoke server must serve that name
+          # too -- otherwise `update` 404s and Phase 14 fails. Mirror the tarball(s) under
+          # the -portable name on linux only.
+          if [ "$OS" = "linux" ]; then
+            cp "/tmp/smoke-server/codebase-memory-mcp${SUFFIX}-${OS}-${ARCH}.tar.gz" \
+               "/tmp/smoke-server/codebase-memory-mcp${SUFFIX}-${OS}-${ARCH}-portable.tar.gz"
+            if [ -n "$SUFFIX" ]; then
+              cp "/tmp/smoke-server/codebase-memory-mcp${SUFFIX}-${OS}-${ARCH}-portable.tar.gz" \
+                 "/tmp/smoke-server/codebase-memory-mcp-${OS}-${ARCH}-portable.tar.gz"
+            fi
+          fi
           cd /tmp/smoke-server
           sha256sum *.tar.gz > checksums.txt 2>/dev/null || shasum -a 256 *.tar.gz > checksums.txt
           python3 -m http.server 18080 -d /tmp/smoke-server &


### PR DESCRIPTION

The dry-run smoke Phase 14 runs the binary's real `update` command, which on
linux downloads the fully-static "-portable" asset (build_update_url in
src/cli/cli.c appends -portable on linux; _build.yml's build-linux-portable job
ships codebase-memory-mcp[-ui]-linux-<arch>-portable.tar.gz). The smoke artifact
server only served the non-portable name, so `update` 404'd and the config-
refresh assertion failed on every linux smoke leg. The mismatch (the smoke half
of the -portable delivery change) was masked until every smoke leg became a
required gate.

Mirror the tarball under the -portable name on linux (standard and ui) so the
served names match build_update_url; checksums.txt globs *.tar.gz and picks up
the new files. Verified the fixed logic serves the exact name the binary
requests for both variants; the gating smoke Phase 14 is the regression guard.

## Root cause
The release dry run's smoke Phase 14 runs the binary's real `update`, which on linux requests the static `-portable` asset (`build_update_url`). The smoke artifact server (`_smoke.yml`) only served the non-`-portable` name → `update` 404'd → config-refresh assertion failed on **every** linux smoke leg (ui + standard). Masked until #882 made each smoke leg a required gate; surfaced in dry run 28748103992.

## Fix
Serve the `-portable` tarball name on linux (both variants). Real releases already ship it (`_build.yml` `build-linux-portable`); only the fake smoke server was missing it. Verified locally that the served names now match what the binary requests.