### PR TITLE
fix(cypher): apply distinct before return limits

### DIFF
--- a/src/cypher/cypher.c
+++ b/src/cypher/cypher.c
@@ -4115,7 +4115,7 @@ static void build_return_columns(result_builder_t *rb, cbm_return_clause_t *ret)
 static void execute_return_simple(cbm_return_clause_t *ret, binding_t *bindings, int bind_count,
                                   int max_rows, result_builder_t *rb) {
     int proj_cap = max_rows;
-    if (ret->limit > 0 && !ret->order_by && ret->skip <= 0) {
+    if (ret->limit > 0 && !ret->distinct && !ret->order_by && ret->skip <= 0) {
         proj_cap = ret->limit;
     }
     for (int bi = 0; bi < bind_count && rb->row_count < proj_cap; bi++) {
@@ -4397,11 +4397,11 @@ static void execute_return_clause(cbm_query_t *q, cbm_return_clause_t *ret, bind
         }
     }
 
-    rb_apply_order_by(rb, ret);
-    rb_apply_skip_limit(rb, ret->skip, ret->limit >= 0 ? ret->limit : max_rows);
     if (ret->distinct) {
         rb_apply_distinct(rb);
     }
+    rb_apply_order_by(rb, ret);
+    rb_apply_skip_limit(rb, ret->skip, ret->limit >= 0 ? ret->limit : max_rows);
 }
 
 static int execute_single(cbm_store_t *store, cbm_query_t *q, const char *project, int max_rows,

--- a/tests/test_cypher.c
+++ b/tests/test_cypher.c
@@ -2528,6 +2528,52 @@ TEST(cypher_issue237_distinct_order_limit) {
     PASS();
 }
 
+/* #873: duplicate projected rows must be deduped before ORDER BY + LIMIT */
+TEST(cypher_issue873_distinct_order_limit_dedupes_before_limit) {
+    cbm_store_t *s = setup_cypher_store();
+    cbm_cypher_result_t r = {0};
+    int rc = cbm_cypher_execute(
+        s, "MATCH (n) RETURN DISTINCT n.label AS label ORDER BY label LIMIT 2", "test", 0, &r);
+    ASSERT_EQ(rc, 0);
+    ASSERT_NULL(r.error);
+    ASSERT_EQ(r.row_count, 2);
+    ASSERT_STR_EQ(r.rows[0][0], "Function");
+    ASSERT_STR_EQ(r.rows[1][0], "Module");
+    cbm_cypher_result_free(&r);
+    cbm_store_close(s);
+    PASS();
+}
+
+/* #873: early LIMIT must not truncate rows before DISTINCT for simple RETURN */
+TEST(cypher_issue873_distinct_limit_dedupes_before_limit) {
+    cbm_store_t *s = setup_cypher_store();
+    cbm_cypher_result_t r = {0};
+    int rc = cbm_cypher_execute(
+        s, "MATCH (n) RETURN DISTINCT n.label AS label LIMIT 2", "test", 0, &r);
+    ASSERT_EQ(rc, 0);
+    ASSERT_NULL(r.error);
+    ASSERT_EQ(r.row_count, 2);
+    cbm_cypher_result_free(&r);
+    cbm_store_close(s);
+    PASS();
+}
+
+/* #873: SKIP is applied after DISTINCT and ORDER BY, not before dedupe */
+TEST(cypher_issue873_distinct_order_skip_limit_dedupes_before_skip) {
+    cbm_store_t *s = setup_cypher_store();
+    cbm_cypher_result_t r = {0};
+    int rc = cbm_cypher_execute(
+        s, "MATCH (n) RETURN DISTINCT n.label AS label ORDER BY label SKIP 1 LIMIT 1", "test",
+        0, &r);
+    ASSERT_EQ(rc, 0);
+    ASSERT_NULL(r.error);
+    ASSERT_EQ(r.row_count, 1);
+    ASSERT_STR_EQ(r.rows[0][0], "Module");
+    cbm_cypher_result_free(&r);
+    cbm_store_close(s);
+    PASS();
+}
+
 /* #252: toInteger() */
 TEST(cypher_issue252_tointeger) {
     cbm_store_t *s = setup_cypher_store();
@@ -2669,6 +2715,9 @@ SUITE(cypher) {
     RUN_TEST(cypher_exec_match_all_functions);
     RUN_TEST(cypher_issue240_labels_function);
     RUN_TEST(cypher_issue237_distinct_order_limit);
+    RUN_TEST(cypher_issue873_distinct_order_limit_dedupes_before_limit);
+    RUN_TEST(cypher_issue873_distinct_limit_dedupes_before_limit);
+    RUN_TEST(cypher_issue873_distinct_order_skip_limit_dedupes_before_skip);
     RUN_TEST(cypher_issue252_tointeger);
     RUN_TEST(cypher_issue305_count_star_alias);
     RUN_TEST(cypher_exec_where_eq);


### PR DESCRIPTION
## Summary

- Apply `RETURN DISTINCT` before `ORDER BY`, `SKIP`, and `LIMIT` post-processing.
- Preserve the simple `RETURN ... LIMIT` fast path only for non-`DISTINCT`, non-ordered returns.
- Add regressions for `RETURN DISTINCT` with `ORDER BY/LIMIT`, `LIMIT` only, and `ORDER BY/SKIP/LIMIT`.

## Root Cause

`RETURN` rows were sorted and truncated before de-duplication. When duplicate projected rows appeared before the limit boundary, those duplicates consumed the limit and the final `DISTINCT` pass returned too few rows.

## Test Plan

- `make -f Makefile.cbm build/c/test-runner`
- `./build/c/test-runner 2>&1 | awk '/=== cypher ===/{show=1} show{print} /cypher_parse_unwind_var/{exit}'`
  - Passed the Cypher regression window, including the new issue 873 tests.
- `git diff --check origin/main..HEAD`
- `scripts/test.sh`
  - Failed in the existing incremental/MCP tooling suite with repeated `pipeline.err phase=dump` failures and an AddressSanitizer leak summary.
  - The observed failures were outside the Cypher query execution path changed here.
- `scripts/lint.sh`
  - Failed after installing `clang-tidy`, `clang-format`, and `cppcheck`.
  - `clang-tidy` reports repository-wide warnings-as-errors outside this change.
  - `cppcheck` reports `src/pipeline/pass_pkgmap.c:421` null-pointer warning and an internal AST error at `internal/cbm/extract_defs.c:3386`.

## Notes

Fixes #873
Refs #594
