### PR TITLE
fix(lsp/php): prevent OOM when a PHP trait uses itself

### DIFF
--- a/internal/cbm/lsp/php_lsp.c
+++ b/internal/cbm/lsp/php_lsp.c
@@ -3459,13 +3459,31 @@ static void flatten_trait_into_class(PHPLSPContext *ctx, CBMTypeRegistry *reg, c
         t = lookup_type_with_project(ctx, trait_qn);
     const char *canonical_trait_qn = t ? t->qualified_name : trait_qn;
 
+    /* A trait cannot meaningfully flatten into itself. PHP itself rejects
+     * `trait T { use T; }` ("Trait T cannot use itself"), and an aliased
+     * `use X as Y; use Y;` can resolve back onto the enclosing trait by short
+     * name. Without this guard the loop below copies the trait's own methods
+     * back onto it with receiver_type == canonical_trait_qn; because each copy
+     * then re-matches the loop's filter while cbm_registry_add_func() keeps
+     * growing reg->func_count, the iteration never terminates — it arena-
+     * allocates a fresh method every pass until the process exhausts all
+     * memory (observed: 40 GB+, freezing the host). See regression test
+     * phplsp_trait_self_use_terminates. */
+    if (strcmp(class_qn, canonical_trait_qn) == 0)
+        return;
+
     /* Iterate registry funcs whose receiver_type is the trait.
      *
      * Self-substitution: when the trait's method has a return type that
      * names the trait itself (e.g. `tap(): self` registered as
      * NAMED(trait_qn)), rewrite it to NAMED(using_class_qn) so chains
-     * like `$c->tap()->classMethod()` resolve correctly. */
-    for (int i = 0; i < reg->func_count; i++) {
+     * like `$c->tap()->classMethod()` resolve correctly.
+     *
+     * Snapshot the count before iterating: cbm_registry_add_func() below
+     * appends to reg->funcs, so the loop must never visit entries it adds
+     * during iteration (a mutate-while-iterating hazard). */
+    const int func_count_before = reg->func_count;
+    for (int i = 0; i < func_count_before; i++) {
         const CBMRegisteredFunc *src = &reg->funcs[i];
         if (!src->receiver_type || strcmp(src->receiver_type, canonical_trait_qn) != 0) {
             continue;

--- a/tests/test_php_lsp.c
+++ b/tests/test_php_lsp.c
@@ -543,6 +543,31 @@ TEST(phplsp_trait_method_flattened) {
     PASS();
 }
 
+/* ── 23b. Regression: a trait that uses itself must terminate ─────
+ *
+ * `trait T { use T; ... }` — directly, or via an alias that resolves back
+ * to T by short name (`use Other\T as A; use A;`) — previously sent
+ * flatten_trait_into_class() into an unbounded loop: each copied method
+ * re-matched the loop filter while cbm_registry_add_func() grew the
+ * registry, exhausting all memory (40 GB+, freezing the host). The fix
+ * short-circuits self-flattening and snapshots the loop bound. The
+ * assertion is simply that extraction returns: pre-fix this never
+ * completed, and under the ASan test build a regression would surface as
+ * an OOM/abort here rather than a silent hang. */
+TEST(phplsp_trait_self_use_terminates) {
+    const char *src =
+        "<?php\n"
+        "namespace App;\n"
+        "trait EnumTrait {\n"
+        "    use EnumTrait;\n"
+        "    public function getRandom(): int { return 1; }\n"
+        "}\n";
+    CBMFileResult *r = extract_php(src);
+    ASSERT(r);
+    cbm_free_result(r);
+    PASS();
+}
+
 /* ── 24. Match expression result type ──────────────────────────── */
 
 TEST(phplsp_match_result_type) {
@@ -5160,6 +5185,7 @@ SUITE(php_lsp) {
     RUN_TEST(phplsp_phpdoc_property_class_tag);
     RUN_TEST(phplsp_phpdoc_method_class_tag);
     RUN_TEST(phplsp_trait_method_flattened);
+    RUN_TEST(phplsp_trait_self_use_terminates);
     RUN_TEST(phplsp_match_result_type);
     RUN_TEST(phplsp_ternary_result_type);
     RUN_TEST(phplsp_method_chain_depth_three);


### PR DESCRIPTION
## What does this PR do?

Fixes an **unbounded memory blow-up** (observed **40 GB+**, freezing the host)
when the PHP Hybrid-LSP pass indexes a file whose **trait uses itself**. It was
hit in a real project by a 4-line trait; the only workaround was to add the file
to `.cbmignore`.

**Minimal reproducer** (`index_repository`, `mode: "full"` — runs away on `main`):

```php
<?php
namespace App;
trait EnumTrait {
    use EnumTrait;                                  // trait adopts itself
    public function getRandom(): int { return 1; }
}
```

It also triggers via an alias that resolves back to the enclosing trait by short
name, which is how it appeared in the wild (`use Vendor\EnumTrait as X; use X;`
inside a trait that is itself named `EnumTrait`).

### Root cause

`flatten_trait_into_class()` in `internal/cbm/lsp/php_lsp.c` copies a trait's
methods onto the using class by iterating the type registry with a **live upper
bound**:

```c
for (int i = 0; i < reg->func_count; i++) {         // bound grows inside the loop
    if (strcmp(src->receiver_type, canonical_trait_qn) != 0) continue;
    ...
    rf.receiver_type = class_qn;                     // copy tagged with the user
    cbm_registry_add_func(reg, rf);                  // APPENDS → func_count++
}
```

`cbm_registry_add_func()` appends to the very array being iterated (no dedup) and
increments `reg->func_count`. Normally the copies get `receiver_type = class_qn`,
which differs from the trait, so they don't re-match and the loop ends.

When a trait adopts **itself**, `class_qn == canonical_trait_qn`, so every copied
method is tagged with the trait's own QN and **re-matches the loop filter** —
appending another method and pushing the bound out ahead of `i`. The loop never
terminates, arena-allocating a fresh method each pass until memory is exhausted.

(Confirmed by differential reduction — self-adoption + ≥1 member + a trait `use`
are each necessary — and a live `sample(1)` showing `flatten_trait_into_class →
cbm_arena_sprintf` with the footprint climbing through 6 GB.)

### Fix (`internal/cbm/lsp/php_lsp.c`)

1. **Short-circuit self-flattening** — a trait cannot meaningfully use itself
   (PHP raises *"Trait X cannot use itself"*), so return early when
   `class_qn == canonical_trait_qn`. This removes the only path by which an
   appended func can re-match the filter.
2. **Snapshot the loop bound** before iterating, so entries appended during the
   loop are never revisited — closing the mutate-while-iterating hazard
   structurally, independent of (1).

## Checklist

- [x] Every commit is signed off (`git commit -s`) — DCO trailer present
- [x] Tests pass locally — full `build/c/test-runner` (ASan+UBSan): **5916 passed,
      1 skipped, 0 failures, 0 sanitizer errors**; `php_lsp` suite **279/279**
- [ ] Lint passes (`make -f Makefile.cbm lint-ci`) — could not run locally
      (clang-format / clang-tidy / cppcheck not installed). Diff manually checked
      against `.clang-format` (LLVM, ColumnLimit 100: added lines ≤ 79, 4-space
      indent, attach braces) and mirrors the surrounding formatted code; please
      let CI verify.
- [x] New behavior is covered by a test (reproduce-first) — added
      `phplsp_trait_self_use_terminates`, confirmed it **hangs/OOMs on pre-fix
      code** and **passes after** the fix.

---

Verified end to end: the production binary now indexes the original triggering
file (and its real-world siblings) in **< 0.5 s at ~6 MB RSS** instead of running
away.
