### PR TITLE
fix(smoke): derive arch from CI matrix, not emulated uname (arm64 12a)

### DIFF
--- a/.github/workflows/_smoke.yml
+++ b/.github/workflows/_smoke.yml
@@ -235,6 +235,7 @@ jobs:
         run: scripts/smoke-test.sh ./codebase-memory-mcp.exe
         env:
           SMOKE_DOWNLOAD_URL: http://127.0.0.1:18080
+          SMOKE_ARCH: ${{ matrix.arch }}
 
       - name: Security audits
         shell: msys2 {0}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1570,18 +1570,26 @@ DL_OS=$(uname -s | tr 'A-Z' 'a-z')
 case "$DL_OS" in
   mingw*|msys*) DL_OS="windows" ;;
 esac
-DL_ARCH=$(uname -m)
-case "$DL_ARCH" in
-  aarch64) DL_ARCH="arm64" ;;
-  x86_64)
-    # Rosetta detection
-    if [ "$DL_OS" = "darwin" ] && sysctl -n machdep.cpu.brand_string 2>/dev/null | grep -qi apple; then
-      DL_ARCH="arm64"
-    else
-      DL_ARCH="amd64"
-    fi
-    ;;
-esac
+# Prefer a CI-provided SMOKE_ARCH over `uname -m`: on windows-11-arm the base
+# MSYS2 `uname` is an emulated x86_64 binary that reports "x86_64", so uname would
+# request the amd64 archive and 404. The smoke workflow passes the true matrix
+# arch (arm64/amd64). Fall back to uname when SMOKE_ARCH is unset (local runs).
+if [ -n "${SMOKE_ARCH:-}" ]; then
+  DL_ARCH="$SMOKE_ARCH"
+else
+  DL_ARCH=$(uname -m)
+  case "$DL_ARCH" in
+    aarch64) DL_ARCH="arm64" ;;
+    x86_64)
+      # Rosetta detection
+      if [ "$DL_OS" = "darwin" ] && sysctl -n machdep.cpu.brand_string 2>/dev/null | grep -qi apple; then
+        DL_ARCH="arm64"
+      else
+        DL_ARCH="amd64"
+      fi
+      ;;
+  esac
+fi
 
 if [ "$DL_OS" = "darwin" ] || [ "$DL_OS" = "linux" ]; then
   DL_EXT="tar.gz"


### PR DESCRIPTION

The persistent windows-11-arm smoke Phase 12a failure was a 404, not a network
error: it requested codebase-memory-mcp-windows-amd64.zip on the arm64 leg. Cause:
DL_ARCH came from `uname -m`, which on windows-11-arm is an emulated x86_64 MSYS2
uname reporting "x86_64" -> wrong (amd64) archive -> 404 (server has arm64). Phase
14 worked because the binary's own detect_arch() is native. Prefer SMOKE_ARCH
(passed from the smoke workflow's matrix.arch) over uname; fall back to uname for
local runs. This is the real cause the earlier curl/proxy/ipv4 attempts masked --
the 404 was swallowed by 2>/dev/null until #905 surfaced it.