### PR TITLE
ci: green the dry-run smoke gate + ship native windows-arm64

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -183,6 +183,75 @@ jobs:
           name: binaries-windows-amd64
           path: "*.zip"
 
+  build-windows-arm64:
+    # Native ARM64 Windows binary via the CLANGARM64 toolchain on the
+    # windows-11-arm runner (the same toolchain the test suite already
+    # exercises). Without it, ARM-Windows users fall back to the x86_64
+    # binary under emulation, and npm/pip on native-ARM Node/Python 404.
+    runs-on: windows-11-arm
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
+        with:
+          msystem: CLANGARM64
+          path-type: inherit
+          install: >-
+            mingw-w64-clang-aarch64-clang
+            mingw-w64-clang-aarch64-zlib
+            make
+            zip
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      - name: Build standard binary
+        shell: msys2 {0}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$VERSION" ]; then
+            scripts/build.sh --version "$VERSION" CC=clang CXX=clang++
+          else
+            scripts/build.sh CC=clang CXX=clang++
+          fi
+
+      - name: Archive standard binary
+        shell: msys2 {0}
+        run: |
+          BIN=build/c/codebase-memory-mcp
+          [ -f "${BIN}.exe" ] && BIN="${BIN}.exe"
+          cp "$BIN" codebase-memory-mcp.exe
+          scripts/gen-third-party-notices.sh THIRD_PARTY_NOTICES.md
+          zip codebase-memory-mcp-windows-arm64.zip codebase-memory-mcp.exe LICENSE install.ps1 THIRD_PARTY_NOTICES.md
+
+      - name: Build UI binary
+        shell: msys2 {0}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$VERSION" ]; then
+            scripts/build.sh --with-ui --version "$VERSION" CC=clang CXX=clang++
+          else
+            scripts/build.sh --with-ui CC=clang CXX=clang++
+          fi
+
+      - name: Archive UI binary
+        shell: msys2 {0}
+        run: |
+          BIN=build/c/codebase-memory-mcp
+          [ -f "${BIN}.exe" ] && BIN="${BIN}.exe"
+          cp "$BIN" codebase-memory-mcp.exe
+          scripts/gen-third-party-notices.sh THIRD_PARTY_NOTICES.md
+          zip codebase-memory-mcp-ui-windows-arm64.zip codebase-memory-mcp.exe LICENSE install.ps1 THIRD_PARTY_NOTICES.md
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binaries-windows-arm64
+          path: "*.zip"
+
   build-linux-portable:
     # Fully static Linux binaries (gcc -static on Ubuntu).
     # Runs on any Linux distro without shared library dependencies.

--- a/.github/workflows/_smoke.yml
+++ b/.github/workflows/_smoke.yml
@@ -37,20 +37,24 @@ jobs:
             {"os":"macos-14","goos":"darwin","goarch":"arm64"},
             {"os":"macos-15-intel","goos":"darwin","goarch":"amd64"}
           ]'
-          # Broad legs reuse existing goos/goarch artifacts on newer/older OS
-          # versions (e.g. ubuntu-22.04 = older glibc) to widen the run-anywhere
-          # signal without building new targets.
+          # Broad legs reuse existing goos/goarch artifacts on additional OS
+          # versions to widen the run-anywhere signal without building new targets.
           # Broad legs are REQUIRED gates (no optional / continue-on-error):
           # every smoke leg must pass. No `optional` flags anywhere.
+          #
+          # NOTE: the *dynamic* linux binary links glibc 2.38+ and cannot run on
+          # older distros by design — older-glibc coverage is the -portable (static)
+          # binary's job, exercised green by the smoke-linux-portable broad legs
+          # (ubuntu-22.04 / 22.04-arm). So the dynamic broad legs stay on
+          # forward-compatible OSes only (macOS); running the dynamic binary on
+          # ubuntu-22.04 would fail Phase 1 (glibc too old), not a real regression.
           BROAD_UNIX='[
-            {"os":"ubuntu-22.04","goos":"linux","goarch":"amd64"},
-            {"os":"ubuntu-22.04-arm","goos":"linux","goarch":"arm64"},
             {"os":"macos-15","goos":"darwin","goarch":"arm64"}
           ]'
-          CORE_WIN='[{"os":"windows-latest"}]'
-          # windows-11-arm runs the shipped x86_64 binary under emulation —
-          # verifies the Windows artifact still launches on ARM hardware.
-          BROAD_WIN='[{"os":"windows-2025"},{"os":"windows-11-arm"}]'
+          CORE_WIN='[{"os":"windows-latest","arch":"amd64"}]'
+          # windows-11-arm now runs the NATIVE arm64 binary (build-windows-arm64),
+          # not the x86_64 binary under emulation — we smoke the artifact we ship.
+          BROAD_WIN='[{"os":"windows-2025","arch":"amd64"},{"os":"windows-11-arm","arch":"arm64"}]'
           CORE_PORTABLE='[
             {"arch":"amd64","runner":"ubuntu-latest"},
             {"arch":"arm64","runner":"ubuntu-24.04-arm"}
@@ -152,6 +156,10 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update -qq && sudo apt-get install -y -qq clamav > /dev/null 2>&1
+          # apt auto-starts the clamav-freshclam daemon, which holds a lock on
+          # freshclam's log/db; stop it so the manual freshclam below can run
+          # (else: "Failed to lock the log file ... Resource temporarily unavailable").
+          sudo systemctl stop clamav-freshclam 2>/dev/null || true
           sudo sed -i 's/^Example/#Example/' /etc/clamav/freshclam.conf 2>/dev/null || true
           grep -q "DatabaseMirror" /etc/clamav/freshclam.conf 2>/dev/null || \
             echo "DatabaseMirror database.clamav.net" | sudo tee -a /etc/clamav/freshclam.conf > /dev/null
@@ -183,23 +191,24 @@ jobs:
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
-          msystem: CLANG64
+          msystem: ${{ matrix.arch == 'arm64' && 'CLANGARM64' || 'CLANG64' }}
           path-type: inherit
           install: >-
-            mingw-w64-clang-x86_64-python3
+            mingw-w64-clang-${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}-python3
             unzip
             zip
             coreutils
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: binaries-windows-amd64
+          name: binaries-windows-${{ matrix.arch }}
 
       - name: Extract binary
         shell: msys2 {0}
         run: |
           SUFFIX=${{ matrix.variant == 'ui' && '-ui' || '' }}
-          unzip -o "codebase-memory-mcp${SUFFIX}-windows-amd64.zip"
+          ARCH=${{ matrix.arch }}
+          unzip -o "codebase-memory-mcp${SUFFIX}-windows-${ARCH}.zip"
           [ -n "$SUFFIX" ] && cp "codebase-memory-mcp${SUFFIX}.exe" codebase-memory-mcp.exe || true
 
       - name: Start artifact server
@@ -208,10 +217,11 @@ jobs:
           mkdir -p /tmp/smoke-server
           cp codebase-memory-mcp.exe /tmp/smoke-server/
           SUFFIX=${{ matrix.variant == 'ui' && '-ui' || '' }}
+          ARCH=${{ matrix.arch }}
           cd /tmp/smoke-server
-          zip -q "codebase-memory-mcp${SUFFIX}-windows-amd64.zip" codebase-memory-mcp.exe
+          zip -q "codebase-memory-mcp${SUFFIX}-windows-${ARCH}.zip" codebase-memory-mcp.exe
           if [ -n "$SUFFIX" ]; then
-            cp "codebase-memory-mcp${SUFFIX}-windows-amd64.zip" "codebase-memory-mcp-windows-amd64.zip"
+            cp "codebase-memory-mcp${SUFFIX}-windows-${ARCH}.zip" "codebase-memory-mcp-windows-${ARCH}.zip"
           fi
           sha256sum *.zip > checksums.txt
           python3 -m http.server 18080 -d /tmp/smoke-server &

--- a/.github/workflows/_soak.yml
+++ b/.github/workflows/_soak.yml
@@ -137,6 +137,58 @@ jobs:
           path: soak-results-query-leak/
           retention-days: 14
 
+  soak-quick-windows-arm64:
+    # Native ARM64 Windows soak (CLANGARM64, no sanitizer — ASan is unavailable
+    # on native ARM64 Windows). Builds from source like soak-quick-windows.
+    runs-on: windows-11-arm
+    timeout-minutes: 300
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
+        with:
+          msystem: CLANGARM64
+          path-type: inherit
+          install: >-
+            mingw-w64-clang-aarch64-clang
+            mingw-w64-clang-aarch64-zlib
+            mingw-w64-clang-aarch64-python3
+            make
+            git
+            coreutils
+      - name: Build
+        shell: msys2 {0}
+        run: scripts/build.sh ${{ inputs.version && format('--version {0}', inputs.version) || '' }} CC=clang CXX=clang++
+      - name: Soak (${{ inputs.duration_minutes }} min)
+        shell: msys2 {0}
+        run: |
+          BIN=build/c/codebase-memory-mcp
+          [ -f "${BIN}.exe" ] && BIN="${BIN}.exe"
+          scripts/soak-test.sh "$BIN" ${{ inputs.duration_minutes }}
+      # #581 guard on Windows — the platform the bug is reported on.
+      - name: Query-leak soak (#581, read-only)
+        shell: msys2 {0}
+        env:
+          CBM_SOAK_MODE: query-leak
+          RESULTS_DIR: soak-results-query-leak
+        run: |
+          BIN=build/c/codebase-memory-mcp
+          [ -f "${BIN}.exe" ] && BIN="${BIN}.exe"
+          scripts/soak-test.sh "$BIN" ${{ inputs.duration_minutes }} --skip-crash-test
+      - name: Upload metrics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: soak-quick-windows-arm64
+          path: soak-results/
+          retention-days: 14
+      - name: Upload query-leak metrics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: soak-query-leak-windows-arm64
+          path: soak-results-query-leak/
+          retention-days: 14
+
   soak-asan:
     if: ${{ inputs.run_asan }}
     strategy:

--- a/install.ps1
+++ b/install.ps1
@@ -31,16 +31,26 @@ foreach ($arg in $args) {
     if ($arg -like "--dir=*") { $InstallDir = $arg.Substring(6) }
 }
 
+# Detect architecture (ARM64 vs x64). PROCESSOR_ARCHITEW6432 is set to ARM64
+# when an x86/x64 process runs under emulation on ARM hardware, so check both to
+# resolve ARM64 even from an emulated shell; anything else falls back to amd64.
+if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64" -or $env:PROCESSOR_ARCHITEW6432 -eq "ARM64") {
+    $Arch = "arm64"
+} else {
+    $Arch = "amd64"
+}
+
 Write-Host "codebase-memory-mcp installer (Windows)"
 Write-Host "  variant: $Variant"
+Write-Host "  arch:    $Arch"
 Write-Host "  target:  $InstallDir\$BinName"
 Write-Host ""
 
 # Build download URL
 if ($Variant -eq "ui") {
-    $Archive = "codebase-memory-mcp-ui-windows-amd64.zip"
+    $Archive = "codebase-memory-mcp-ui-windows-$Arch.zip"
 } else {
-    $Archive = "codebase-memory-mcp-windows-amd64.zip"
+    $Archive = "codebase-memory-mcp-windows-$Arch.zip"
 }
 $Url = "$BaseUrl/$Archive"
 


### PR DESCRIPTION

Two release-blockers surfaced once #882 made every smoke leg a required gate
(continue-on-error previously masked them):

- smoke-unix ran the *dynamic* linux binary on ubuntu-22.04 / 22.04-arm, where
  it cannot start (it links glibc 2.38+) -> Phase 1 died. Older-glibc coverage
  is the -portable (static) binary's job and is green via the smoke-linux-portable
  broad legs, so drop the impossible dynamic broad legs (keep macOS).
- the ClamAV scan died on every linux leg: apt auto-starts the clamav-freshclam
  daemon which holds the freshclam log lock, so the manual freshclam failed with
  "Failed to lock the log file ... Resource temporarily unavailable". Stop the
  daemon first.

Also add native ARM64 Windows as a first-class release target -- the one platform
we test (windows-11-arm) but never shipped:
- build-windows-arm64 job (CLANGARM64) producing codebase-memory-mcp[-ui]-windows-arm64.zip
- smoke-windows is now arch-aware: windows-11-arm smokes the NATIVE arm64 binary
  instead of the x86_64 binary under emulation
- a native soak-quick-windows-arm64 leg (no sanitizer -- ASan is unavailable on
  native ARM64 Windows)
- arm64 detection in install.ps1

release.yml already publishes windows-arm64 (asset filter + merge-multiple) and
build_update_url/detect_arch already resolve it; npm/pip/install.sh compute arm64
already. scoop/winget/chocolatey per-version manifests are updated at release time.