### PR TITLE
fix(smoke/install): pass explicit CBM_ARCH to install.ps1 (arm64 Phase 13)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -36,14 +36,20 @@ foreach ($arg in $args) {
 # unlike $env:PROCESSOR_ARCHITECTURE, which reports the emulated "AMD64", and
 # PROCESSOR_ARCHITEW6432, which is unset for 64-bit emulated processes. Fall back
 # to the env vars only if the .NET API is somehow unavailable.
-try {
-    $osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-    $Arch = if ($osArch -eq 'Arm64') { "arm64" } else { "amd64" }
-} catch {
-    if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64" -or $env:PROCESSOR_ARCHITEW6432 -eq "ARM64") {
-        $Arch = "arm64"
-    } else {
-        $Arch = "amd64"
+if ($env:CBM_ARCH) {
+    # Explicit override wins — used by CI/tests, and an escape hatch under x64
+    # emulation on ARM64 where no in-process detection is reliable.
+    $Arch = $env:CBM_ARCH
+} else {
+    try {
+        $osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+        $Arch = if ($osArch -eq 'Arm64') { "arm64" } else { "amd64" }
+    } catch {
+        if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64" -or $env:PROCESSOR_ARCHITEW6432 -eq "ARM64") {
+            $Arch = "arm64"
+        } else {
+            $Arch = "amd64"
+        }
     }
 }
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1778,7 +1778,9 @@ elif [ -f "$REPO_ROOT/install.ps1" ] && command -v powershell.exe &>/dev/null; t
   fi
 
   # 13f: run install.ps1
-  HOME="$PS1_TEST_HOME" CBM_DOWNLOAD_URL="$WIN_URL" \
+  # Pass the known-correct arch: powershell runs under x64 emulation on ARM64, so
+  # install.ps1's own detection can't tell it's arm64. DL_ARCH is authoritative here.
+  HOME="$PS1_TEST_HOME" CBM_DOWNLOAD_URL="$WIN_URL" CBM_ARCH="$DL_ARCH" \
     powershell.exe -ExecutionPolicy ByPass -File "$WIN_SCRIPT" "--dir=$WIN_DIR" 2>&1 || true
 
   # 13g: binary placed


### PR DESCRIPTION

install.ps1 kept detecting arch=amd64 on windows-11-arm because it runs under x64
emulation, where neither $env:PROCESSOR_ARCHITECTURE nor .NET OSArchitecture (on
Windows PowerShell 5.1) reports the real Arm64. Add a CBM_ARCH env override to
install.ps1 (wins over auto-detect; also a genuine escape hatch for emulated
invocations) and have smoke Phase 13 pass the authoritative DL_ARCH. Deterministic
-- no reliance on in-process detection under emulation. Same emulated-arch class
as #907 (uname) and #908.