### PR TITLE
fix(install): detect arch via OSArchitecture, not PROCESSOR_ARCHITECTURE (arm64)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -31,13 +31,20 @@ foreach ($arg in $args) {
     if ($arg -like "--dir=*") { $InstallDir = $arg.Substring(6) }
 }
 
-# Detect architecture (ARM64 vs x64). PROCESSOR_ARCHITEW6432 is set to ARM64
-# when an x86/x64 process runs under emulation on ARM hardware, so check both to
-# resolve ARM64 even from an emulated shell; anything else falls back to amd64.
-if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64" -or $env:PROCESSOR_ARCHITEW6432 -eq "ARM64") {
-    $Arch = "arm64"
-} else {
-    $Arch = "amd64"
+# Detect the OS architecture. RuntimeInformation.OSArchitecture reports the real
+# OS arch (Arm64) even from an x64 process running under emulation on ARM64 --
+# unlike $env:PROCESSOR_ARCHITECTURE, which reports the emulated "AMD64", and
+# PROCESSOR_ARCHITEW6432, which is unset for 64-bit emulated processes. Fall back
+# to the env vars only if the .NET API is somehow unavailable.
+try {
+    $osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    $Arch = if ($osArch -eq 'Arm64') { "arm64" } else { "amd64" }
+} catch {
+    if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64" -or $env:PROCESSOR_ARCHITEW6432 -eq "ARM64") {
+        $Arch = "arm64"
+    } else {
+        $Arch = "amd64"
+    }
 }
 
 Write-Host "codebase-memory-mcp installer (Windows)"


### PR DESCRIPTION

install.ps1 reported "arch: amd64" on windows-11-arm and 404'd on the amd64 zip:
$env:PROCESSOR_ARCHITECTURE reports the emulated "AMD64" for an x64 process under
ARM64 emulation, and PROCESSOR_ARCHITEW6432 is unset for 64-bit emulated procs.
RuntimeInformation.OSArchitecture reports the real OS arch (Arm64) regardless of
process emulation. Same emulated-arch class as the smoke uname fix (#907); this
one is a genuine product improvement -- real ARM users invoking install.ps1 from
an x64 context now get the arm64 binary.