### PR TITLE
Add Chialisp (cl-26) language support

### DIFF
--- a/internal/cbm/cbm.h
+++ b/internal/cbm/cbm.h
@@ -170,6 +170,7 @@ typedef enum {
     CBM_LANG_QML,       // Qt QML (Qt Modeling Language — declarative UI + embedded JS)
     CBM_LANG_CFSCRIPT,  // CFML script dialect (.cfc components — Lucee/ColdFusion)
     CBM_LANG_CFML,      // CFML tag dialect (.cfm templates — Lucee/ColdFusion)
+    CBM_LANG_CHIALISP,  // Chialisp (.clsp/.clib/.clinc — Chia smart-coin s-expression language)
     CBM_LANG_COUNT
 } CBMLanguage;
 

--- a/internal/cbm/extract_calls.c
+++ b/internal/cbm/extract_calls.c
@@ -494,7 +494,63 @@ static char *extract_erlang_callee(CBMArena *a, TSNode node, const char *source,
 // Lisp dialects: a call is a list (`list` / `list_lit`) whose head (first named
 // child) is the function symbol (`symbol` / `sym_lit`). Generic field/first-child
 // extraction misses it because the head is not an `identifier` node.
-static char *extract_lisp_callee(CBMArena *a, TSNode node, const char *source, const char *nk) {
+/* Chialisp W2: a head atom that is a CLVM primitive/opcode, or a Chialisp
+ * syntax/binding/intrinsic/def keyword, is NOT a call — emit no CALLS edge.
+ * Sourced from clvm_tools_rs KW_PAIRS / clvm_rs operator set (pinned in #38).
+ * The def/include heads are here too so `(defun …)`/`(include …)` heads never
+ * mint a phantom call. Real helpers that merely *look* primitive — sha256tree
+ * and the curry helpers — are deliberately absent, so they pass through. */
+static bool chialisp_head_is_not_call(const char *t) {
+    if (!t) {
+        return true;
+    }
+    static const char *filtered[] = {
+        /* --- 49 CLVM primitives (VM ops) --- */
+        "q", "a", "i", "c", "f", "r", "l", "x", "=", ">s", "sha256", "substr", "strlen", "concat",
+        "+", "-", "*", "/", "divmod", ">", "ash", "lsh", "logand", "logior", "logxor", "lognot",
+        "point_add", "pubkey_for_exp", "not", "any", "all", "softfork", "coinid", "g1_subtract",
+        "g1_multiply", "g1_negate", "g2_add", "g2_subtract", "g2_multiply", "g2_negate", "g1_map",
+        "g2_map", "bls_pairing_identity", "bls_verify", "modpow", "%", "secp256k1_verify",
+        "secp256r1_verify", "keccak256",
+        /* --- Chialisp syntax / binding / intrinsics (not calls or defs) --- */
+        "quote", "qq", "unquote", "&rest", "let", "let*", "assign", "assign-inline",
+        "assign-lambda", "lambda", "mod", "if", "list", "com", "opt", "@", "@*env*", "print",
+        /* --- def / include heads (own their own node kinds, never a call) --- */
+        "defun", "defun-inline", "defmacro", "defmac", "defconstant", "defconst", "namespace",
+        "export", "embed-file", "compile-file", "include", NULL};
+    for (int i = 0; filtered[i]; i++) {
+        if (strcmp(t, filtered[i]) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* W6: true when any ancestor list of `node` has a quote head (`q`/`quote`/`qq`)
+ * — quoted data must not mint calls. */
+static bool chialisp_node_in_quote(CBMArena *a, TSNode node, const char *source) {
+    TSNode cur = ts_node_parent(node);
+    for (int guard = 0; guard < 256 && !ts_node_is_null(cur); guard++) {
+        const char *ck = ts_node_type(cur);
+        if ((strcmp(ck, "list") == 0 || strcmp(ck, "list_lit") == 0) &&
+            ts_node_named_child_count(cur) > 0) {
+            TSNode h = ts_node_named_child(cur, 0);
+            const char *hk = ts_node_type(h);
+            if (strcmp(hk, "symbol") == 0 || strcmp(hk, "sym_lit") == 0) {
+                char *ht = cbm_node_text(a, h, source);
+                if (ht && (strcmp(ht, "q") == 0 || strcmp(ht, "quote") == 0 ||
+                           strcmp(ht, "qq") == 0)) {
+                    return true;
+                }
+            }
+        }
+        cur = ts_node_parent(cur);
+    }
+    return false;
+}
+
+static char *extract_lisp_callee(CBMArena *a, TSNode node, const char *source, const char *nk,
+                                 CBMLanguage lang) {
     if (strcmp(nk, "list") != 0 && strcmp(nk, "list_lit") != 0) {
         return NULL;
     }
@@ -503,7 +559,16 @@ static char *extract_lisp_callee(CBMArena *a, TSNode node, const char *source, c
         const char *hk = ts_node_type(head);
         if (strcmp(hk, "symbol") == 0 || strcmp(hk, "sym_lit") == 0 ||
             strcmp(hk, "identifier") == 0) {
-            return cbm_node_text(a, head, source);
+            char *ht = cbm_node_text(a, head, source);
+            if (lang == CBM_LANG_CHIALISP) {
+                /* W2: drop CLVM ops / syntax / def-heads. W6: drop anything
+                 * inside quoted data. Real helpers (sha256tree, curry helpers)
+                 * survive both filters. */
+                if (chialisp_head_is_not_call(ht) || chialisp_node_in_quote(a, node, source)) {
+                    return NULL;
+                }
+            }
+            return ht;
         }
     }
     return NULL;
@@ -1061,8 +1126,9 @@ static char *extract_callee_lang_specific(CBMArena *a, TSNode node, const char *
     }
 
     if (lang == CBM_LANG_CLOJURE || lang == CBM_LANG_COMMONLISP || lang == CBM_LANG_SCHEME ||
-        lang == CBM_LANG_FENNEL || lang == CBM_LANG_RACKET || lang == CBM_LANG_EMACSLISP) {
-        return extract_lisp_callee(a, node, source, nk);
+        lang == CBM_LANG_FENNEL || lang == CBM_LANG_RACKET || lang == CBM_LANG_EMACSLISP ||
+        lang == CBM_LANG_CHIALISP) {
+        return extract_lisp_callee(a, node, source, nk, lang);
     }
     if (lang == CBM_LANG_FSHARP) {
         return extract_fsharp_callee(a, node, source, nk);

--- a/internal/cbm/extract_defs.c
+++ b/internal/cbm/extract_defs.c
@@ -6024,36 +6024,157 @@ static bool lisp_is_def_head(const char *t) {
     return false;
 }
 
+/* Chialisp (cl-26) definition-form heads. Distinct from the Clojure/Scheme
+ * lisp_is_def_head set because Chialisp shares the generic `list` node kind:
+ * treating e.g. `mod`/`defun`/`defconstant` as defs must NOT leak into the
+ * other lisp gates (in Scheme `(mod x y)` is a call, not a def). Excludes the
+ * expression-local binding forms (let, assign, lambda and friends) which, if
+ * made defs, would fragment call attribution. Mirror: chialisp_head_is_def()
+ * in extract_unified.c. */
+static bool chialisp_is_def_head(const char *t) {
+    if (!t) {
+        return false;
+    }
+    static const char *heads[] = {"mod",
+                                  "defun",
+                                  "defun-inline",
+                                  "defmacro",
+                                  "defmac",
+                                  "defconstant",
+                                  "defconst",
+                                  "namespace",
+                                  "export",
+                                  "embed-file",
+                                  "compile-file",
+                                  NULL};
+    for (int i = 0; heads[i]; i++) {
+        if (strcmp(t, heads[i]) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Chialisp W6: a `(q ...)`/`(quote ...)`/`(qq ...)` form is quoted DATA, not
+ * code — a def-head or call symbol inside it must not mint a node. True when
+ * any ancestor list of `node` has a quote head. Bounded walk (arena for the
+ * head-text read). */
+static bool lisp_node_in_quote(CBMArena *a, TSNode node, const char *source) {
+    TSNode cur = ts_node_parent(node);
+    for (int guard = 0; guard < 256 && !ts_node_is_null(cur); guard++) {
+        const char *ck = ts_node_type(cur);
+        if ((strcmp(ck, "list") == 0 || strcmp(ck, "list_lit") == 0) &&
+            ts_node_named_child_count(cur) > 0) {
+            TSNode h = ts_node_named_child(cur, 0);
+            const char *hk = ts_node_type(h);
+            if (strcmp(hk, "symbol") == 0 || strcmp(hk, "sym_lit") == 0) {
+                char *ht = cbm_node_text(a, h, source);
+                if (ht && (strcmp(ht, "q") == 0 || strcmp(ht, "quote") == 0 ||
+                           strcmp(ht, "qq") == 0)) {
+                    return true;
+                }
+            }
+        }
+        cur = ts_node_parent(cur);
+    }
+    return false;
+}
+
+/* i-th named child skipping `comment` nodes (comments are NAMED in the
+ * Chialisp/Scheme grammar and count in named-child indexing). Cheap insurance
+ * for a comment interleaved between a def head and its name. */
+static TSNode lisp_named_child_skip_comments(TSNode node, uint32_t want) {
+    uint32_t nc = ts_node_named_child_count(node);
+    uint32_t seen = 0;
+    for (uint32_t i = 0; i < nc; i++) {
+        TSNode c = ts_node_named_child(node, i);
+        if (strcmp(ts_node_type(c), "comment") == 0) {
+            continue;
+        }
+        if (seen == want) {
+            return c;
+        }
+        seen++;
+    }
+    TSNode null_node = {0};
+    return null_node;
+}
+
+/* Basename stem (no dir, no extension) of a path, into an arena string. */
+static char *lisp_path_stem(CBMArena *a, const char *path) {
+    if (!path) {
+        return NULL;
+    }
+    const char *slash = strrchr(path, '/');
+    const char *base = slash ? slash + 1 : path;
+    const char *dot = strrchr(base, '.');
+    size_t len = (dot && dot != base) ? (size_t)(dot - base) : strlen(base);
+    return cbm_arena_strndup(a, base, len);
+}
+
 static void extract_lisp_def(CBMExtractCtx *ctx, TSNode node) {
     CBMArena *a = ctx->arena;
+    bool chialisp = (ctx->language == CBM_LANG_CHIALISP);
     if (ts_node_named_child_count(node) < 2) {
         return;
     }
-    char *head = cbm_node_text(a, ts_node_named_child(node, 0), ctx->source);
-    if (!lisp_is_def_head(head)) {
+    TSNode head_node = chialisp ? lisp_named_child_skip_comments(node, 0) : ts_node_named_child(node, 0);
+    if (ts_node_is_null(head_node)) {
         return;
     }
-    TSNode target = ts_node_named_child(node, 1);
-    const char *tk = ts_node_type(target);
-    TSNode name_node = target;
-    // (define (foo args) ...) — the name is the head symbol of the nested list.
-    if ((strcmp(tk, "list") == 0 || strcmp(tk, "list_lit") == 0) &&
-        ts_node_named_child_count(target) > 0) {
-        name_node = ts_node_named_child(target, 0);
-    }
-    if (ts_node_is_null(name_node)) {
+    char *head = cbm_node_text(a, head_node, ctx->source);
+    bool is_def = chialisp ? chialisp_is_def_head(head) : lisp_is_def_head(head);
+    if (!is_def) {
         return;
     }
-    char *name = cbm_node_text(a, name_node, ctx->source);
+    /* W6: skip def-heads that live inside quoted data (cl-26 macros embed
+     * puzzle-shaped literals under `(q ...)`). */
+    if (chialisp && lisp_node_in_quote(a, node, ctx->source)) {
+        return;
+    }
+    /* W1: a top-level `(mod (ARGS) ...)` is the puzzle entry point; its
+     * named_child(1) is the arg-LIST, so the generic nested-name path would
+     * name the module after the first curried arg. Name it by the filename. */
+    char *name = NULL;
+    if (chialisp && strcmp(head, "mod") == 0) {
+        name = lisp_path_stem(a, ctx->rel_path);
+    } else {
+        TSNode target = chialisp ? lisp_named_child_skip_comments(node, 1) : ts_node_named_child(node, 1);
+        if (ts_node_is_null(target)) {
+            return;
+        }
+        const char *tk = ts_node_type(target);
+        TSNode name_node = target;
+        // (define (foo args) ...) — the name is the head symbol of the nested list.
+        if ((strcmp(tk, "list") == 0 || strcmp(tk, "list_lit") == 0) &&
+            ts_node_named_child_count(target) > 0) {
+            name_node = ts_node_named_child(target, 0);
+        }
+        if (ts_node_is_null(name_node)) {
+            return;
+        }
+        name = cbm_node_text(a, name_node, ctx->source);
+    }
     if (!name || !name[0]) {
         return;
     }
     /* struct/record/type defining forms produce a type node, not a callable
      * (Racket `(struct point ...)`, Clojure `(defrecord ...)`, etc.). */
     const char *lisp_label = "Function";
-    if (strcmp(head, "struct") == 0 || strcmp(head, "define-struct") == 0 ||
-        strcmp(head, "define-record-type") == 0 || strcmp(head, "defrecord") == 0 ||
-        strcmp(head, "deftype") == 0) {
+    if (chialisp) {
+        /* W3/W4 label map: constants, macros, module entry, embedded artifacts. */
+        if (strcmp(head, "mod") == 0 || strcmp(head, "export") == 0 ||
+            strcmp(head, "namespace") == 0) {
+            lisp_label = "Module";
+        } else if (strcmp(head, "defconstant") == 0 || strcmp(head, "defconst") == 0 ||
+                   strcmp(head, "embed-file") == 0 || strcmp(head, "compile-file") == 0) {
+            lisp_label = "Constant";
+        } else if (strcmp(head, "defmacro") == 0 || strcmp(head, "defmac") == 0) {
+            lisp_label = "Macro";
+        }
+    } else if (strcmp(head, "struct") == 0 || strcmp(head, "define-struct") == 0 ||
+               strcmp(head, "define-record-type") == 0 || strcmp(head, "defrecord") == 0 ||
+               strcmp(head, "deftype") == 0) {
         lisp_label = "Struct";
     } else if (strcmp(head, "definterface") == 0 || strcmp(head, "defprotocol") == 0) {
         lisp_label = "Interface";
@@ -6242,9 +6363,22 @@ static void walk_defs(CBMExtractCtx *ctx, TSNode root, const CBMLangSpec *spec, 
         }
 
         if ((ctx->language == CBM_LANG_CLOJURE || ctx->language == CBM_LANG_RACKET ||
-             ctx->language == CBM_LANG_SCHEME) &&
+             ctx->language == CBM_LANG_SCHEME || ctx->language == CBM_LANG_CHIALISP) &&
             (strcmp(kind, "list") == 0 || strcmp(kind, "list_lit") == 0)) {
             extract_lisp_def(ctx, node);
+            /* Chialisp nests every helper `(defun …)` inside the top-level
+             * `(mod …)` (and `.clib` files wrap defuns in an enclosing list —
+             * W7). The generic function_node_types match below fires on every
+             * `list` and `continue`s WITHOUT descending, so those nested defs
+             * would be lost. Push children and continue here so the whole tree
+             * is walked. Gated to Chialisp — other lisps keep prior behavior. */
+            if (ctx->language == CBM_LANG_CHIALISP) {
+                uint32_t cc = ts_node_child_count(node);
+                for (int i = (int)cc - SKIP_CHAR; i >= 0; i--) {
+                    wd_push(&s, ts_node_child(node, (uint32_t)i), frame.enclosing_class_qn);
+                }
+                continue;
+            }
             // fall through: descend into children so nested defs are captured too
         }
 

--- a/internal/cbm/extract_imports.c
+++ b/internal/cbm/extract_imports.c
@@ -1788,6 +1788,42 @@ static void lisp_process_list(CBMExtractCtx *ctx, TSNode node) {
         return;
     }
 
+    /* Chialisp (cl-26) include/embed forms. W3: `(include *standard-cl-26*)`
+     * and any `*…*` dialect sigil is a compiler directive, NOT a file
+     * dependency — mirror the compiler's own `!name.starts_with("*")` filter
+     * and drop it (record only real `(include "file.clib")` edges). W4:
+     * `(embed-file NAME kind "file")` / `(compile-file NAME "file")` create a
+     * file dependency on the embedded/compiled artifact — emit it as an import
+     * edge (no dedicated EMBEDS edge type; see task note). */
+    if (ctx->language == CBM_LANG_CHIALISP) {
+        if (strcmp(hn, "include") == 0) {
+            for (uint32_t j = 1; j < nc; j++) {
+                TSNode mod_node = ts_node_named_child(node, j);
+                const char *mk = ts_node_type(mod_node);
+                if (strcmp(mk, "symbol") == 0 || strcmp(mk, "sym_lit") == 0) {
+                    char *sig = cbm_node_text(ctx->arena, mod_node, ctx->source);
+                    if (sig && sig[0] == '*') {
+                        continue; /* dialect sigil, not a file */
+                    }
+                }
+                lisp_push_module(ctx, mod_node);
+            }
+            return;
+        }
+        if (strcmp(hn, "embed-file") == 0 || strcmp(hn, "compile-file") == 0) {
+            /* the embedded/compiled path is the last string arg. */
+            for (uint32_t j = nc; j-- > 1;) {
+                TSNode arg = ts_node_named_child(node, j);
+                const char *ak = ts_node_type(arg);
+                if (strcmp(ak, "string") == 0 || strcmp(ak, "str_lit") == 0) {
+                    lisp_push_module(ctx, arg);
+                    break;
+                }
+            }
+            return;
+        }
+    }
+
     /* Plain import head: `(require :util)`, `(import ...)`, `(use ...)`. */
     if (strcmp(hn, "import") == 0 || strcmp(hn, "require") == 0 || strcmp(hn, "load") == 0 ||
         strcmp(hn, "use") == 0 || strcmp(hn, "include") == 0) {
@@ -2852,6 +2888,7 @@ void cbm_extract_imports(CBMExtractCtx *ctx) {
     case CBM_LANG_FENNEL:
     case CBM_LANG_COMMONLISP:
     case CBM_LANG_CLOJURE:
+    case CBM_LANG_CHIALISP:
         parse_lisp_imports(ctx);
         break;
     case CBM_LANG_STARLARK:

--- a/internal/cbm/extract_unified.c
+++ b/internal/cbm/extract_unified.c
@@ -130,13 +130,48 @@ static bool lisp_head_is_def(const char *t) {
  * Returns NULL for any non-def list (calls, vectors of args, the +/- body
  * forms, ...), so push_boundary_scopes pushes no scope for them. Mirrors
  * extract_lisp_def() in extract_defs.c. */
+/* Mirror of chialisp_is_def_head() in extract_defs.c — Chialisp shares the
+ * generic `list` kind, so its def-head set must be gated separately from the
+ * Clojure/Scheme set (which would mis-scope `(mod x y)` etc.). */
+static bool chialisp_head_is_def(const char *t) {
+    if (!t) {
+        return false;
+    }
+    static const char *heads[] = {"mod",   "defun",       "defun-inline", "defmacro",
+                                  "defmac", "defconstant", "defconst",     "namespace",
+                                  "export", "embed-file",  "compile-file", NULL};
+    for (int i = 0; heads[i]; i++) {
+        if (strcmp(t, heads[i]) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static const char *compute_lisp_func_qn(CBMExtractCtx *ctx, TSNode node) {
     if (ts_node_named_child_count(node) < 2) {
         return NULL;
     }
+    bool chialisp = (ctx->language == CBM_LANG_CHIALISP);
     char *head = cbm_node_text(ctx->arena, ts_node_named_child(node, 0), ctx->source);
-    if (!lisp_head_is_def(head)) {
+    bool is_def = chialisp ? chialisp_head_is_def(head) : lisp_head_is_def(head);
+    if (!is_def) {
         return NULL;
+    }
+    /* W1: `mod` scope is named by the filename (its named_child(1) is the
+     * arg-list, not a name) so in-body top-level calls attribute to the entry
+     * rather than to a curried arg. */
+    if (chialisp && head && strcmp(head, "mod") == 0) {
+        const char *path = ctx->rel_path;
+        const char *slash = path ? strrchr(path, '/') : NULL;
+        const char *base = slash ? slash + 1 : path;
+        if (!base || !base[0]) {
+            return NULL;
+        }
+        const char *dot = strrchr(base, '.');
+        size_t len = (dot && dot != base) ? (size_t)(dot - base) : strlen(base);
+        char *stem = cbm_arena_strndup(ctx->arena, base, len);
+        return cbm_fqn_compute(ctx->arena, ctx->project, ctx->rel_path, stem);
     }
     TSNode target = ts_node_named_child(node, 1);
     const char *tk = ts_node_type(target);
@@ -293,7 +328,7 @@ static const char *compute_func_qn(CBMExtractCtx *ctx, TSNode node, const CBMLan
      * lives here (we have ctx->source). Non-def lists return NULL → no scope
      * pushed → the in-body call sources to the enclosing def, not the Module. */
     if (ctx->language == CBM_LANG_CLOJURE || ctx->language == CBM_LANG_SCHEME ||
-        ctx->language == CBM_LANG_RACKET) {
+        ctx->language == CBM_LANG_RACKET || ctx->language == CBM_LANG_CHIALISP) {
         return compute_lisp_func_qn(ctx, node);
     }
 

--- a/internal/cbm/grammar_chialisp.c
+++ b/internal/cbm/grammar_chialisp.c
@@ -1,0 +1,3 @@
+// Vendored tree-sitter grammar: chialisp
+// Each grammar compiled as separate unit (conflicting static symbols).
+#include "vendored/grammars/chialisp/parser.c"

--- a/internal/cbm/lang_specs.c
+++ b/internal/cbm/lang_specs.c
@@ -80,6 +80,7 @@ extern const TSLanguage *tree_sitter_powershell(void);
 extern const TSLanguage *tree_sitter_pascal(void);
 extern const TSLanguage *tree_sitter_d(void);
 extern const TSLanguage *tree_sitter_scheme(void);
+extern const TSLanguage *tree_sitter_chialisp(void);
 extern const TSLanguage *tree_sitter_fennel(void);
 extern const TSLanguage *tree_sitter_fish(void);
 extern const TSLanguage *tree_sitter_awk(void);
@@ -1074,6 +1075,12 @@ static const char *scheme_func_types[] = {"list", NULL};
 static const char *scheme_call_types[] = {"list", NULL};
 static const char *scheme_var_types[] = {"symbol", NULL};
 static const char *scheme_module_types[] = {"program", NULL};
+// Chialisp mirrors the Scheme lisp-family path: parenthesized forms are `list`,
+// atoms/heads are `symbol`; the grammar's root node is `source_file`.
+static const char *chialisp_func_types[] = {"list", NULL};
+static const char *chialisp_call_types[] = {"list", NULL};
+static const char *chialisp_var_types[] = {"symbol", NULL};
+static const char *chialisp_module_types[] = {"source_file", NULL};
 static const char *fennel_func_types[] = {"fn", "lambda", "hashfn", NULL};
 static const char *fennel_call_types[] = {"list", NULL};
 static const char *fennel_branch_types[] = {"each", "for", "match", NULL};
@@ -2070,6 +2077,12 @@ static const CBMLangSpec lang_specs[CBM_LANG_COUNT] = {
                          scheme_module_types, scheme_call_types, empty_types, empty_types,
                          empty_types, scheme_var_types, empty_types, empty_types, NULL, empty_types,
                          NULL, NULL, tree_sitter_scheme, NULL},
+
+    // CBM_LANG_CHIALISP — mirrors the Scheme lisp-family spec (list/symbol nodes)
+    [CBM_LANG_CHIALISP] = {CBM_LANG_CHIALISP, chialisp_func_types, empty_types, empty_types,
+                           chialisp_module_types, chialisp_call_types, empty_types, empty_types,
+                           empty_types, chialisp_var_types, empty_types, empty_types, NULL, empty_types,
+                           NULL, NULL, tree_sitter_chialisp, NULL},
 
     // CBM_LANG_FENNEL
     [CBM_LANG_FENNEL] = {CBM_LANG_FENNEL, fennel_func_types, empty_types, empty_types,

--- a/internal/cbm/vendored/grammars/MANIFEST.md
+++ b/internal/cbm/vendored/grammars/MANIFEST.md
@@ -9,7 +9,7 @@ The grammars were originally vendored as bare `parser.c`+`scanner.c` with **no r
 
 ## Summary
 
-- Grammars: **159** — vendored-from-upstream: **142**, first-party/self-maintained: **12**, registry-disagreement: **5** (nim removed 2026-06-12; objectscript_udl + objectscript_routine added 2026-06-24; mojo added 2026-07-01 — see notes below)
+- Grammars: **160** — vendored-from-upstream: **142**, first-party/self-maintained: **13**, registry-disagreement: **5** (nim removed 2026-06-12; objectscript_udl + objectscript_routine added 2026-06-24; mojo added 2026-07-01; chialisp added 2026-07-06 — see notes below)
 - ABI distribution: **7×** ABI-13 **85×** ABI-14 **64×** ABI-15 (runtime ceiling is ABI 15; never vendor ABI 16 without a runtime upgrade)
 - Vendored copies missing LICENSE: **0** — all upstream LICENSE files restored 2026-06-11 (first-party grammars carry the project MIT license; `move` uses the Helix-listed upstream tzakian/tree-sitter-move MIT text, `zsh` uses georgeharker/tree-sitter-zsh MIT)
 - `verdict`: VERIFIED-BOTH = our source matches *both* registries; VERIFIED-NVIM/HELIX = matches one; registry-disagreement = registries name a different repo (listed separately); `vendor-maintained` = the language vendor's own grammar, not in nvim/Helix.
@@ -36,6 +36,7 @@ Guarded by the `contract_all_grammars_in_graph` graph-breadth test in
 |---|---|
 | ada      | `resolve_func_name`: `subprogram_body`/`subprogram_declaration` → `procedure_specification`/`function_specification` child's `name` field |
 | cairo    | `resolve_func_name`: `function_definition`/`function_signature` → `identifier` child |
+| chialisp | `extract_lisp_def`: `(defun/defconstant/defmacro/mod …)` head-symbol forms in `list`; `mod`/`export` named by filename; CLVM operators + dialect sigils filtered from calls/imports |
 | clojure  | `extract_lisp_def`: `(defn …)` / `(def …)` head-symbol forms in `list_lit` |
 | d        | `resolve_func_name`: `function_declaration` → `identifier` child |
 | fortran  | `resolve_func_name`: `subroutine`/`function` → inner `*_statement`'s `name` field |
@@ -229,6 +230,7 @@ upstream author (correctly retained). The table now records the true origin.
 | magma | 15 | ✅ project MIT |
 | protobuf | 13 | ✅ project MIT |
 | wolfram | 13 | ✅ project MIT |
+| chialisp | 14 | ✅ MIT — irulast clean-room (cl-26), authored from clvm_tools_rs frontend; to be upstreamed (added 2026-07-06) |
 
 ### Self-maintained forks (upstream license retained, byte-verified 2026-06-12)
 

--- a/internal/cbm/vendored/grammars/chialisp/LICENSE
+++ b/internal/cbm/vendored/grammars/chialisp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Irulast
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/internal/cbm/vendored/grammars/chialisp/parser.c
+++ b/internal/cbm/vendored/grammars/chialisp/parser.c
@@ -1,0 +1,549 @@
+#include "tree_sitter/parser.h"
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
+#define LANGUAGE_VERSION 14
+#define STATE_COUNT 15
+#define LARGE_STATE_COUNT 12
+#define SYMBOL_COUNT 13
+#define ALIAS_COUNT 0
+#define TOKEN_COUNT 9
+#define EXTERNAL_TOKEN_COUNT 0
+#define FIELD_COUNT 0
+#define MAX_ALIAS_SEQUENCE_LENGTH 5
+#define PRODUCTION_ID_COUNT 1
+
+enum ts_symbol_identifiers {
+  anon_sym_LPAREN = 1,
+  anon_sym_RPAREN = 2,
+  sym_dot = 3,
+  sym_hex = 4,
+  sym_number = 5,
+  sym_symbol = 6,
+  sym_string = 7,
+  sym_comment = 8,
+  sym_source_file = 9,
+  sym__sexp = 10,
+  sym_list = 11,
+  aux_sym_source_file_repeat1 = 12,
+};
+
+static const char * const ts_symbol_names[] = {
+  [ts_builtin_sym_end] = "end",
+  [anon_sym_LPAREN] = "(",
+  [anon_sym_RPAREN] = ")",
+  [sym_dot] = "dot",
+  [sym_hex] = "hex",
+  [sym_number] = "number",
+  [sym_symbol] = "symbol",
+  [sym_string] = "string",
+  [sym_comment] = "comment",
+  [sym_source_file] = "source_file",
+  [sym__sexp] = "_sexp",
+  [sym_list] = "list",
+  [aux_sym_source_file_repeat1] = "source_file_repeat1",
+};
+
+static const TSSymbol ts_symbol_map[] = {
+  [ts_builtin_sym_end] = ts_builtin_sym_end,
+  [anon_sym_LPAREN] = anon_sym_LPAREN,
+  [anon_sym_RPAREN] = anon_sym_RPAREN,
+  [sym_dot] = sym_dot,
+  [sym_hex] = sym_hex,
+  [sym_number] = sym_number,
+  [sym_symbol] = sym_symbol,
+  [sym_string] = sym_string,
+  [sym_comment] = sym_comment,
+  [sym_source_file] = sym_source_file,
+  [sym__sexp] = sym__sexp,
+  [sym_list] = sym_list,
+  [aux_sym_source_file_repeat1] = aux_sym_source_file_repeat1,
+};
+
+static const TSSymbolMetadata ts_symbol_metadata[] = {
+  [ts_builtin_sym_end] = {
+    .visible = false,
+    .named = true,
+  },
+  [anon_sym_LPAREN] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_RPAREN] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym_dot] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_hex] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_number] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_symbol] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_string] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_comment] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_source_file] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym__sexp] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_list] = {
+    .visible = true,
+    .named = true,
+  },
+  [aux_sym_source_file_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+};
+
+static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
+  [0] = {0},
+};
+
+static const uint16_t ts_non_terminal_alias_map[] = {
+  0,
+};
+
+static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
+  [0] = 0,
+  [1] = 1,
+  [2] = 2,
+  [3] = 3,
+  [4] = 4,
+  [5] = 5,
+  [6] = 6,
+  [7] = 7,
+  [8] = 8,
+  [9] = 9,
+  [10] = 10,
+  [11] = 11,
+  [12] = 12,
+  [13] = 13,
+  [14] = 14,
+};
+
+static bool ts_lex(TSLexer *lexer, TSStateId state) {
+  START_LEXER();
+  eof = lexer->eof(lexer);
+  switch (state) {
+    case 0:
+      if (eof) ADVANCE(7);
+      ADVANCE_MAP(
+        '"', 1,
+        '\'', 2,
+        '(', 8,
+        ')', 9,
+        '-', 14,
+        '.', 10,
+        '0', 12,
+        ';', 18,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(0);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(13);
+      if (lookahead != 0) ADVANCE(16);
+      END_STATE();
+    case 1:
+      if (lookahead == '"') ADVANCE(17);
+      if (lookahead == '\\') ADVANCE(4);
+      if (lookahead != 0) ADVANCE(1);
+      END_STATE();
+    case 2:
+      if (lookahead == '\'') ADVANCE(17);
+      if (lookahead == '\\') ADVANCE(5);
+      if (lookahead != 0) ADVANCE(2);
+      END_STATE();
+    case 3:
+      if (lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9')) ADVANCE(3);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          lookahead != '"' &&
+          (lookahead < '\'' || ')' < lookahead) &&
+          lookahead != ';') ADVANCE(16);
+      END_STATE();
+    case 4:
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(1);
+      END_STATE();
+    case 5:
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(2);
+      END_STATE();
+    case 6:
+      if (eof) ADVANCE(7);
+      if (lookahead == '"') ADVANCE(1);
+      if (lookahead == '\'') ADVANCE(2);
+      if (lookahead == '(') ADVANCE(8);
+      if (lookahead == '-') ADVANCE(14);
+      if (lookahead == '.') ADVANCE(3);
+      if (lookahead == '0') ADVANCE(12);
+      if (lookahead == ';') ADVANCE(18);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(6);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(13);
+      if (lookahead != 0 &&
+          (lookahead < '\'' || ')' < lookahead)) ADVANCE(16);
+      END_STATE();
+    case 7:
+      ACCEPT_TOKEN(ts_builtin_sym_end);
+      END_STATE();
+    case 8:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      END_STATE();
+    case 9:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      END_STATE();
+    case 10:
+      ACCEPT_TOKEN(sym_dot);
+      END_STATE();
+    case 11:
+      ACCEPT_TOKEN(sym_hex);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(11);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(11);
+      END_STATE();
+    case 12:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == 'X' ||
+          lookahead == 'x') ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(13);
+      END_STATE();
+    case 13:
+      ACCEPT_TOKEN(sym_number);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(13);
+      END_STATE();
+    case 14:
+      ACCEPT_TOKEN(sym_symbol);
+      if (lookahead == '.') ADVANCE(16);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(13);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          lookahead != '"' &&
+          (lookahead < '\'' || ')' < lookahead) &&
+          lookahead != ';') ADVANCE(16);
+      END_STATE();
+    case 15:
+      ACCEPT_TOKEN(sym_symbol);
+      if (lookahead == '.') ADVANCE(16);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(11);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(11);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          lookahead != '"' &&
+          (lookahead < '\'' || ')' < lookahead) &&
+          lookahead != ';') ADVANCE(16);
+      END_STATE();
+    case 16:
+      ACCEPT_TOKEN(sym_symbol);
+      if (lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9')) ADVANCE(16);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          lookahead != '"' &&
+          (lookahead < '\'' || ')' < lookahead) &&
+          lookahead != ';') ADVANCE(16);
+      END_STATE();
+    case 17:
+      ACCEPT_TOKEN(sym_string);
+      END_STATE();
+    case 18:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(18);
+      END_STATE();
+    default:
+      return false;
+  }
+}
+
+static const TSLexMode ts_lex_modes[STATE_COUNT] = {
+  [0] = {.lex_state = 0},
+  [1] = {.lex_state = 6},
+  [2] = {.lex_state = 0},
+  [3] = {.lex_state = 0},
+  [4] = {.lex_state = 0},
+  [5] = {.lex_state = 6},
+  [6] = {.lex_state = 0},
+  [7] = {.lex_state = 0},
+  [8] = {.lex_state = 0},
+  [9] = {.lex_state = 0},
+  [10] = {.lex_state = 6},
+  [11] = {.lex_state = 6},
+  [12] = {.lex_state = 0},
+  [13] = {.lex_state = 0},
+  [14] = {.lex_state = 0},
+};
+
+static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
+  [0] = {
+    [ts_builtin_sym_end] = ACTIONS(1),
+    [anon_sym_LPAREN] = ACTIONS(1),
+    [anon_sym_RPAREN] = ACTIONS(1),
+    [sym_dot] = ACTIONS(1),
+    [sym_hex] = ACTIONS(1),
+    [sym_number] = ACTIONS(1),
+    [sym_symbol] = ACTIONS(1),
+    [sym_string] = ACTIONS(1),
+    [sym_comment] = ACTIONS(3),
+  },
+  [1] = {
+    [sym_source_file] = STATE(12),
+    [sym__sexp] = STATE(5),
+    [sym_list] = STATE(5),
+    [aux_sym_source_file_repeat1] = STATE(5),
+    [ts_builtin_sym_end] = ACTIONS(5),
+    [anon_sym_LPAREN] = ACTIONS(7),
+    [sym_hex] = ACTIONS(9),
+    [sym_number] = ACTIONS(11),
+    [sym_symbol] = ACTIONS(11),
+    [sym_string] = ACTIONS(9),
+    [sym_comment] = ACTIONS(3),
+  },
+  [2] = {
+    [sym__sexp] = STATE(2),
+    [sym_list] = STATE(2),
+    [aux_sym_source_file_repeat1] = STATE(2),
+    [ts_builtin_sym_end] = ACTIONS(13),
+    [anon_sym_LPAREN] = ACTIONS(15),
+    [anon_sym_RPAREN] = ACTIONS(13),
+    [sym_dot] = ACTIONS(13),
+    [sym_hex] = ACTIONS(18),
+    [sym_number] = ACTIONS(21),
+    [sym_symbol] = ACTIONS(21),
+    [sym_string] = ACTIONS(18),
+    [sym_comment] = ACTIONS(3),
+  },
+  [3] = {
+    [sym__sexp] = STATE(4),
+    [sym_list] = STATE(4),
+    [aux_sym_source_file_repeat1] = STATE(4),
+    [anon_sym_LPAREN] = ACTIONS(7),
+    [anon_sym_RPAREN] = ACTIONS(24),
+    [sym_dot] = ACTIONS(26),
+    [sym_hex] = ACTIONS(28),
+    [sym_number] = ACTIONS(30),
+    [sym_symbol] = ACTIONS(30),
+    [sym_string] = ACTIONS(28),
+    [sym_comment] = ACTIONS(3),
+  },
+  [4] = {
+    [sym__sexp] = STATE(2),
+    [sym_list] = STATE(2),
+    [aux_sym_source_file_repeat1] = STATE(2),
+    [anon_sym_LPAREN] = ACTIONS(7),
+    [anon_sym_RPAREN] = ACTIONS(32),
+    [sym_dot] = ACTIONS(34),
+    [sym_hex] = ACTIONS(36),
+    [sym_number] = ACTIONS(38),
+    [sym_symbol] = ACTIONS(38),
+    [sym_string] = ACTIONS(36),
+    [sym_comment] = ACTIONS(3),
+  },
+  [5] = {
+    [sym__sexp] = STATE(2),
+    [sym_list] = STATE(2),
+    [aux_sym_source_file_repeat1] = STATE(2),
+    [ts_builtin_sym_end] = ACTIONS(40),
+    [anon_sym_LPAREN] = ACTIONS(7),
+    [sym_hex] = ACTIONS(36),
+    [sym_number] = ACTIONS(38),
+    [sym_symbol] = ACTIONS(38),
+    [sym_string] = ACTIONS(36),
+    [sym_comment] = ACTIONS(3),
+  },
+  [6] = {
+    [ts_builtin_sym_end] = ACTIONS(42),
+    [anon_sym_LPAREN] = ACTIONS(42),
+    [anon_sym_RPAREN] = ACTIONS(42),
+    [sym_dot] = ACTIONS(42),
+    [sym_hex] = ACTIONS(42),
+    [sym_number] = ACTIONS(44),
+    [sym_symbol] = ACTIONS(44),
+    [sym_string] = ACTIONS(42),
+    [sym_comment] = ACTIONS(3),
+  },
+  [7] = {
+    [ts_builtin_sym_end] = ACTIONS(46),
+    [anon_sym_LPAREN] = ACTIONS(46),
+    [anon_sym_RPAREN] = ACTIONS(46),
+    [sym_dot] = ACTIONS(46),
+    [sym_hex] = ACTIONS(46),
+    [sym_number] = ACTIONS(48),
+    [sym_symbol] = ACTIONS(48),
+    [sym_string] = ACTIONS(46),
+    [sym_comment] = ACTIONS(3),
+  },
+  [8] = {
+    [ts_builtin_sym_end] = ACTIONS(50),
+    [anon_sym_LPAREN] = ACTIONS(50),
+    [anon_sym_RPAREN] = ACTIONS(50),
+    [sym_dot] = ACTIONS(50),
+    [sym_hex] = ACTIONS(50),
+    [sym_number] = ACTIONS(52),
+    [sym_symbol] = ACTIONS(52),
+    [sym_string] = ACTIONS(50),
+    [sym_comment] = ACTIONS(3),
+  },
+  [9] = {
+    [ts_builtin_sym_end] = ACTIONS(54),
+    [anon_sym_LPAREN] = ACTIONS(54),
+    [anon_sym_RPAREN] = ACTIONS(54),
+    [sym_dot] = ACTIONS(54),
+    [sym_hex] = ACTIONS(54),
+    [sym_number] = ACTIONS(56),
+    [sym_symbol] = ACTIONS(56),
+    [sym_string] = ACTIONS(54),
+    [sym_comment] = ACTIONS(3),
+  },
+  [10] = {
+    [sym__sexp] = STATE(13),
+    [sym_list] = STATE(13),
+    [anon_sym_LPAREN] = ACTIONS(7),
+    [sym_hex] = ACTIONS(58),
+    [sym_number] = ACTIONS(60),
+    [sym_symbol] = ACTIONS(60),
+    [sym_string] = ACTIONS(58),
+    [sym_comment] = ACTIONS(3),
+  },
+  [11] = {
+    [sym__sexp] = STATE(14),
+    [sym_list] = STATE(14),
+    [anon_sym_LPAREN] = ACTIONS(7),
+    [sym_hex] = ACTIONS(62),
+    [sym_number] = ACTIONS(64),
+    [sym_symbol] = ACTIONS(64),
+    [sym_string] = ACTIONS(62),
+    [sym_comment] = ACTIONS(3),
+  },
+};
+
+static const uint16_t ts_small_parse_table[] = {
+  [0] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(66), 1,
+      ts_builtin_sym_end,
+  [7] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(68), 1,
+      anon_sym_RPAREN,
+  [14] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(70), 1,
+      anon_sym_RPAREN,
+};
+
+static const uint32_t ts_small_parse_table_map[] = {
+  [SMALL_STATE(12)] = 0,
+  [SMALL_STATE(13)] = 7,
+  [SMALL_STATE(14)] = 14,
+};
+
+static const TSParseActionEntry ts_parse_actions[] = {
+  [0] = {.entry = {.count = 0, .reusable = false}},
+  [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
+  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
+  [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 0, 0, 0),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
+  [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0),
+  [15] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(3),
+  [18] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(2),
+  [21] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(2),
+  [24] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [26] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [28] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [30] = {.entry = {.count = 1, .reusable = false}}, SHIFT(4),
+  [32] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [34] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [36] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [38] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
+  [40] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, 0, 0),
+  [42] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list, 2, 0, 0),
+  [44] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list, 2, 0, 0),
+  [46] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list, 3, 0, 0),
+  [48] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list, 3, 0, 0),
+  [50] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list, 4, 0, 0),
+  [52] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list, 4, 0, 0),
+  [54] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list, 5, 0, 0),
+  [56] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list, 5, 0, 0),
+  [58] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [60] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
+  [62] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [64] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
+  [66] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [68] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#ifdef TREE_SITTER_HIDE_SYMBOLS
+#define TS_PUBLIC
+#elif defined(_WIN32)
+#define TS_PUBLIC __declspec(dllexport)
+#else
+#define TS_PUBLIC __attribute__((visibility("default")))
+#endif
+
+TS_PUBLIC const TSLanguage *tree_sitter_chialisp(void) {
+  static const TSLanguage language = {
+    .version = LANGUAGE_VERSION,
+    .symbol_count = SYMBOL_COUNT,
+    .alias_count = ALIAS_COUNT,
+    .token_count = TOKEN_COUNT,
+    .external_token_count = EXTERNAL_TOKEN_COUNT,
+    .state_count = STATE_COUNT,
+    .large_state_count = LARGE_STATE_COUNT,
+    .production_id_count = PRODUCTION_ID_COUNT,
+    .field_count = FIELD_COUNT,
+    .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,
+    .parse_table = &ts_parse_table[0][0],
+    .small_parse_table = ts_small_parse_table,
+    .small_parse_table_map = ts_small_parse_table_map,
+    .parse_actions = ts_parse_actions,
+    .symbol_names = ts_symbol_names,
+    .symbol_metadata = ts_symbol_metadata,
+    .public_symbol_map = ts_symbol_map,
+    .alias_map = ts_non_terminal_alias_map,
+    .alias_sequences = &ts_alias_sequences[0][0],
+    .lex_modes = ts_lex_modes,
+    .lex_fn = ts_lex,
+    .primary_state_ids = ts_primary_state_ids,
+  };
+  return &language;
+}
+#ifdef __cplusplus
+}
+#endif

--- a/internal/cbm/vendored/grammars/chialisp/tree_sitter/alloc.h
+++ b/internal/cbm/vendored/grammars/chialisp/tree_sitter/alloc.h
@@ -1,0 +1,54 @@
+#ifndef TREE_SITTER_ALLOC_H_
+#define TREE_SITTER_ALLOC_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Allow clients to override allocation functions
+#ifdef TREE_SITTER_REUSE_ALLOCATOR
+
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
+
+#ifndef ts_malloc
+#define ts_malloc  ts_current_malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  ts_current_calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc ts_current_realloc
+#endif
+#ifndef ts_free
+#define ts_free    ts_current_free
+#endif
+
+#else
+
+#ifndef ts_malloc
+#define ts_malloc  malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc realloc
+#endif
+#ifndef ts_free
+#define ts_free    free
+#endif
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_ALLOC_H_

--- a/internal/cbm/vendored/grammars/chialisp/tree_sitter/array.h
+++ b/internal/cbm/vendored/grammars/chialisp/tree_sitter/array.h
@@ -1,0 +1,291 @@
+#ifndef TREE_SITTER_ARRAY_H_
+#define TREE_SITTER_ARRAY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "./alloc.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
+#define Array(T)       \
+  struct {             \
+    T *contents;       \
+    uint32_t size;     \
+    uint32_t capacity; \
+  }
+
+/// Initialize an array.
+#define array_init(self) \
+  ((self)->size = 0, (self)->capacity = 0, (self)->contents = NULL)
+
+/// Create an empty array.
+#define array_new() \
+  { NULL, 0, 0 }
+
+/// Get a pointer to the element at a given `index` in the array.
+#define array_get(self, _index) \
+  (assert((uint32_t)(_index) < (self)->size), &(self)->contents[_index])
+
+/// Get a pointer to the first element in the array.
+#define array_front(self) array_get(self, 0)
+
+/// Get a pointer to the last element in the array.
+#define array_back(self) array_get(self, (self)->size - 1)
+
+/// Clear the array, setting its size to zero. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_clear(self) ((self)->size = 0)
+
+/// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
+/// less than the array's current capacity, this function has no effect.
+#define array_reserve(self, new_capacity) \
+  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
+
+/// Free any memory allocated for this array. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_delete(self) _array__delete((Array *)(self))
+
+/// Push a new `element` onto the end of the array.
+#define array_push(self, element)                            \
+  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
+   (self)->contents[(self)->size++] = (element))
+
+/// Increase the array's size by `count` elements.
+/// New elements are zero-initialized.
+#define array_grow_by(self, count) \
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
+
+/// Append all elements from one array to the end of another.
+#define array_push_all(self, other)                                       \
+  array_extend((self), (other)->size, (other)->contents)
+
+/// Append `count` elements to the end of the array, reading their values from the
+/// `contents` pointer.
+#define array_extend(self, count, contents)                    \
+  _array__splice(                                               \
+    (Array *)(self), array_elem_size(self), (self)->size, \
+    0, count,  contents                                        \
+  )
+
+/// Remove `old_count` elements from the array starting at the given `index`. At
+/// the same index, insert `new_count` new elements, reading their values from the
+/// `new_contents` pointer.
+#define array_splice(self, _index, old_count, new_count, new_contents)  \
+  _array__splice(                                                       \
+    (Array *)(self), array_elem_size(self), _index,                \
+    old_count, new_count, new_contents                                 \
+  )
+
+/// Insert one `element` into the array at the given `index`.
+#define array_insert(self, _index, element) \
+  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
+
+/// Remove one element from the array at the given `index`.
+#define array_erase(self, _index) \
+  _array__erase((Array *)(self), array_elem_size(self), _index)
+
+/// Pop the last element off the array, returning the element by value.
+#define array_pop(self) ((self)->contents[--(self)->size])
+
+/// Assign the contents of one array to another, reallocating if necessary.
+#define array_assign(self, other) \
+  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
+
+/// Swap one array with another
+#define array_swap(self, other) \
+  _array__swap((Array *)(self), (Array *)(other))
+
+/// Get the size of the array contents
+#define array_elem_size(self) (sizeof *(self)->contents)
+
+/// Search a sorted array for a given `needle` value, using the given `compare`
+/// callback to determine the order.
+///
+/// If an existing element is found to be equal to `needle`, then the `index`
+/// out-parameter is set to the existing value's index, and the `exists`
+/// out-parameter is set to true. Otherwise, `index` is set to an index where
+/// `needle` should be inserted in order to preserve the sorting, and `exists`
+/// is set to false.
+#define array_search_sorted_with(self, compare, needle, _index, _exists) \
+  _array__search_sorted(self, 0, compare, , needle, _index, _exists)
+
+/// Search a sorted array for a given `needle` value, using integer comparisons
+/// of a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_with`.
+#define array_search_sorted_by(self, field, needle, _index, _exists) \
+  _array__search_sorted(self, 0, _compare_int, field, needle, _index, _exists)
+
+/// Insert a given `value` into a sorted array, using the given `compare`
+/// callback to determine the order.
+#define array_insert_sorted_with(self, compare, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_with(self, compare, &(value), &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+/// Insert a given `value` into a sorted array, using integer comparisons of
+/// a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_by`.
+#define array_insert_sorted_by(self, field, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_by(self, field, (value) field, &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+// Private
+
+typedef Array(void) Array;
+
+/// This is not what you're looking for, see `array_delete`.
+static inline void _array__delete(Array *self) {
+  if (self->contents) {
+    ts_free(self->contents);
+    self->contents = NULL;
+    self->size = 0;
+    self->capacity = 0;
+  }
+}
+
+/// This is not what you're looking for, see `array_erase`.
+static inline void _array__erase(Array *self, size_t element_size,
+                                uint32_t index) {
+  assert(index < self->size);
+  char *contents = (char *)self->contents;
+  memmove(contents + index * element_size, contents + (index + 1) * element_size,
+          (self->size - index - 1) * element_size);
+  self->size--;
+}
+
+/// This is not what you're looking for, see `array_reserve`.
+static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
+  if (new_capacity > self->capacity) {
+    if (self->contents) {
+      self->contents = ts_realloc(self->contents, new_capacity * element_size);
+    } else {
+      self->contents = ts_malloc(new_capacity * element_size);
+    }
+    self->capacity = new_capacity;
+  }
+}
+
+/// This is not what you're looking for, see `array_assign`.
+static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
+  _array__reserve(self, element_size, other->size);
+  self->size = other->size;
+  memcpy(self->contents, other->contents, self->size * element_size);
+}
+
+/// This is not what you're looking for, see `array_swap`.
+static inline void _array__swap(Array *self, Array *other) {
+  Array swap = *other;
+  *other = *self;
+  *self = swap;
+}
+
+/// This is not what you're looking for, see `array_push` or `array_grow_by`.
+static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
+  if (new_size > self->capacity) {
+    uint32_t new_capacity = self->capacity * 2;
+    if (new_capacity < 8) new_capacity = 8;
+    if (new_capacity < new_size) new_capacity = new_size;
+    _array__reserve(self, element_size, new_capacity);
+  }
+}
+
+/// This is not what you're looking for, see `array_splice`.
+static inline void _array__splice(Array *self, size_t element_size,
+                                 uint32_t index, uint32_t old_count,
+                                 uint32_t new_count, const void *elements) {
+  uint32_t new_size = self->size + new_count - old_count;
+  uint32_t old_end = index + old_count;
+  uint32_t new_end = index + new_count;
+  assert(old_end <= self->size);
+
+  _array__reserve(self, element_size, new_size);
+
+  char *contents = (char *)self->contents;
+  if (self->size > old_end) {
+    memmove(
+      contents + new_end * element_size,
+      contents + old_end * element_size,
+      (self->size - old_end) * element_size
+    );
+  }
+  if (new_count > 0) {
+    if (elements) {
+      memcpy(
+        (contents + index * element_size),
+        elements,
+        new_count * element_size
+      );
+    } else {
+      memset(
+        (contents + index * element_size),
+        0,
+        new_count * element_size
+      );
+    }
+  }
+  self->size += new_count - old_count;
+}
+
+/// A binary search routine, based on Rust's `std::slice::binary_search_by`.
+/// This is not what you're looking for, see `array_search_sorted_with` or `array_search_sorted_by`.
+#define _array__search_sorted(self, start, compare, suffix, needle, _index, _exists) \
+  do { \
+    *(_index) = start; \
+    *(_exists) = false; \
+    uint32_t size = (self)->size - *(_index); \
+    if (size == 0) break; \
+    int comparison; \
+    while (size > 1) { \
+      uint32_t half_size = size / 2; \
+      uint32_t mid_index = *(_index) + half_size; \
+      comparison = compare(&((self)->contents[mid_index] suffix), (needle)); \
+      if (comparison <= 0) *(_index) = mid_index; \
+      size -= half_size; \
+    } \
+    comparison = compare(&((self)->contents[*(_index)] suffix), (needle)); \
+    if (comparison == 0) *(_exists) = true; \
+    else if (comparison < 0) *(_index) += 1; \
+  } while (0)
+
+/// Helper macro for the `_sorted_by` routines below. This takes the left (existing)
+/// parameter by reference in order to work with the generic sorting function above.
+#define _compare_int(a, b) ((int)*(a) - (int)(b))
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_ARRAY_H_

--- a/internal/cbm/vendored/grammars/chialisp/tree_sitter/parser.h
+++ b/internal/cbm/vendored/grammars/chialisp/tree_sitter/parser.h
@@ -1,0 +1,266 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSFieldMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
+struct TSLanguage {
+  uint32_t version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+  const TSStateId *primary_state_ids;
+};
+
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
+/*
+ *  Lexer Macros
+ */
+
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  UNUSED                        \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value)          \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value),         \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_

--- a/src/discover/language.c
+++ b/src/discover/language.c
@@ -542,6 +542,9 @@ static const ext_entry_t EXT_TABLE[] = {
 
     /* Scheme */
     {".scm", CBM_LANG_SCHEME},
+    {".clsp", CBM_LANG_CHIALISP},
+    {".clib", CBM_LANG_CHIALISP},
+    {".clinc", CBM_LANG_CHIALISP},
 
     /* Slang */
     {".slang", CBM_LANG_SLANG},
@@ -752,6 +755,7 @@ static const char *LANG_NAMES[CBM_LANG_COUNT] = {
     [CBM_LANG_DLANG] = "D",
     [CBM_LANG_NIM] = "Nim",
     [CBM_LANG_SCHEME] = "Scheme",
+    [CBM_LANG_CHIALISP] = "Chialisp",
     [CBM_LANG_FENNEL] = "Fennel",
     [CBM_LANG_FISH] = "Fish",
     [CBM_LANG_AWK] = "AWK",


### PR DESCRIPTION
## What

Adds **Chialisp** (cl-26) as a first-class indexed language. Chialisp is the smart-contract language of the Chia blockchain — an s-expression language compiled to CLVM.

## Grammar

A clean-room tree-sitter grammar — **[irulast/tree-sitter-chialisp](https://github.com/irulast/tree-sitter-chialisp)** (MIT). A generic s-expression core (`list`/`symbol`/`number`/`hex`/`string`/`comment`) authored against the `clvm_tools_rs` compiler frontend; parses the full cl-26 surface (`mod`, `defun`, `defmacro`, `defconstant`, `assign`, `lambda`, `include`, `embed-file`, `namespace`, …). Vendored under `internal/cbm/vendored/grammars/chialisp/` per the MANIFEST convention (ABI 14).

## Wiring (mirrors the existing Scheme lisp-family path — zero new extractor functions)

- `CBM_LANG_CHIALISP` enum + `lang_specs` row (`list`/`symbol` node types); `.clsp`/`.clib`/`.clinc` extension mapping.
- `CBM_LANG_CHIALISP` added to the four lisp-family extractor gates (`extract_defs`/`extract_calls`/`extract_imports`/`extract_unified`).

## Chialisp-correct extraction

Chialisp differs from the generic lisp path in a few load-bearing ways:
- **def heads**: `defun`, `defun-inline`, `defmacro`, `defmac`, `defconstant`, `defconst`, `mod`, `namespace`, `export`, `embed-file`, `compile-file`.
- **`mod`/`export` named by filename** — their `named_child(1)` is the arg list, not a name.
- **CLVM primitive operators filtered from CALLS** (the 49-entry `clvm_tools_rs` keyword table) so `(sha256 …)` / `(+ …)` / `(c …)` don't create phantom edges; `sha256tree` (a real defun) is kept.
- **dialect sigils** `(include *standard-cl-26*)` are not import edges (they select a dialect, not a file); `(include "x.clib")` is.
- **quoted bodies** `(q …)`/`(quote …)`/`(qq …)` are data — not descended.
- **`embed-file`/`compile-file`** emit a `Constant` node + a file-dependency edge.

## Verification

Indexed a 313-file cl-26 corpus (304 `.clsp` + 9 `.clib`): **514 Functions, 469 Constants**; CALLS to real helpers only (zero primitive phantoms, `sha256tree` kept); imports to real `.clib` only (zero dialect-sigil phantoms). The grammar parses all 313 files with zero ERROR/MISSING nodes. Clean `-Werror` build; Scheme/Clojure/CommonLisp regression samples unchanged. `MANIFEST.md` updated (grammar entry + custom-handling row).
