### PR TITLE
feat(extract): preserve generic type info for symbol-keyed messaging frameworks

### DIFF
--- a/internal/cbm/cbm.h
+++ b/internal/cbm/cbm.h
@@ -6,6 +6,15 @@
 #include "arena.h"
 #include "tree_sitter/api.h"
 
+/* Extraction-schema version stamped into cache databases (PRAGMA
+ * user_version). Incremental indexing reuses unchanged files' nodes verbatim,
+ * so a cache written by older extractors would silently lack newer property
+ * fields forever; the pipeline treats a version mismatch as "full reindex".
+ * Bump when extractors emit new persisted fields.
+ *   1: base_types on class-likes (heritage with generic args, C#/Java)
+ *   2: type_params on class-likes (declared generic parameter names, C#/Java) */
+#define CBM_CACHE_SCHEMA_VERSION 2
+
 // Language enum mirrors lang.Language in Go.
 // Order must match lang_specs.c tables.
 typedef enum {
@@ -189,6 +198,10 @@ typedef struct {
     const char *parent_class;  // enclosing class QN for methods (NULL if none)
     const char **decorators;   // NULL-terminated array (NULL if none)
     const char **base_classes; // NULL-terminated array (NULL if none)
+    const char **base_types;   // like base_classes but with generic type args
+                               // preserved (IHandler<Foo>); C#/Java, else NULL
+    const char **type_params;  // generic parameter names the declaration itself
+                               // declares (Handler<T> -> ["T"]); C#/Java, else NULL
     const char **param_names;  // NULL-terminated array (NULL if none)
     const char **param_types;  // NULL-terminated array (NULL if none)
     const char **return_types; // NULL-terminated array (NULL if none)
@@ -610,5 +623,20 @@ void cbm_extract_k8s(CBMExtractCtx *ctx);
 // instead of scattering `|| strcmp(label,"Struct")==0` across the tree.
 // `label` may be NULL (returns false). Defined in helpers.c.
 bool cbm_label_is_type_like(const char *label);
+
+// Extracts the single plain type argument of a generic invocation's callee
+// text: "x.AddPublication<Order.Accepted>" -> "Accepted" (namespace dropped).
+// Returns 0 unless the callee carries exactly one non-nested, single type
+// argument. Used by the calls passes to keep a type-reference edge for
+// generic invocations of EXTERNAL methods (messaging registrations are the
+// canonical case) whose own resolution fails. Defined in helpers.c.
+int cbm_generic_type_arg(const char *callee, char *out, size_t out_sz);
+
+// Extracts the type constructed by a `new T(...)`/`new T{...}` argument
+// expression ("new Order.Accepted { X = 1 }" -> "Accepted"). Companion to
+// cbm_generic_type_arg for calls that carry the type reference in an argument
+// rather than a generic slot (`publisher.PublishAsync(new OrderAccepted{...})`).
+// Defined in helpers.c.
+int cbm_ctor_arg_type(const char *expr, char *out, size_t out_sz);
 
 #endif // CBM_H

--- a/internal/cbm/extract_defs.c
+++ b/internal/cbm/extract_defs.c
@@ -2161,6 +2161,172 @@ static const char **extract_julia_base_classes(CBMArena *a, TSNode node, const c
     return result;
 }
 
+/* extract_base_types — heritage entries with generic type arguments preserved
+ * (IHandlerAsync<Foo> stays IHandlerAsync<Foo>), complementing
+ * extract_base_classes, whose stripped names feed INHERITS resolution.
+ * Symbol-keyed messaging frameworks (JustSaying, MassTransit, ...) carry the
+ * message TYPE in the generic slot, so graph consumers need the full text.
+ * Additive: captured for C# and Java; NULL for other languages until needed. */
+static const char **extract_base_types(CBMArena *a, TSNode node, const char *source,
+                                       CBMLanguage lang) {
+    const char *bases[MAX_BASES];
+    int count = 0;
+
+    if (lang == CBM_LANG_CSHARP) {
+        uint32_t cc = ts_node_child_count(node);
+        for (uint32_t i = 0; i < cc; i++) {
+            TSNode child = ts_node_child(node, i);
+            if (strcmp(ts_node_type(child), "base_list") != 0) {
+                continue;
+            }
+            uint32_t bnc = ts_node_named_child_count(child);
+            for (uint32_t bi = 0; bi < bnc && count < MAX_BASES_MINUS_1; bi++) {
+                TSNode bc = ts_node_named_child(child, bi);
+                const char *bk = ts_node_type(bc);
+                char *text = NULL;
+                if (strcmp(bk, "identifier") == 0 || strcmp(bk, "generic_name") == 0 ||
+                    strcmp(bk, "qualified_name") == 0) {
+                    text = cbm_node_text(a, bc, source);
+                } else {
+                    TSNode inner = ts_node_named_child(bc, 0);
+                    if (!ts_node_is_null(inner)) {
+                        text = cbm_node_text(a, inner, source);
+                    }
+                }
+                if (text && text[0]) {
+                    bases[count++] = text;
+                }
+            }
+        }
+    } else if (lang == CBM_LANG_JAVA) {
+        /* superclass field: `extends Base<T>` — the field's named child is the
+         * type node (type_identifier | generic_type | scoped_type_identifier). */
+        TSNode sc = ts_node_child_by_field_name(node, TS_FIELD("superclass"));
+        if (!ts_node_is_null(sc)) {
+            uint32_t nc = ts_node_named_child_count(sc);
+            for (uint32_t i = 0; i < nc && count < MAX_BASES_MINUS_1; i++) {
+                char *t = cbm_node_text(a, ts_node_named_child(sc, i), source);
+                if (t && t[0]) {
+                    bases[count++] = t;
+                }
+            }
+        }
+        /* `implements IFoo<X>, Closeable` / interface `extends A, B` — the
+         * heritage child wraps a (interface_)type_list of type nodes. */
+        uint32_t cc = ts_node_named_child_count(node);
+        for (uint32_t i = 0; i < cc; i++) {
+            TSNode child = ts_node_named_child(node, i);
+            const char *ck = ts_node_type(child);
+            if (strcmp(ck, "super_interfaces") != 0 && strcmp(ck, "extends_interfaces") != 0) {
+                continue;
+            }
+            uint32_t inc = ts_node_named_child_count(child);
+            for (uint32_t j = 0; j < inc; j++) {
+                TSNode lst = ts_node_named_child(child, j);
+                const char *lk = ts_node_type(lst);
+                if (strcmp(lk, "type_list") != 0 && strcmp(lk, "interface_type_list") != 0) {
+                    continue;
+                }
+                uint32_t tn = ts_node_named_child_count(lst);
+                for (uint32_t k = 0; k < tn && count < MAX_BASES_MINUS_1; k++) {
+                    char *t = cbm_node_text(a, ts_node_named_child(lst, k), source);
+                    if (t && t[0]) {
+                        bases[count++] = t;
+                    }
+                }
+            }
+        }
+    }
+
+    if (count == 0) {
+        return NULL;
+    }
+    const char **result =
+        (const char **)cbm_arena_alloc(a, (size_t)(count + NULL_TERM) * sizeof(const char *));
+    if (!result) {
+        return NULL;
+    }
+    for (int j = 0; j < count; j++) {
+        result[j] = bases[j];
+    }
+    result[count] = NULL;
+    return result;
+}
+
+/* extract_type_params — the generic parameter NAMES a class-like declaration
+ * itself declares (class RetryingHandler<THandler, TPayload> ->
+ * ["THandler","TPayload"]). Heritage-chain resolution needs them to tell an
+ * open generic base (IHandler<TPayload> where TPayload is the declarer's own
+ * parameter) from a closed one (IHandler<OrderAccepted>). Additive: captured
+ * for C# and Java alongside base_types; NULL for other languages until needed. */
+static const char **extract_type_params(CBMArena *a, TSNode node, const char *source,
+                                        CBMLanguage lang) {
+    if (lang != CBM_LANG_CSHARP && lang != CBM_LANG_JAVA) {
+        return NULL;
+    }
+    /* Scan direct children, like extract_base_types does for base_list: the
+     * list node is type_parameter_list in C# and type_parameters in Java,
+     * both holding type_parameter children. */
+    TSNode list;
+    bool found = false;
+    uint32_t cc = ts_node_child_count(node);
+    for (uint32_t ci = 0; ci < cc && !found; ci++) {
+        TSNode child = ts_node_child(node, ci);
+        const char *ck = ts_node_type(child);
+        if (strcmp(ck, "type_parameter_list") == 0 || strcmp(ck, "type_parameters") == 0) {
+            list = child;
+            found = true;
+        }
+    }
+    if (!found) {
+        return NULL;
+    }
+    const char *params[MAX_BASES];
+    int count = 0;
+    uint32_t nc = ts_node_named_child_count(list);
+    for (uint32_t i = 0; i < nc && count < MAX_BASES_MINUS_1; i++) {
+        TSNode tp = ts_node_named_child(list, i);
+        if (strcmp(ts_node_type(tp), "type_parameter") != 0) {
+            continue;
+        }
+        /* C# names the parameter identifier via a field; Java has no field —
+         * the name is the first (type_)identifier child, with any bound
+         * wrapped separately in type_bound. */
+        TSNode name = ts_node_child_by_field_name(tp, TS_FIELD("name"));
+        if (ts_node_is_null(name)) {
+            uint32_t tnc = ts_node_named_child_count(tp);
+            for (uint32_t j = 0; j < tnc; j++) {
+                TSNode cand = ts_node_named_child(tp, j);
+                const char *ct = ts_node_type(cand);
+                if (strcmp(ct, "identifier") == 0 || strcmp(ct, "type_identifier") == 0) {
+                    name = cand;
+                    break;
+                }
+            }
+        }
+        if (ts_node_is_null(name)) {
+            continue;
+        }
+        char *t = cbm_node_text(a, name, source);
+        if (t && t[0]) {
+            params[count++] = t;
+        }
+    }
+    if (count == 0) {
+        return NULL;
+    }
+    const char **result =
+        (const char **)cbm_arena_alloc(a, (size_t)(count + NULL_TERM) * sizeof(const char *));
+    if (!result) {
+        return NULL;
+    }
+    for (int j = 0; j < count; j++) {
+        result[j] = params[j];
+    }
+    result[count] = NULL;
+    return result;
+}
+
 static const char **extract_base_classes(CBMArena *a, TSNode node, const char *source,
                                          CBMLanguage lang) {
     // Languages whose heritage is not exposed via a tree-sitter field need
@@ -3633,6 +3799,8 @@ static void extract_class_def(CBMExtractCtx *ctx, TSNode node, const CBMLangSpec
     def.lines = (int)(def.end_line - def.start_line + TS_LINE_OFFSET);
     def.is_exported = cbm_is_exported(name, ctx->language);
     def.base_classes = extract_base_classes(a, node, ctx->source, ctx->language);
+    def.base_types = extract_base_types(a, node, ctx->source, ctx->language);
+    def.type_params = extract_type_params(a, node, ctx->source, ctx->language);
     def.decorators = extract_decorators(a, node, ctx->source, ctx->language, spec);
     def.docstring = extract_docstring(a, node, ctx->source, ctx->language);
 

--- a/internal/cbm/helpers.c
+++ b/internal/cbm/helpers.c
@@ -1443,3 +1443,85 @@ int cbm_classify_string(const char *str, int len) {
 
     return NOT_FOUND;
 }
+
+/* cbm_generic_type_arg — single plain type argument of a generic invocation.
+ * "x.AddPublication<Order.Accepted>" -> "Accepted"; 0 when the callee has no
+ * generic argument, a nested one (<A<B>>), or a list (<A,B>) — those carry no
+ * single symbol reference. See cbm.h for the consumer contract. */
+int cbm_generic_type_arg(const char *callee, char *out, size_t out_sz) {
+    if (!callee || out_sz == 0) {
+        return 0;
+    }
+    const char *lt = strchr(callee, '<');
+    const char *gt = strrchr(callee, '>');
+    if (!lt || lt == callee || !gt || gt < lt + 1) {
+        return 0;
+    }
+    const char *start = lt + 1;
+    const char *end = gt;
+    while (start < end && (*start == ' ' || *start == '\t')) {
+        start++;
+    }
+    while (end > start && (end[-1] == ' ' || end[-1] == '\t')) {
+        end--;
+    }
+    if (start >= end) {
+        return 0;
+    }
+    for (const char *p = start; p < end; p++) {
+        if (*p == '<' || *p == ',') {
+            return 0;
+        }
+        if (*p == '.') {
+            start = p + 1; /* drop namespace qualification as we scan */
+        }
+    }
+    size_t n = (size_t)(end - start);
+    if (n == 0 || n >= out_sz) {
+        return 0;
+    }
+    memcpy(out, start, n);
+    out[n] = '\0';
+    return 1;
+}
+
+/* cbm_ctor_arg_type — type constructed by a `new T(...)` / `new T{...}`
+ * argument expression: "new Order.Accepted { X = 1 }" -> "Accepted". 0 when
+ * the expression is not an object creation or the type token is empty. */
+int cbm_ctor_arg_type(const char *expr, char *out, size_t out_sz) {
+    if (!expr || out_sz == 0) {
+        return 0;
+    }
+    while (*expr == ' ' || *expr == '\t' || *expr == '\n' || *expr == '\r') {
+        expr++;
+    }
+    if (strncmp(expr, "new", 3) != 0) {
+        return 0;
+    }
+    const char *p = expr + 3;
+    if (*p != ' ' && *p != '\t' && *p != '\n' && *p != '\r') {
+        return 0;
+    }
+    while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r') {
+        p++;
+    }
+    const char *start = p;
+    const char *last_seg = p;
+    while (*p && *p != '(' && *p != '{' && *p != '<' && *p != ' ' && *p != '\t' && *p != '\n' &&
+           *p != '\r') {
+        if (*p == '.') {
+            last_seg = p + 1;
+        }
+        p++;
+    }
+    if (p == start || p == last_seg) {
+        return 0;
+    }
+    size_t n = (size_t)(p - last_seg);
+    if (n >= out_sz) {
+        return 0;
+    }
+    memcpy(out, last_seg, n);
+    out[n] = '\0';
+    return 1;
+}

--- a/src/pipeline/pass_calls.c
+++ b/src/pipeline/pass_calls.c
@@ -417,6 +417,46 @@ static const cbm_gbuf_node_t *calls_find_source(cbm_pipeline_ctx_t *ctx, const c
     return src;
 }
 
+/* Generic-invocation fallback: `x.AddPublication<OrderAccepted>()` — the
+ * method lives in an EXTERNAL library so its own resolution fails, but the
+ * TYPE ARGUMENT is a project symbol reference the graph must not lose (it is
+ * the only edge tying the caller to that type; messaging registrations are
+ * the canonical case). Resolve the type argument instead and emit the CALLS
+ * edge onto the type's node — the callee text (generics included) rides in
+ * the edge props. Mirrored in pass_parallel.c::resolve_file_calls. */
+static int emit_generic_type_arg_edge(cbm_pipeline_ctx_t *ctx, const CBMCall *call,
+                                      const cbm_gbuf_node_t *source_node, const char *module_qn,
+                                      const char **imp_keys, const char **imp_vals, int imp_count) {
+    char tyname[256];
+    const char *strategy = "generic_type_arg";
+    if (!cbm_generic_type_arg(call->callee_name, tyname, sizeof(tyname))) {
+        /* No generic slot — the type reference may ride in an argument:
+         * `publisher.PublishAsync(new OrderAccepted {...})`. */
+        strategy = "ctor_arg_type";
+        int found = 0;
+        for (int i = 0; i < call->arg_count && !found; i++) {
+            found = cbm_ctor_arg_type(call->args[i].expr, tyname, sizeof(tyname));
+        }
+        if (!found) {
+            return 0;
+        }
+    }
+    cbm_resolution_t tres =
+        cbm_registry_resolve(ctx->registry, tyname, module_qn, imp_keys, imp_vals, imp_count);
+    if (!tres.qualified_name || tres.qualified_name[0] == '\0') {
+        return 0;
+    }
+    const cbm_gbuf_node_t *target = cbm_gbuf_find_by_qn(ctx->gbuf, tres.qualified_name);
+    if (!target || target->id == source_node->id) {
+        return 0;
+    }
+    cbm_resolution_t res = tres;
+    res.strategy = strategy;
+    emit_classified_edge(ctx, call, source_node, target, &res, module_qn, imp_keys, imp_vals,
+                         imp_count);
+    return 1;
+}
+
 /* Resolve one call and emit the appropriate edge. Returns 1 if resolved, 0 if not. */
 static int resolve_single_call(cbm_pipeline_ctx_t *ctx, CBMCall *call,
                                const CBMResolvedCallArray *lsp_calls, const char *rel,
@@ -497,6 +537,10 @@ static int resolve_single_call(cbm_pipeline_ctx_t *ctx, CBMCall *call,
                 return SKIP_ONE;
             }
         }
+        if (emit_generic_type_arg_edge(ctx, call, source_node, module_qn, imp_keys, imp_vals,
+                                       imp_count)) {
+            return SKIP_ONE;
+        }
         return 0;
     }
 
@@ -535,6 +579,12 @@ static int resolve_single_call(cbm_pipeline_ctx_t *ctx, CBMCall *call,
 
     const cbm_gbuf_node_t *target_node = cbm_gbuf_find_by_qn(ctx->gbuf, res.qualified_name);
     if (!target_node || source_node->id == target_node->id) {
+        /* Resolved to an unindexed QN (external library) — keep the
+         * type-argument reference when the invocation carries one. */
+        if (!target_node && emit_generic_type_arg_edge(ctx, call, source_node, module_qn, imp_keys,
+                                                       imp_vals, imp_count)) {
+            return SKIP_ONE;
+        }
         return 0;
     }
     emit_classified_edge(ctx, call, source_node, target_node, &res, module_qn, imp_keys, imp_vals,

--- a/src/pipeline/pass_definitions.c
+++ b/src/pipeline/pass_definitions.c
@@ -257,6 +257,8 @@ static void build_def_props(char *buf, size_t bufsize, const CBMDefinition *def)
     append_json_string(buf, bufsize, &pos, "parent_class", def->parent_class);
     append_json_str_array(buf, bufsize, &pos, "decorators", def->decorators);
     append_json_str_array(buf, bufsize, &pos, "base_classes", def->base_classes);
+    append_json_str_array(buf, bufsize, &pos, "base_types", def->base_types);
+    append_json_str_array(buf, bufsize, &pos, "type_params", def->type_params);
     append_json_str_array(buf, bufsize, &pos, "param_names", def->param_names);
     append_json_str_array(buf, bufsize, &pos, "param_types", def->param_types);
     append_json_string(buf, bufsize, &pos, "route_path", def->route_path);

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -300,6 +300,8 @@ static void build_def_props(char *buf, size_t bufsize, const CBMDefinition *def)
     append_json_string(buf, bufsize, &pos, "parent_class", def->parent_class);
     append_json_str_array(buf, bufsize, &pos, "decorators", def->decorators);
     append_json_str_array(buf, bufsize, &pos, "base_classes", def->base_classes);
+    append_json_str_array(buf, bufsize, &pos, "base_types", def->base_types);
+    append_json_str_array(buf, bufsize, &pos, "type_params", def->type_params);
     append_json_str_array(buf, bufsize, &pos, "param_names", def->param_names);
     append_json_str_array(buf, bufsize, &pos, "param_types", def->param_types);
     append_json_string(buf, bufsize, &pos, "route_path", def->route_path);
@@ -1739,6 +1741,46 @@ static void lsp_idx_free_key(const char *key, void *value, void *ud) {
 }
 
 /* Resolve calls for one file and emit CALLS/HTTP_CALLS/ASYNC_CALLS edges. */
+/* Generic-invocation fallback — mirrors pass_calls.c::emit_generic_type_arg_edge:
+ * an external method invoked with a generic type argument keeps a CALLS edge
+ * onto the TYPE's node (the type argument is the project symbol reference the
+ * graph must not lose; messaging registrations are the canonical case). */
+static int emit_generic_type_arg_edge_par(resolve_ctx_t *rc, resolve_worker_state_t *ws,
+                                          const CBMCall *call,
+                                          const cbm_gbuf_node_t *source_node,
+                                          const char *module_qn, const char **imp_keys,
+                                          const char **imp_vals, int imp_count) {
+    char tyname[256];
+    const char *strategy = "generic_type_arg";
+    if (!cbm_generic_type_arg(call->callee_name, tyname, sizeof(tyname))) {
+        /* No generic slot — the type reference may ride in an argument:
+         * `publisher.PublishAsync(new OrderAccepted {...})`. Mirrors pass_calls.c. */
+        strategy = "ctor_arg_type";
+        int found = 0;
+        for (int i = 0; i < call->arg_count && !found; i++) {
+            found = cbm_ctor_arg_type(call->args[i].expr, tyname, sizeof(tyname));
+        }
+        if (!found) {
+            return 0;
+        }
+    }
+    cbm_resolution_t tres =
+        cbm_registry_resolve(rc->registry, tyname, module_qn, imp_keys, imp_vals, imp_count);
+    if (!tres.qualified_name || tres.qualified_name[0] == '\0') {
+        return 0;
+    }
+    const cbm_gbuf_node_t *target = cbm_gbuf_find_by_qn(rc->main_gbuf, tres.qualified_name);
+    if (!target || target->id == source_node->id) {
+        return 0;
+    }
+    cbm_resolution_t res = tres;
+    res.strategy = strategy;
+    emit_service_edge(ws->local_edge_buf, source_node, target, call, &res, module_qn,
+                      rc->registry, rc->main_gbuf, imp_keys, imp_vals, imp_count);
+    ws->calls_resolved++;
+    return 1;
+}
+
 static void resolve_file_calls(resolve_ctx_t *rc, resolve_worker_state_t *ws, CBMFileResult *result,
                                const char *rel, const char *module_qn, const char **imp_keys,
                                const char **imp_vals, int imp_count, CBMLanguage lang) {
@@ -1897,6 +1939,10 @@ static void resolve_file_calls(resolve_ctx_t *rc, resolve_worker_state_t *ws, CB
                 emit_service_edge(ws->local_edge_buf, source_node, source_node, call, &fake_res,
                                   module_qn, rc->registry, rc->main_gbuf, imp_keys, imp_vals,
                                   imp_count);
+            } else {
+                /* Generic-invocation fallback — mirrors pass_calls.c. */
+                emit_generic_type_arg_edge_par(rc, ws, call, source_node, module_qn, imp_keys,
+                                               imp_vals, imp_count);
             }
             continue;
         }
@@ -1930,6 +1976,12 @@ static void resolve_file_calls(resolve_ctx_t *rc, resolve_worker_state_t *ws, CB
                                       rc->registry, rc->main_gbuf, imp_keys, imp_vals, imp_count);
                     ws->calls_resolved++;
                 }
+            } else if (!target_node) {
+                /* Resolved to an unindexed QN (external library) — keep the
+                 * type-argument reference when the invocation carries one.
+                 * Mirrors pass_calls.c. */
+                emit_generic_type_arg_edge_par(rc, ws, call, source_node, module_qn, imp_keys,
+                                               imp_vals, imp_count);
             }
             continue;
         }

--- a/src/pipeline/pipeline.c
+++ b/src/pipeline/pipeline.c
@@ -22,6 +22,7 @@ enum { CBM_DIR_PERMS = 0755, PL_RING = 4, PL_RING_MASK = 3, PL_SEQ_PASSES = 6, P
 #include "graph_buffer/graph_buffer.h"
 #include "git/git_context.h"
 #include "store/store.h"
+#include "cbm.h"
 #include "discover/discover.h"
 #include "discover/userconfig.h"
 #include "foundation/platform.h"
@@ -882,15 +883,22 @@ static int try_incremental_or_delete_db(cbm_pipeline_t *p, cbm_file_info_t *file
         int hash_count = 0;
         cbm_store_get_file_hashes(check_store, p->project_name, &hashes, &hash_count);
         cbm_store_free_file_hashes(hashes, hash_count);
+        int cache_ver = cbm_store_user_version(check_store);
         cbm_store_close(check_store);
-        if (hash_count > 0 && file_count <= hash_count + (hash_count / PAIR_LEN)) {
+        /* Incremental reuse copies unchanged files' nodes verbatim, so a cache
+         * written by older extractors would keep their property gaps forever.
+         * A version mismatch therefore routes to full reindex. */
+        if (cache_ver != CBM_CACHE_SCHEMA_VERSION) {
+            cbm_log_info("pipeline.route", "path", "schema_stale_reindex", "cache_version",
+                         itoa_buf(cache_ver), "current_version",
+                         itoa_buf(CBM_CACHE_SCHEMA_VERSION));
+        } else if (hash_count > 0 && file_count <= hash_count + (hash_count / PAIR_LEN)) {
             cbm_log_info("pipeline.route", "path", "incremental", "stored_hashes",
                          itoa_buf(hash_count));
             int rc = cbm_pipeline_run_incremental(p, db_path, files, file_count);
             free(db_path);
             return rc;
-        }
-        if (hash_count > 0) {
+        } else if (hash_count > 0) {
             cbm_log_info("pipeline.route", "path", "mode_change_reindex", "stored_hashes",
                          itoa_buf(hash_count), "discovered", itoa_buf(file_count));
         }
@@ -972,6 +980,11 @@ static int dump_and_persist_hashes(cbm_pipeline_t *p, const cbm_file_info_t *fil
     cbm_log_info("pass.timing", "pass", "dump", "elapsed_ms", itoa_buf((int)elapsed_ms(*t)));
     cbm_store_t *hash_store = cbm_store_open_path(db_path);
     if (hash_store) {
+        /* Stamp the extraction-schema version: the raw btree dump writes a
+         * fresh header, which zeroes any prior PRAGMA user_version. */
+        char ver_sql[48];
+        snprintf(ver_sql, sizeof(ver_sql), "PRAGMA user_version = %d;", CBM_CACHE_SCHEMA_VERSION);
+        cbm_store_exec(hash_store, ver_sql);
         cbm_store_delete_file_hashes(hash_store, p->project_name);
 
         /* Restore the ADR captured before the dump. Surface a failed restore

--- a/src/pipeline/pipeline_incremental.c
+++ b/src/pipeline/pipeline_incremental.c
@@ -18,6 +18,7 @@ enum { INCR_RING_BUF = 4, INCR_RING_MASK = 3, INCR_TS_BUF = 24, INCR_WAL_BUF = 1
 #include <time.h>
 #include "pipeline/pipeline_internal.h"
 #include "store/store.h"
+#include "cbm.h"
 #include "graph_buffer/graph_buffer.h"
 #include "discover/discover.h"
 #include "foundation/log.h"
@@ -649,6 +650,11 @@ static void dump_and_persist(cbm_gbuf_t *gbuf, const char *db_path, const char *
 
     cbm_store_t *hash_store = cbm_store_open_path(db_path);
     if (hash_store) {
+        /* Re-stamp the extraction-schema version — the raw btree dump above
+         * rewrote the header, zeroing PRAGMA user_version. */
+        char ver_sql[48];
+        snprintf(ver_sql, sizeof(ver_sql), "PRAGMA user_version = %d;", CBM_CACHE_SCHEMA_VERSION);
+        cbm_store_exec(hash_store, ver_sql);
         persist_hashes(hash_store, project, files, file_count, mode_skipped, mode_skipped_count);
 
         /* FTS5 rebuild after incremental dump.  The btree dump path bypasses

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -922,6 +922,22 @@ int cbm_store_exec(cbm_store_t *s, const char *sql) {
     return exec_sql(s, sql);
 }
 
+int cbm_store_user_version(cbm_store_t *s) {
+    if (!s || !s->db) {
+        return 0;
+    }
+    sqlite3_stmt *stmt = NULL;
+    if (sqlite3_prepare_v2(s->db, "PRAGMA user_version;", -1, &stmt, NULL) != SQLITE_OK) {
+        return 0;
+    }
+    int v = 0;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        v = sqlite3_column_int(stmt, 0);
+    }
+    sqlite3_finalize(stmt);
+    return v;
+}
+
 const char *cbm_store_error(cbm_store_t *s) {
     return s ? s->errbuf : "null store";
 }

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -216,6 +216,10 @@ const char *cbm_store_db_path(const cbm_store_t *s);
  * Returns false if corruption is detected — caller should delete and re-index. */
 bool cbm_store_check_integrity(cbm_store_t *s);
 
+/* Read the cache's extraction-schema stamp (PRAGMA user_version). 0 for a
+ * never-stamped database. See CBM_CACHE_SCHEMA_VERSION in internal/cbm/cbm.h. */
+int cbm_store_user_version(cbm_store_t *s);
+
 /* Open database for a named project in the default cache dir. */
 cbm_store_t *cbm_store_open(const char *project);
 


### PR DESCRIPTION
## Problem

Symbol-keyed messaging frameworks (JustSaying, MassTransit, and friends) carry the *message type* — the one fact that ties services together — in places the graph currently drops:

1. **Heritage loses generics.** `class OrderAcceptedHandler : IHandlerAsync<OrderAccepted>` is captured as `base_classes: ["IHandlerAsync"]`. Correct for inheritance resolution, but the consumer-side link (`which message does this handler handle?`) is unrecoverable from the graph.
2. **Publisher registrations produce no edge at all.** `bus.AddPublication<OrderAccepted>()` and `publisher.PublishAsync(new OrderAccepted {...})` invoke methods that live in an external package, so call resolution fails and the call is discarded — losing the only reference tying the caller to the message type, even though the type itself is an indexed project symbol.

Together these make pub/sub topologies invisible to graph consumers, while all the needed facts are sitting in the AST.

## Changes

- **`base_types` + `type_params` on class-likes (C#/Java).** `base_types` mirrors `base_classes` with generic arguments intact (`IHandlerAsync<OrderAccepted>`); `type_params` records the parameter names the declaration itself declares (`ScheduledHandler<THandler>` → `["THandler"]`), so consumers can tell an open generic base from a closed one. Additive: `NULL` for other languages, `base_classes` untouched.
- **Generic-invocation fallback edge.** When a call fails to resolve (or resolves to an unindexed external QN), but the callee carries a single plain generic type argument — or an argument of the form `new T(...)` — that resolves to a project symbol, emit the CALLS edge onto the *type's* node with resolution strategy `generic_type_arg` / `ctor_arg_type`. The full callee text still rides in the edge props. Implemented identically in the serial (`pass_calls.c`) and parallel (`pass_parallel.c`) resolvers.
- **Extraction-schema version stamp.** Caches are stamped with `PRAGMA user_version` (`CBM_CACHE_SCHEMA_VERSION`). Incremental indexing reuses unchanged files' nodes verbatim, so a cache written by older extractors would lack the new fields forever on quiet repos; a version mismatch now routes to full reindex. Both dump paths re-stamp after the raw btree dump (which rewrites the header and zeroes `user_version`). This also gives any future extraction change a safe upgrade path.

## Notes

- No behavior change for languages the patch doesn't touch; conservative fallbacks return early on nested (`<A<B>>`) or multi-argument (`<A,B>`) generic slots, which carry no single symbol reference.
- The one-time full reindex on first run after upgrade is intentional (see above).
- Ran `scripts/test.sh` (ASan/UBSan) locally against this branch.

Happy to split into three commits or adjust field naming if you'd prefer.
