### PR TITLE
perf: kernel-scale indexing campaign (-61% wall, deterministic output)

### DIFF
--- a/Makefile.cbm
+++ b/Makefile.cbm
@@ -412,6 +412,7 @@ TEST_STACK_OVERFLOW_SRCS = tests/test_stack_overflow.c
 # Kept out of the gating `make test` so `ci-ok` stays green; run via `make test-repro`.
 TEST_REPRO_SRCS = \
     tests/repro/repro_main.c \
+    tests/repro/repro_parallel_determinism.c \
     tests/repro/repro_extraction.c \
     tests/repro/repro_issue495.c \
     tests/repro/repro_issue521.c \

--- a/Makefile.cbm
+++ b/Makefile.cbm
@@ -220,7 +220,7 @@ PIPELINE_SRCS = \
 SIMHASH_SRCS = src/simhash/minhash.c
 
 # Semantic embedding module
-SEMANTIC_SRCS = src/semantic/semantic.c src/semantic/ast_profile.c
+SEMANTIC_SRCS = src/semantic/semantic.c src/semantic/ast_profile.c src/semantic/rotsq.c
 
 # nomic-embed-code pretrained vectors (assembler blob)
 UNIXCODER_BLOB_SRC = vendored/nomic/code_vectors_blob.S

--- a/internal/cbm/lsp/c_lsp.c
+++ b/internal/cbm/lsp/c_lsp.c
@@ -64,6 +64,7 @@ void c_lsp_init(CLSPContext *ctx, CBMArena *arena, const char *source, int sourc
     ctx->source_len = source_len;
     ctx->registry = registry;
     ctx->module_qn = module_qn;
+    ctx->module_qn_len = module_qn ? strlen(module_qn) : 0;
     ctx->cpp_mode = cpp_mode;
     ctx->resolved_calls = out;
     ctx->current_scope = cbm_scope_push(arena, NULL);
@@ -2506,6 +2507,105 @@ static const CBMType *c_eval_expr_type_inner(CLSPContext *ctx, TSNode node) {
 // c_lookup_member: method/field lookup with base class traversal
 // ============================================================================
 
+// Build "<module_qn>.<type_qn>" into a caller-provided stack buffer, replacing the
+// vsnprintf("%s.%s") path (whose %s does a strlen of both args) that otherwise
+// dominates the kernel cross-file resolve miss cascade. Uses the cached module_qn_len.
+// Returns buf on success, or NULL if the result would not fit (caller falls back to
+// cbm_arena_sprintf). The buffer is only read by the immediate registry lookup — a
+// stack lifetime is sufficient (the QN is never retained).
+static const char *c_build_module_prefixed(const CLSPContext *ctx, const char *type_qn, char *buf,
+                                           size_t bufsz) {
+    size_t mlen = ctx->module_qn_len;
+    size_t tlen = strlen(type_qn);
+    if (mlen + 1 + tlen + 1 > bufsz)
+        return NULL; // would truncate → fall back to arena sprintf
+    memcpy(buf, ctx->module_qn, mlen);
+    buf[mlen] = '.';
+    memcpy(buf + mlen + 1, type_qn, tlen);
+    buf[mlen + 1 + tlen] = '\0';
+    return buf;
+}
+
+// FNV-1a over (type_qn, 0xff separator, member_name) for the negative-lookup memo.
+// 0 is remapped to 1 so it can serve as the empty-slot sentinel.
+static uint64_t c_neg_memo_hash(const char *type_qn, const char *member_name) {
+    uint64_t h = 1469598103934665603ULL; // FNV-1a offset basis
+    for (const unsigned char *p = (const unsigned char *)type_qn; *p; p++) {
+        h ^= (uint64_t)*p;
+        h *= 1099511628211ULL;
+    }
+    h ^= (uint64_t)0xffu;
+    h *= 1099511628211ULL;
+    for (const unsigned char *p = (const unsigned char *)member_name; *p; p++) {
+        h ^= (uint64_t)*p;
+        h *= 1099511628211ULL;
+    }
+    return h ? h : 1ULL;
+}
+
+static bool c_neg_memo_contains(const CLSPContext *ctx, uint64_t h) {
+    if (!ctx->neg_memo || ctx->neg_memo_cap == 0)
+        return false;
+    uint64_t mask = (uint64_t)ctx->neg_memo_cap - 1;
+    for (uint64_t i = h & mask;; i = (i + 1) & mask) {
+        uint64_t slot = ctx->neg_memo[i];
+        if (slot == 0)
+            return false; // empty slot → not present
+        if (slot == h)
+            return true;
+    }
+}
+
+static void c_neg_memo_insert(CLSPContext *ctx, uint64_t h) {
+    // Lazy alloc / grow-by-rehash at 70% load. On OOM, silently disable the memo
+    // (correctness is unaffected — the full cascade still runs).
+    if (ctx->neg_memo == NULL) {
+        uint64_t *nm = (uint64_t *)calloc(1024, sizeof(uint64_t));
+        if (!nm)
+            return;
+        ctx->neg_memo = nm;
+        ctx->neg_memo_cap = 1024;
+        ctx->neg_memo_count = 0;
+    } else if ((ctx->neg_memo_count + 1) * 10 >= ctx->neg_memo_cap * 7) {
+        int new_cap = ctx->neg_memo_cap * 2;
+        uint64_t *nm = (uint64_t *)calloc((size_t)new_cap, sizeof(uint64_t));
+        if (nm) {
+            uint64_t nmask = (uint64_t)new_cap - 1;
+            for (int j = 0; j < ctx->neg_memo_cap; j++) {
+                uint64_t v = ctx->neg_memo[j];
+                if (v == 0)
+                    continue;
+                uint64_t k = v & nmask;
+                while (nm[k] != 0)
+                    k = (k + 1) & nmask;
+                nm[k] = v;
+            }
+            free(ctx->neg_memo);
+            ctx->neg_memo = nm;
+            ctx->neg_memo_cap = new_cap;
+        }
+        // if calloc failed: keep the existing table (load may exceed 70%, still correct)
+    }
+    uint64_t mask = (uint64_t)ctx->neg_memo_cap - 1;
+    for (uint64_t i = h & mask;; i = (i + 1) & mask) {
+        if (ctx->neg_memo[i] == 0) {
+            ctx->neg_memo[i] = h;
+            ctx->neg_memo_count++;
+            return;
+        }
+        if (ctx->neg_memo[i] == h)
+            return; // already recorded
+    }
+}
+
+static void c_neg_memo_free(CLSPContext *ctx) {
+    if (ctx->neg_memo)
+        free(ctx->neg_memo);
+    ctx->neg_memo = NULL;
+    ctx->neg_memo_cap = 0;
+    ctx->neg_memo_count = 0;
+}
+
 static const CBMRegisteredFunc *c_lookup_member_depth(CLSPContext *ctx, const char *type_qn,
                                                       const char *member_name, int depth) {
     if (!type_qn || !member_name)
@@ -2513,21 +2613,42 @@ static const CBMRegisteredFunc *c_lookup_member_depth(CLSPContext *ctx, const ch
     if (depth > CBM_LSP_MAX_LOOKUP_DEPTH)
         return NULL;
 
-    // Direct method lookup
+    // Direct method lookup. Runs FIRST, before consulting the memo, so a real
+    // direct-resolvable member (incl. a hash-collision victim, or one registered
+    // mid-file) can never be skipped: it is returned here regardless of the memo.
     const CBMRegisteredFunc *f = cbm_registry_lookup_method(ctx->registry, type_qn, member_name);
     if (f)
         return f;
 
-    // Try module-prefixed QN (e.g., "Container" -> "test.main.Container")
-    if (ctx->module_qn) {
-        const char *prefixed = cbm_arena_sprintf(ctx->arena, "%s.%s", ctx->module_qn, type_qn);
+    // Negative-lookup memo (depth==0, shared read-only registry only). A recorded
+    // hit means this exact (type_qn, member) already failed the whole cascade. Under
+    // the sealed Tier-2 registry the module-prefix (below), base-class and short-name
+    // cascades are pure, immutable functions of (type_qn, registry), so they are
+    // provably still NULL and can be skipped. Only the SCOPE-ALIAS path is
+    // context-dependent, so it is still evaluated below before we trust the memo.
+    // The direct lookup above already served as the collision/staleness verification.
+    bool neg_memo_hit = false;
+    uint64_t neg_h = 0;
+    if (depth == 0 && ctx->registry_shared) {
+        neg_h = c_neg_memo_hash(type_qn, member_name);
+        neg_memo_hit = c_neg_memo_contains(ctx, neg_h);
+    }
+
+    // Try module-prefixed QN (e.g., "Container" -> "test.main.Container").
+    // Skipped on a memo hit: provably NULL under the read-only shared registry.
+    if (!neg_memo_hit && ctx->module_qn) {
+        char sbuf[1024];
+        const char *prefixed = c_build_module_prefixed(ctx, type_qn, sbuf, sizeof(sbuf));
+        if (!prefixed)
+            prefixed = cbm_arena_sprintf(ctx->arena, "%s.%s", ctx->module_qn, type_qn);
         f = cbm_registry_lookup_method(ctx->registry, prefixed, member_name);
         if (f)
             return f;
     }
 
     // Scope-based alias: using Vec = std::vector<T>;
-    // Vec is in scope as ALIAS → follow to underlying type's QN
+    // Vec is in scope as ALIAS → follow to underlying type's QN.
+    // ALWAYS evaluated (scope is context-dependent — not covered by the memo).
     {
         const CBMType *scoped = cbm_scope_lookup(ctx->current_scope, type_qn);
         if (scoped && scoped->kind == CBM_TYPE_ALIAS) {
@@ -2543,11 +2664,21 @@ static const CBMRegisteredFunc *c_lookup_member_depth(CLSPContext *ctx, const ch
         }
     }
 
+    // Memo hit and the scope-alias path also missed: the remaining base-class and
+    // short-name cascades are registry-only and provably NULL → skip them (this is
+    // where the O(type_count) short-name scan is avoided). Idempotent re-insert is
+    // unnecessary since neg_h is already present.
+    if (neg_memo_hit)
+        return NULL;
+
     // Check registered type for alias and base classes
     const CBMRegisteredType *rt = cbm_registry_lookup_type(ctx->registry, type_qn);
     if (!rt && ctx->module_qn) {
-        rt = cbm_registry_lookup_type(
-            ctx->registry, cbm_arena_sprintf(ctx->arena, "%s.%s", ctx->module_qn, type_qn));
+        char sbuf[1024];
+        const char *prefixed = c_build_module_prefixed(ctx, type_qn, sbuf, sizeof(sbuf));
+        if (!prefixed)
+            prefixed = cbm_arena_sprintf(ctx->arena, "%s.%s", ctx->module_qn, type_qn);
+        rt = cbm_registry_lookup_type(ctx->registry, prefixed);
     }
     if (rt) {
         // Alias chain
@@ -2606,6 +2737,10 @@ static const CBMRegisteredFunc *c_lookup_member_depth(CLSPContext *ctx, const ch
         }
     }
 
+    // Whole cascade missed: record the negative result so a repeat of this exact
+    // (type_qn, member) can skip the module-prefix/base-class/short-name work.
+    if (depth == 0 && ctx->registry_shared)
+        c_neg_memo_insert(ctx, neg_h);
     return NULL;
 }
 
@@ -4845,6 +4980,10 @@ __attribute__((no_sanitize("address"))) void c_lsp_process_file(CLSPContext *ctx
         child = kids[i];
         c_process_body_child(ctx, child);
     }
+
+    // Release the per-file negative-lookup memo (malloc-owned; only allocated in
+    // shared-registry mode). No-op when it was never populated.
+    c_neg_memo_free(ctx);
 }
 
 // ============================================================================

--- a/internal/cbm/lsp/c_lsp.h
+++ b/internal/cbm/lsp/c_lsp.h
@@ -44,6 +44,19 @@ typedef struct {
     const char *enclosing_func_qn;
     const char *enclosing_class_qn; // for implicit `this` resolution
     const char *module_qn;
+    size_t module_qn_len; // cached strlen(module_qn); for stack-buffer QN building
+
+    // Negative-lookup memo for c_lookup_member_depth (depth==0 misses only).
+    // Open-addressing uint64 hash SET; 0 is the empty-slot sentinel. Populated
+    // ONLY when the Tier-2 registry is shared+read-only (registry_shared), where
+    // the module-prefix/base-class/short-name cascades are pure, stable functions
+    // of (type_qn, registry) — so a recorded miss can never turn into a hit. Lets
+    // the hot resolve path skip the sprintf("%s.%s") strlen storm + the O(type_count)
+    // short-name scan on repeated misses of the same (type_qn, member). malloc-owned;
+    // freed at end of c_lsp_process_file.
+    uint64_t *neg_memo;
+    int neg_memo_cap;   // power-of-two; 0 until first insert
+    int neg_memo_count; // live entries (grow by rehash at 70% load)
 
     // Output
     CBMResolvedCallArray *resolved_calls;

--- a/internal/cbm/lsp/lsp_neg_memo.h
+++ b/internal/cbm/lsp/lsp_neg_memo.h
@@ -139,4 +139,92 @@ static inline void cbm_negmemo_insert(CBMNegMemo *m, CBMArena *arena, uint64_t k
     }
 }
 
+/* ── CBMIdxMemo: exact-match string-key → int index map ─────────────────────
+ * Companion for build-time registration loops that need "have I registered
+ * this QN, and at which index?" in O(1) — the registry's own buckets don't
+ * exist before finalize, and probing it linearly from inside the registration
+ * loop is the classic quadratic (kernel shared rust registry: ~63 s).
+ * Exact match: each slot stores the borrowed key pointer and verifies with
+ * strcmp, so hash collisions can't map to a wrong index. First-put wins. */
+typedef struct {
+    struct cbm_idxmemo_slot {
+        uint64_t h; /* 0 = empty */
+        const char *key;
+        int32_t val;
+    } *slots;
+    int cap; /* power of two */
+    int count;
+} CBMIdxMemo;
+
+static inline int32_t cbm_idxmemo_get(const CBMIdxMemo *m, const char *key) {
+    if (!m->slots || !key || m->count == 0) {
+        return -1;
+    }
+    uint64_t h = cbm_negmemo_key(0, key, NULL);
+    uint64_t mask = (uint64_t)(m->cap - 1);
+    for (uint64_t i = h & mask;; i = (i + 1) & mask) {
+        if (m->slots[i].h == 0) {
+            return -1;
+        }
+        if (m->slots[i].h == h && m->slots[i].key && strcmp(m->slots[i].key, key) == 0) {
+            return m->slots[i].val;
+        }
+    }
+}
+
+static inline void cbm_idxmemo_put_raw(struct cbm_idxmemo_slot *slots, int cap, uint64_t h,
+                                       const char *key, int32_t val) {
+    uint64_t mask = (uint64_t)(cap - 1);
+    for (uint64_t i = h & mask;; i = (i + 1) & mask) {
+        if (slots[i].h == 0) {
+            slots[i].h = h;
+            slots[i].key = key;
+            slots[i].val = val;
+            return;
+        }
+        if (slots[i].h == h && slots[i].key && strcmp(slots[i].key, key) == 0) {
+            return; /* first-put wins */
+        }
+    }
+}
+
+static inline void cbm_idxmemo_put_if_absent(CBMIdxMemo *m, CBMArena *arena, const char *key,
+                                             int32_t val) {
+    if (!arena || !key) {
+        return;
+    }
+    if (!m->slots) {
+        m->slots = cbm_arena_alloc(arena,
+                                   sizeof(struct cbm_idxmemo_slot) * CBM_NEGMEMO_INIT_CAP);
+        if (!m->slots) {
+            return;
+        }
+        memset(m->slots, 0, sizeof(struct cbm_idxmemo_slot) * CBM_NEGMEMO_INIT_CAP);
+        m->cap = CBM_NEGMEMO_INIT_CAP;
+        m->count = 0;
+    }
+    if ((int64_t)(m->count + 1) * CBM_NEGMEMO_LOAD_DEN >=
+        (int64_t)m->cap * CBM_NEGMEMO_LOAD_NUM) {
+        int new_cap = m->cap * CBM_NEGMEMO_GROW;
+        struct cbm_idxmemo_slot *ns =
+            cbm_arena_alloc(arena, sizeof(struct cbm_idxmemo_slot) * (size_t)new_cap);
+        if (!ns) {
+            return;
+        }
+        memset(ns, 0, sizeof(struct cbm_idxmemo_slot) * (size_t)new_cap);
+        for (int i = 0; i < m->cap; i++) {
+            if (m->slots[i].h) {
+                cbm_idxmemo_put_raw(ns, new_cap, m->slots[i].h, m->slots[i].key, m->slots[i].val);
+            }
+        }
+        m->slots = ns;
+        m->cap = new_cap;
+    }
+    uint64_t h = cbm_negmemo_key(0, key, NULL);
+    if (cbm_idxmemo_get(m, key) < 0) {
+        cbm_idxmemo_put_raw(m->slots, m->cap, h, key, val);
+        m->count++;
+    }
+}
+
 #endif /* CBM_LSP_NEG_MEMO_H */

--- a/internal/cbm/lsp/lsp_neg_memo.h
+++ b/internal/cbm/lsp/lsp_neg_memo.h
@@ -1,0 +1,142 @@
+/*
+ * lsp_neg_memo.h — generic negative-lookup memo for LSP resolve cascades.
+ *
+ * Problem (all hybrid-LSP languages): a resolve cascade probes a ladder of
+ * hypotheses (direct hit, module-prefixed retry, alias walk, trait/base
+ * dispatch, short-name fallback) and most probes MISS — macro-expanded or
+ * generated code asks the SAME failing question thousands of times per file,
+ * re-paying the whole ladder each time (linux kernel: 4 trait-heavy rust
+ * files at ~63 s each; the C resolver had the same disease before its memo).
+ *
+ * A miss is a pure fact of (registry, query) — but ONLY while the registry
+ * cannot change. Callers must therefore gate the memo on a SEALED registry
+ * (reg->read_only, set at finalize; cbm_registry_add_* hard-return then) and
+ * must key only queries whose cascade reads nothing but the registry and the
+ * query strings (no per-function scope state in the memoized rungs).
+ *
+ * Shape: open-addressing set of 64-bit keys, arena-backed (dies with the
+ * per-file arena — no explicit free, mirroring the py field overlay). A memo
+ * HIT means "this exact query already ran the full cascade and returned
+ * nothing" → the caller returns its miss result immediately. To make a hash
+ * collision harmless, callers keep their cheap DIRECT lookup before the memo
+ * check (the C-memo pattern): a colliding real hit is still found; only the
+ * expensive registry-pure miss ladder is skipped.
+ *
+ * Per-language wiring is a few lines: add a CBMNegMemo to the language ctx,
+ * key each cascade entry with cbm_negmemo_key (site tag + query strings),
+ * check at entry, insert on the miss return. Wired: rust. Candidates per the
+ * 2026-07 resolve audit: php, c# (extension methods), java, kotlin; the C
+ * resolver's bespoke memo in c_lsp.c predates this header and can migrate.
+ */
+#ifndef CBM_LSP_NEG_MEMO_H
+#define CBM_LSP_NEG_MEMO_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "arena.h"
+
+typedef struct {
+    uint64_t *slots; /* arena-owned; 0 = empty (keys are never 0) */
+    int cap;         /* power of two */
+    int count;
+} CBMNegMemo;
+
+enum {
+    CBM_NEGMEMO_INIT_CAP = 1024,
+    CBM_NEGMEMO_GROW = 2,
+    CBM_NEGMEMO_LOAD_NUM = 7, /* grow at 70% load */
+    CBM_NEGMEMO_LOAD_DEN = 10,
+};
+
+/* FNV-1a over (site tag, a, 0xff, b). The site tag keeps two cascades with
+ * the same argument strings from sharing keys. Never returns 0. */
+static inline uint64_t cbm_negmemo_key(uint8_t site, const char *a, const char *b) {
+    uint64_t h = 0xcbf29ce484222325ULL;
+    h ^= site;
+    h *= 0x100000001b3ULL;
+    if (a) {
+        while (*a) {
+            h ^= (unsigned char)*a++;
+            h *= 0x100000001b3ULL;
+        }
+    }
+    h ^= 0xff;
+    h *= 0x100000001b3ULL;
+    if (b) {
+        while (*b) {
+            h ^= (unsigned char)*b++;
+            h *= 0x100000001b3ULL;
+        }
+    }
+    return h ? h : 1;
+}
+
+static inline bool cbm_negmemo_contains(const CBMNegMemo *m, uint64_t key) {
+    if (!m->slots || m->count == 0) {
+        return false;
+    }
+    uint64_t mask = (uint64_t)(m->cap - 1);
+    for (uint64_t i = key & mask;; i = (i + 1) & mask) {
+        uint64_t s = m->slots[i];
+        if (s == 0) {
+            return false;
+        }
+        if (s == key) {
+            return true;
+        }
+    }
+}
+
+static inline void cbm_negmemo_insert_raw(uint64_t *slots, int cap, uint64_t key) {
+    uint64_t mask = (uint64_t)(cap - 1);
+    for (uint64_t i = key & mask;; i = (i + 1) & mask) {
+        if (slots[i] == key) {
+            return;
+        }
+        if (slots[i] == 0) {
+            slots[i] = key;
+            return;
+        }
+    }
+}
+
+/* Arena-backed insert: lazy first allocation, grow-by-rehash at 70% load.
+ * The abandoned table stays in the arena (bounded, freed with the file). */
+static inline void cbm_negmemo_insert(CBMNegMemo *m, CBMArena *arena, uint64_t key) {
+    if (!arena) {
+        return; /* no arena — memo silently disabled */
+    }
+    if (!m->slots) {
+        m->slots = cbm_arena_alloc(arena, sizeof(uint64_t) * CBM_NEGMEMO_INIT_CAP);
+        if (!m->slots) {
+            return;
+        }
+        memset(m->slots, 0, sizeof(uint64_t) * CBM_NEGMEMO_INIT_CAP);
+        m->cap = CBM_NEGMEMO_INIT_CAP;
+        m->count = 0;
+    }
+    if ((int64_t)(m->count + 1) * CBM_NEGMEMO_LOAD_DEN >=
+        (int64_t)m->cap * CBM_NEGMEMO_LOAD_NUM) {
+        int new_cap = m->cap * CBM_NEGMEMO_GROW;
+        uint64_t *ns = cbm_arena_alloc(arena, sizeof(uint64_t) * (size_t)new_cap);
+        if (!ns) {
+            return; /* keep the old (full-ish) table; inserts degrade, reads stay correct */
+        }
+        memset(ns, 0, sizeof(uint64_t) * (size_t)new_cap);
+        for (int i = 0; i < m->cap; i++) {
+            if (m->slots[i]) {
+                cbm_negmemo_insert_raw(ns, new_cap, m->slots[i]);
+            }
+        }
+        m->slots = ns;
+        m->cap = new_cap;
+    }
+    if (!cbm_negmemo_contains(m, key)) {
+        cbm_negmemo_insert_raw(m->slots, m->cap, key);
+        m->count++;
+    }
+}
+
+#endif /* CBM_LSP_NEG_MEMO_H */

--- a/internal/cbm/lsp/py_lsp.c
+++ b/internal/cbm/lsp/py_lsp.c
@@ -447,6 +447,50 @@ static const CBMRegisteredFunc *py_lookup_attribute(PyLSPContext *ctx, const cha
     return py_lookup_attribute_depth(ctx, type_qn, member_name, 0);
 }
 
+/* Per-file field overlay: look up a (class_qn, field_name) recorded during resolve
+ * against the sealed shared registry. Linear scan — the overlay only holds fields
+ * discovered in THIS file's own classes, so it is small. */
+static const CBMType *py_overlay_lookup_field(const PyLSPContext *ctx, const char *class_qn,
+                                              const char *field_name) {
+    for (int i = 0; i < ctx->field_overlay_count; i++) {
+        if (strcmp(ctx->field_overlay[i].class_qn, class_qn) == 0 &&
+            strcmp(ctx->field_overlay[i].field_name, field_name) == 0)
+            return ctx->field_overlay[i].field_type;
+    }
+    return NULL;
+}
+
+/* Record a (class_qn, field_name) -> field_type in the per-file overlay. Overwrites
+ * an existing entry (mirrors the direct-mutation overwrite semantics). Arena-backed;
+ * grows by copy. class_qn/field_name are arena-dup'd so the entry never borrows a
+ * transient node-text buffer. */
+static void py_overlay_register_field(PyLSPContext *ctx, const char *class_qn,
+                                      const char *field_name, const CBMType *field_type) {
+    for (int i = 0; i < ctx->field_overlay_count; i++) {
+        if (strcmp(ctx->field_overlay[i].class_qn, class_qn) == 0 &&
+            strcmp(ctx->field_overlay[i].field_name, field_name) == 0) {
+            ctx->field_overlay[i].field_type = field_type;
+            return;
+        }
+    }
+    if (ctx->field_overlay_count >= ctx->field_overlay_cap) {
+        int new_cap = ctx->field_overlay_cap == 0 ? 16 : ctx->field_overlay_cap * 2;
+        void *na = cbm_arena_alloc(ctx->arena, (size_t)new_cap * sizeof(*ctx->field_overlay));
+        if (!na)
+            return; /* OOM: drop this field (resolution degrades, never corrupts) */
+        if (ctx->field_overlay && ctx->field_overlay_count > 0)
+            memcpy(na, ctx->field_overlay,
+                   (size_t)ctx->field_overlay_count * sizeof(*ctx->field_overlay));
+        ctx->field_overlay = na;
+        ctx->field_overlay_cap = new_cap;
+    }
+    ctx->field_overlay[ctx->field_overlay_count].class_qn = cbm_arena_strdup(ctx->arena, class_qn);
+    ctx->field_overlay[ctx->field_overlay_count].field_name =
+        cbm_arena_strdup(ctx->arena, field_name);
+    ctx->field_overlay[ctx->field_overlay_count].field_type = field_type;
+    ctx->field_overlay_count++;
+}
+
 /* Look up a field on a registered type. Walks alias / embedded chain
  * with the same depth cap as method lookup. Returns the field's type
  * or NULL if no match. */
@@ -466,6 +510,15 @@ static const CBMType *py_lookup_field_depth(PyLSPContext *ctx, const char *type_
                 return rt->field_types[i];
             }
         }
+    }
+    /* Per-file overlay: `self.x = ...` fields discovered during resolve against the
+     * sealed shared registry live here (not on rt). Checked at the same point the
+     * direct field scan would have found them in the mutable path — preserving the
+     * derived-shadows-base precedence before recursing into alias/base classes. */
+    {
+        const CBMType *ov = py_overlay_lookup_field(ctx, type_qn, field_name);
+        if (ov)
+            return ov;
     }
     if (rt->alias_of) {
         const CBMType *a = py_lookup_field_depth(ctx, rt->alias_of, field_name, depth + 1);
@@ -496,6 +549,19 @@ static void py_register_instance_field(PyLSPContext *ctx, const char *class_qn,
                                        const char *field_name, const CBMType *field_type) {
     if (!ctx || !ctx->registry || !class_qn || !field_name || !field_type)
         return;
+
+    /* Shared Tier-2 registry is finalized + sealed (read_only) and read concurrently
+     * by all resolve workers. Writing its type entries directly below would bypass the
+     * add_* seal, race the other workers, and leave the shared entry pointing into
+     * this file's resolve arena (freed when the file completes). Route the discovery
+     * to the per-file overlay instead; py_lookup_field consults it alongside the
+     * shared base, so same-file `self.x`/PEP-526 resolution is preserved with zero
+     * shared mutation. Mutable per-file registries (read_only == false) keep the
+     * byte-identical direct write below. */
+    if (ctx->registry->read_only) {
+        py_overlay_register_field(ctx, class_qn, field_name, field_type);
+        return;
+    }
 
     // Find the type entry. cbm_registry_lookup_type returns a const pointer;
     // we need a mutable pointer into the registry's array.

--- a/internal/cbm/lsp/py_lsp.h
+++ b/internal/cbm/lsp/py_lsp.h
@@ -98,6 +98,23 @@ typedef struct {
     int eval_steps;                  // per-file work budget used (PY_EVAL_MAX_STEPS_PER_FILE)
     uint32_t eval_truncations;       // depth/budget cutoff count — gates memo inserts
 
+    // Per-file instance-field OVERLAY. When the Tier-2 registry is shared + sealed
+    // (registry->read_only), `self.x = ...` / PEP-526 field discoveries made during
+    // resolve are recorded HERE instead of mutating the shared registry (which would
+    // bypass the add_* seal, race the other resolve workers, and leave the shared
+    // entry pointing into this file's arena once it is freed). py_lookup_field
+    // consults this overlay alongside the shared base, so same-file attribute-chain
+    // resolution is preserved with zero shared mutation. Arena-allocated (per-file
+    // lifetime); holds no pointer into the shared registry, and the shared registry
+    // holds none into it. Mutable per-file registries keep the direct write.
+    struct {
+        const char *class_qn;
+        const char *field_name;
+        const CBMType *field_type;
+    } *field_overlay;
+    int field_overlay_count;
+    int field_overlay_cap;
+
     // Debug mode (CBM_LSP_DEBUG env, shared across all language LSPs).
     bool debug;
 } PyLSPContext;

--- a/internal/cbm/lsp/rust_lsp.c
+++ b/internal/cbm/lsp/rust_lsp.c
@@ -2324,13 +2324,31 @@ static const CBMRegisteredFunc *rust_resolve_trait_method(RustLSPContext *ctx,
 
     /* First try inherent method on the receiver itself, following any
      * type aliases (so `std.sync.Arc.clone` resolves through to
-     * `alloc.sync.Arc.clone` in the registry). */
+     * `alloc.sync.Arc.clone` in the registry). Stays BEFORE the memo check —
+     * a colliding real hit is always found (collision guard). */
     const CBMRegisteredFunc *inh =
         cbm_registry_lookup_method_aliased(reg, receiver_type_qn, method_name);
     if (inh) {
         if (out_impl_count)
             *out_impl_count = 1;
         return inh;
+    }
+
+    /* Negative memo (sealed registry only): this whole cascade — embedded-
+     * impl walk + trait-default tail — reads nothing but the registry and the
+     * two query strings, so under read_only a miss is a pure fact. Macro-
+     * expanded kernel rust asks the same failing (receiver, method) question
+     * thousands of times per file; without the memo each repeat re-paid the
+     * full walk (~63 s per trait-heavy file). Only the full miss (0 impls,
+     * no trait default) is memoized, preserving out_impl_count fidelity for
+     * the ambiguous (>=2 impls) case. */
+    bool nm_active = reg && reg->read_only;
+    uint64_t nm_key = 0;
+    if (nm_active) {
+        nm_key = cbm_negmemo_key(1, receiver_type_qn, method_name);
+        if (cbm_negmemo_contains(&ctx->neg_memo, nm_key)) {
+            return NULL;
+        }
     }
 
     /* Look at every type whose embedded_types include the receiver_type_qn
@@ -2364,7 +2382,12 @@ static const CBMRegisteredFunc *rust_resolve_trait_method(RustLSPContext *ctx,
         *out_impl_count = impls;
     if (impls == 1)
         return unique;
-    return rust_lookup_method_in_trait(ctx, receiver_type_qn, method_name);
+    const CBMRegisteredFunc *tm =
+        rust_lookup_method_in_trait(ctx, receiver_type_qn, method_name);
+    if (nm_active && !tm && impls == 0) {
+        cbm_negmemo_insert(&ctx->neg_memo, ctx->arena, nm_key);
+    }
+    return tm;
 }
 
 // True if `type_qn` implements a trait that declares `method_name` — i.e. a
@@ -2401,6 +2424,16 @@ static const CBMRegisteredFunc *rust_find_sole_trait_impl(RustLSPContext *ctx, c
     if (!ctx || !trait_qn || !method_name)
         return NULL;
     const CBMTypeRegistry *reg = ctx->registry;
+    /* Negative memo (sealed registry only) — registry-pure cascade; only the
+     * zero-implementer miss is memoized (out_n fidelity for the 2+ case). */
+    bool nm_active = reg && reg->read_only;
+    uint64_t nm_key = 0;
+    if (nm_active) {
+        nm_key = cbm_negmemo_key(2, trait_qn, method_name);
+        if (cbm_negmemo_contains(&ctx->neg_memo, nm_key)) {
+            return NULL;
+        }
+    }
     const char *tdot = strrchr(trait_qn, '.');
     const char *tbare = tdot ? tdot + 1 : trait_qn;
     const CBMRegisteredFunc *first = NULL;
@@ -2441,6 +2474,9 @@ static const CBMRegisteredFunc *rust_find_sole_trait_impl(RustLSPContext *ctx, c
     }
     if (out_n)
         *out_n = n;
+    if (nm_active && n == 0) {
+        cbm_negmemo_insert(&ctx->neg_memo, ctx->arena, nm_key);
+    }
     return n == 1 ? first : NULL;
 }
 

--- a/internal/cbm/lsp/rust_lsp.c
+++ b/internal/cbm/lsp/rust_lsp.c
@@ -2334,10 +2334,16 @@ static const CBMRegisteredFunc *rust_resolve_trait_method(RustLSPContext *ctx,
     }
 
     /* Look at every type whose embedded_types include the receiver_type_qn
-     * (treated as a trait): pick the single-impl case. */
+     * (treated as a trait): pick the single-impl case. Prefilter to the types whose
+     * embedded_types carry a matching BARE name via the registry index; the exact
+     * full-QN check below is unchanged, so the result set is identical. */
     const CBMRegisteredFunc *unique = NULL;
     int impls = 0;
-    for (int ti = 0; ti < reg->type_count && impls < 3; ti++) {
+    const char *rdot = strrchr(receiver_type_qn, '.');
+    const char *rbare = rdot ? rdot + 1 : receiver_type_qn;
+    CBMTypeEmbedIter eit;
+    cbm_registry_types_by_embedded_bare(reg, rbare, &eit);
+    for (int ti; impls < 3 && (ti = cbm_type_embed_iter_next(&eit)) >= 0;) {
         const CBMRegisteredType *t = &reg->types[ti];
         if (!t->embedded_types)
             continue;
@@ -2400,7 +2406,12 @@ static const CBMRegisteredFunc *rust_find_sole_trait_impl(RustLSPContext *ctx, c
     const CBMRegisteredFunc *first = NULL;
     const char *first_qn = NULL;
     int n = 0;
-    for (int ti = 0; ti < reg->type_count && n < 2; ti++) {
+    /* Prefilter to types whose embedded_types carry the trait's BARE name; the
+     * exact (full-QN OR bare) check below is unchanged. tbare-keyed index captures
+     * every original match (a full-QN match implies a bare-name match). */
+    CBMTypeEmbedIter eit;
+    cbm_registry_types_by_embedded_bare(reg, tbare, &eit);
+    for (int ti; n < 2 && (ti = cbm_type_embed_iter_next(&eit)) >= 0;) {
         const CBMRegisteredType *t = &reg->types[ti];
         if (!t->embedded_types || !t->qualified_name)
             continue;
@@ -3762,7 +3773,11 @@ static void rust_resolve_call_expression(RustLSPContext *ctx, TSNode node) {
                     char *needle = cbm_arena_sprintf(ctx->arena, ".%s.", head);
                     const CBMRegisteredFunc *mem_unique = NULL;
                     int mem_matches = 0;
-                    for (int i = 0; i < ctx->registry->func_count && mem_matches < 2; i++) {
+                    /* Iterate only free funcs whose short_name == tail via the index;
+                     * the receiver/short_name/needle re-checks below are unchanged. */
+                    CBMFreeFuncIter ffit;
+                    cbm_registry_free_funcs_by_short_name(ctx->registry, tail, &ffit);
+                    for (int i; mem_matches < 2 && (i = cbm_free_func_iter_next(&ffit)) >= 0;) {
                         const CBMRegisteredFunc *f = &ctx->registry->funcs[i];
                         if (!f->short_name || !f->qualified_name)
                             continue;
@@ -3800,7 +3815,11 @@ static void rust_resolve_call_expression(RustLSPContext *ctx, TSNode node) {
                 first_dot ? (size_t)(first_dot - ctx->module_qn) : strlen(ctx->module_qn);
             const CBMRegisteredFunc *unique = NULL;
             int matches = 0;
-            for (int i = 0; i < ctx->registry->func_count && matches < 2; i++) {
+            /* Iterate only free funcs whose short_name == tail via the index; the
+             * receiver/short_name/crate-prefix re-checks below are unchanged. */
+            CBMFreeFuncIter ffit;
+            cbm_registry_free_funcs_by_short_name(ctx->registry, tail, &ffit);
+            for (int i; matches < 2 && (i = cbm_free_func_iter_next(&ffit)) >= 0;) {
                 const CBMRegisteredFunc *f = &ctx->registry->funcs[i];
                 if (!f->short_name || !f->qualified_name)
                     continue;

--- a/internal/cbm/lsp/rust_lsp.c
+++ b/internal/cbm/lsp/rust_lsp.c
@@ -29,6 +29,7 @@
 #include "rust_cargo.h"
 #include "../helpers.h"
 #include <ctype.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -3159,6 +3160,20 @@ static void rust_expand_user_macro(RustLSPContext *ctx, const char *mname, TSNod
     if (!substituted)
         return;
 
+    /* Expansion memo (see RustLSPContext.macro_memo): reset per top-level
+     * invocation, dedup identical (macro, substituted body) within the
+     * recursion chain — kills the exponential breadth of self-recursive
+     * macro_rules without losing any distinctly-attributed source site. */
+    if (ctx->macro_expand_depth == 0 && ctx->macro_memo.slots) {
+        memset(ctx->macro_memo.slots, 0, sizeof(uint64_t) * (size_t)ctx->macro_memo.cap);
+        ctx->macro_memo.count = 0;
+    }
+    uint64_t mm_key = cbm_negmemo_key(3, mname, substituted);
+    if (cbm_negmemo_contains(&ctx->macro_memo, mm_key)) {
+        return;
+    }
+    cbm_negmemo_insert(&ctx->macro_memo, ctx->arena, mm_key);
+
     /* Wrap and parse. */
     char *wrapped = cbm_arena_sprintf(ctx->arena, "fn __cbm_macro_expand() { %s; }\n", substituted);
     if (!wrapped)
@@ -3238,6 +3253,20 @@ static void rust_resolve_macro_arg_exprs(RustLSPContext *ctx, TSNode invocation)
     char *arg_text = cbm_arena_strndup(ctx->arena, inner, (size_t)inner_len);
     if (!arg_text)
         return;
+
+    /* Same expansion memo as rust_expand_user_macro (site tag 4), but ONLY
+     * inside a recursion chain (depth > 0): there the identical argument text
+     * is re-parsed on every re-expansion of a self-recursive macro and has no
+     * distinct source site. Top-level invocations (depth 0) always parse —
+     * identical args in different enclosing functions attribute differently
+     * and must all be walked. */
+    if (ctx->macro_expand_depth > 0) {
+        uint64_t am_key = cbm_negmemo_key(4, arg_text, NULL);
+        if (cbm_negmemo_contains(&ctx->macro_memo, am_key)) {
+            return;
+        }
+        cbm_negmemo_insert(&ctx->macro_memo, ctx->arena, am_key);
+    }
 
     /* Wrap the comma-separated arguments in a tuple expression so the whole
      * thing parses as one valid expression (a trailing format-spec arg like
@@ -5342,6 +5371,24 @@ static void rust_populate_cross_registry(CBMTypeRegistry *reg, CBMArena *arena,
     cbm_registry_init(reg, arena);
     cbm_rust_stdlib_register(reg, arena);
 
+    /* qn → (type index + 1), FIRST occurrence wins (mirrors the linear scans
+     * this map replaces). Both in-loop registry probes below — the receiver
+     * auto-registration check and the trait-linkage lookup — used to scan the
+     * UNFINALIZED registry linearly (no buckets exist before finalize): the
+     * checklist's lookup-in-registration-loop pattern. Invisible on small
+     * per-file builds; on the shared all_defs build (~1.4M entries) those
+     * scans were a constant ~63 s of the kernel run — and the sibling
+     * null-filter files waited on the build once-guard for exactly that long,
+     * which is why no resolution-side fix ever moved their wall time. Index,
+     * not pointer, because reg->types reallocs as it grows. */
+    CBMIdxMemo type_idx = {0};
+    for (int ti = 0; ti < reg->type_count; ti++) {
+        const char *qn = reg->types[ti].qualified_name;
+        if (qn) {
+            cbm_idxmemo_put_if_absent(&type_idx, arena, qn, ti);
+        }
+    }
+
     for (int i = 0; i < def_count; i++) {
         CBMRustLSPDef *d = &defs[i];
         if (!d->qualified_name || !d->short_name || !d->label)
@@ -5358,6 +5405,7 @@ static void rust_populate_cross_registry(CBMTypeRegistry *reg, CBMArena *arena,
             rt.is_interface = d->is_interface || strcmp(d->label, "Trait") == 0 ||
                               strcmp(d->label, "Interface") == 0;
             cbm_registry_add_type(reg, rt);
+            cbm_idxmemo_put_if_absent(&type_idx, arena, rt.qualified_name, reg->type_count - 1);
         }
 
         if (strcmp(d->label, "Function") == 0 || strcmp(d->label, "Method") == 0) {
@@ -5398,13 +5446,15 @@ static void rust_populate_cross_registry(CBMTypeRegistry *reg, CBMArena *arena,
 
             if (strcmp(d->label, "Method") == 0 && d->receiver_type && d->receiver_type[0]) {
                 rf.receiver_type = cbm_arena_strdup(arena, d->receiver_type);
-                if (!cbm_registry_lookup_type(reg, rf.receiver_type)) {
+                if (cbm_idxmemo_get(&type_idx, rf.receiver_type) < 0) {
                     CBMRegisteredType auto_t;
                     memset(&auto_t, 0, sizeof(auto_t));
                     auto_t.qualified_name = rf.receiver_type;
                     const char *dot = strrchr(d->receiver_type, '.');
                     auto_t.short_name = dot ? cbm_arena_strdup(arena, dot + 1) : rf.receiver_type;
                     cbm_registry_add_type(reg, auto_t);
+                    cbm_idxmemo_put_if_absent(&type_idx, arena, auto_t.qualified_name,
+                                              reg->type_count - 1);
                 }
             }
 
@@ -5413,12 +5463,9 @@ static void rust_populate_cross_registry(CBMTypeRegistry *reg, CBMArena *arena,
             /* If trait_qn set: encode embedded_type linkage on receiver. */
             if (rf.receiver_type && d->trait_qn && d->trait_qn[0]) {
                 CBMRegisteredType *rt = NULL;
-                for (int ti = 0; ti < reg->type_count; ti++) {
-                    if (reg->types[ti].qualified_name &&
-                        strcmp(reg->types[ti].qualified_name, rf.receiver_type) == 0) {
-                        rt = &reg->types[ti];
-                        break;
-                    }
+                int32_t tix = cbm_idxmemo_get(&type_idx, rf.receiver_type);
+                if (tix >= 0) {
+                    rt = &reg->types[tix];
                 }
                 if (rt) {
                     int existing = 0;
@@ -5437,7 +5484,8 @@ static void rust_populate_cross_registry(CBMTypeRegistry *reg, CBMArena *arena,
         }
     }
 
-    /* Finalise the cross-file registry now that all defs are added. */
+    /* Finalise the cross-file registry now that all defs are added.
+     * (type_idx is arena-owned — freed with the registry's arena.) */
     cbm_registry_finalize(reg);
 }
 

--- a/internal/cbm/lsp/rust_lsp.c
+++ b/internal/cbm/lsp/rust_lsp.c
@@ -5294,36 +5294,17 @@ void cbm_run_rust_lsp(CBMArena *arena, CBMFileResult *result, const char *source
 
 extern const TSLanguage *tree_sitter_rust(void);
 
-void cbm_run_rust_lsp_cross_with_manifest(CBMArena *arena, const char *source, int source_len,
-                                          const char *module_qn, CBMRustLSPDef *defs, int def_count,
-                                          const char **import_names, const char **import_qns,
-                                          int import_count, TSTree *cached_tree,
-                                          const struct CBMCargoManifest *manifest,
-                                          CBMResolvedCallArray *out) {
-    if (!source || source_len <= 0 || !out)
-        return;
-
-    TSParser *parser = NULL;
-    TSTree *tree = cached_tree;
-    bool owns_tree = false;
-    if (!tree) {
-        parser = ts_parser_new();
-        if (!parser)
-            return;
-        ts_parser_set_language(parser, tree_sitter_rust());
-        tree = ts_parser_parse_string(parser, NULL, source, source_len);
-        owns_tree = true;
-        if (!tree) {
-            ts_parser_delete(parser);
-            return;
-        }
-    }
-    TSNode root = ts_tree_root_node(tree);
-
-    /* Build registry from cross-file defs + stdlib. */
-    CBMTypeRegistry reg;
-    cbm_registry_init(&reg, arena);
-    cbm_rust_stdlib_register(&reg, arena);
+/* Populate + finalize a Rust cross-file type registry from `defs`. Shared by the
+ * per-file resolver (cbm_run_rust_lsp_cross_with_manifest) and the build-once shared
+ * registry (cbm_rust_build_cross_registry) so both produce a byte-identical registry.
+ * `module_qn` is ONLY the fallback used to qualify a def's return type when that def
+ * carries no def_module_qn; pass NULL for the shared build (all_defs always carry
+ * def_module_qn — verified: 0 NULL across the C + Rust kernel corpora). */
+static void rust_populate_cross_registry(CBMTypeRegistry *reg, CBMArena *arena,
+                                         CBMRustLSPDef *defs, int def_count,
+                                         const char *module_qn) {
+    cbm_registry_init(reg, arena);
+    cbm_rust_stdlib_register(reg, arena);
 
     for (int i = 0; i < def_count; i++) {
         CBMRustLSPDef *d = &defs[i];
@@ -5340,7 +5321,7 @@ void cbm_run_rust_lsp_cross_with_manifest(CBMArena *arena, const char *source, i
             rt.short_name = cbm_arena_strdup(arena, d->short_name);
             rt.is_interface = d->is_interface || strcmp(d->label, "Trait") == 0 ||
                               strcmp(d->label, "Interface") == 0;
-            cbm_registry_add_type(&reg, rt);
+            cbm_registry_add_type(reg, rt);
         }
 
         if (strcmp(d->label, "Function") == 0 || strcmp(d->label, "Method") == 0) {
@@ -5381,25 +5362,25 @@ void cbm_run_rust_lsp_cross_with_manifest(CBMArena *arena, const char *source, i
 
             if (strcmp(d->label, "Method") == 0 && d->receiver_type && d->receiver_type[0]) {
                 rf.receiver_type = cbm_arena_strdup(arena, d->receiver_type);
-                if (!cbm_registry_lookup_type(&reg, rf.receiver_type)) {
+                if (!cbm_registry_lookup_type(reg, rf.receiver_type)) {
                     CBMRegisteredType auto_t;
                     memset(&auto_t, 0, sizeof(auto_t));
                     auto_t.qualified_name = rf.receiver_type;
                     const char *dot = strrchr(d->receiver_type, '.');
                     auto_t.short_name = dot ? cbm_arena_strdup(arena, dot + 1) : rf.receiver_type;
-                    cbm_registry_add_type(&reg, auto_t);
+                    cbm_registry_add_type(reg, auto_t);
                 }
             }
 
-            cbm_registry_add_func(&reg, rf);
+            cbm_registry_add_func(reg, rf);
 
             /* If trait_qn set: encode embedded_type linkage on receiver. */
             if (rf.receiver_type && d->trait_qn && d->trait_qn[0]) {
                 CBMRegisteredType *rt = NULL;
-                for (int ti = 0; ti < reg.type_count; ti++) {
-                    if (reg.types[ti].qualified_name &&
-                        strcmp(reg.types[ti].qualified_name, rf.receiver_type) == 0) {
-                        rt = &reg.types[ti];
+                for (int ti = 0; ti < reg->type_count; ti++) {
+                    if (reg->types[ti].qualified_name &&
+                        strcmp(reg->types[ti].qualified_name, rf.receiver_type) == 0) {
+                        rt = &reg->types[ti];
                         break;
                     }
                 }
@@ -5420,9 +5401,130 @@ void cbm_run_rust_lsp_cross_with_manifest(CBMArena *arena, const char *source, i
         }
     }
 
-    /* Run the per-file walker. */
     /* Finalise the cross-file registry now that all defs are added. */
-    cbm_registry_finalize(&reg);
+    cbm_registry_finalize(reg);
+}
+
+/* Resolve one Rust file against an ALREADY-built (per-file or shared) registry. */
+static void rust_resolve_against_registry(CBMArena *arena, const char *source, int source_len,
+                                          const char *module_qn, const CBMTypeRegistry *reg,
+                                          const char **import_names, const char **import_qns,
+                                          int import_count, TSNode root,
+                                          const struct CBMCargoManifest *manifest,
+                                          CBMResolvedCallArray *out, CBMFileResult *result) {
+    RustLSPContext ctx;
+    rust_lsp_init(&ctx, arena, source, source_len, reg, module_qn, out);
+    ctx.cargo_manifest = manifest;
+    rust_collect_uses(&ctx, root);
+    for (int i = 0; i < import_count; i++) {
+        if (import_names[i] && import_qns[i]) {
+            rust_lsp_add_use(&ctx, import_names[i], import_qns[i]);
+        }
+    }
+    rust_lsp_process_file(&ctx, root);
+    if (result)
+        cbm_rust_synth_proc_macro_edges(arena, result);
+}
+
+/* Tier-2: build the Rust cross registry ONCE from all project defs, sealed
+ * read-only, and shared across every Rust file's resolve (mirrors C/py/cs/ts).
+ * Converts the pipeline's CBMLSPDef into CBMRustLSPDef inline (same field copy as
+ * pass_lsp_cross.c's pxc_lspdefs_to_rust, incl. trait_qn=NULL). module_qn=NULL is
+ * byte-identical because all_defs always carry def_module_qn. */
+CBMTypeRegistry *cbm_rust_build_cross_registry(CBMArena *arena, CBMLSPDef *defs, int def_count) {
+    if (!arena)
+        return NULL;
+    CBMTypeRegistry *reg = (CBMTypeRegistry *)cbm_arena_alloc(arena, sizeof(*reg));
+    if (!reg)
+        return NULL;
+    CBMRustLSPDef *rdefs = NULL;
+    if (def_count > 0) {
+        rdefs = (CBMRustLSPDef *)cbm_arena_alloc(arena, (size_t)def_count * sizeof(CBMRustLSPDef));
+        if (!rdefs)
+            return NULL;
+        for (int i = 0; i < def_count; i++) {
+            rdefs[i].qualified_name = defs[i].qualified_name;
+            rdefs[i].short_name = defs[i].short_name;
+            rdefs[i].label = defs[i].label;
+            rdefs[i].receiver_type = defs[i].receiver_type;
+            rdefs[i].def_module_qn = defs[i].def_module_qn;
+            rdefs[i].return_types = defs[i].return_types;
+            rdefs[i].embedded_types = defs[i].embedded_types;
+            rdefs[i].field_defs = defs[i].field_defs;
+            rdefs[i].method_names_str = defs[i].method_names_str;
+            rdefs[i].trait_qn = NULL;
+            rdefs[i].is_interface = defs[i].is_interface;
+        }
+    }
+    rust_populate_cross_registry(reg, arena, rdefs, def_count, /*module_qn=*/NULL);
+    reg->read_only = true; /* seal: shared Tier-2 registry is read-only during resolve */
+    return reg;
+}
+
+/* Cross-file Rust resolve using a pre-built shared registry (Tier-2). Skips the
+ * per-file registry build; just parse + resolve. Mirrors cbm_run_c_lsp_cross_with_registry. */
+void cbm_run_rust_lsp_cross_with_registry(CBMArena *arena, const char *source, int source_len,
+                                          const char *module_qn, const CBMTypeRegistry *reg,
+                                          const char **import_names, const char **import_qns,
+                                          int import_count, TSTree *cached_tree,
+                                          const struct CBMCargoManifest *manifest,
+                                          CBMResolvedCallArray *out, CBMFileResult *result) {
+    if (!source || source_len <= 0 || !out || !reg)
+        return;
+    TSParser *parser = NULL;
+    TSTree *tree = cached_tree;
+    bool owns_tree = false;
+    if (!tree) {
+        parser = ts_parser_new();
+        if (!parser)
+            return;
+        ts_parser_set_language(parser, tree_sitter_rust());
+        tree = ts_parser_parse_string(parser, NULL, source, source_len);
+        owns_tree = true;
+        if (!tree) {
+            ts_parser_delete(parser);
+            return;
+        }
+    }
+    TSNode root = ts_tree_root_node(tree);
+    rust_resolve_against_registry(arena, source, source_len, module_qn, reg, import_names,
+                                  import_qns, import_count, root, manifest, out, result);
+    if (owns_tree) {
+        ts_tree_delete(tree);
+        if (parser)
+            ts_parser_delete(parser);
+    }
+}
+
+void cbm_run_rust_lsp_cross_with_manifest(CBMArena *arena, const char *source, int source_len,
+                                          const char *module_qn, CBMRustLSPDef *defs, int def_count,
+                                          const char **import_names, const char **import_qns,
+                                          int import_count, TSTree *cached_tree,
+                                          const struct CBMCargoManifest *manifest,
+                                          CBMResolvedCallArray *out) {
+    if (!source || source_len <= 0 || !out)
+        return;
+
+    TSParser *parser = NULL;
+    TSTree *tree = cached_tree;
+    bool owns_tree = false;
+    if (!tree) {
+        parser = ts_parser_new();
+        if (!parser)
+            return;
+        ts_parser_set_language(parser, tree_sitter_rust());
+        tree = ts_parser_parse_string(parser, NULL, source, source_len);
+        owns_tree = true;
+        if (!tree) {
+            ts_parser_delete(parser);
+            return;
+        }
+    }
+    TSNode root = ts_tree_root_node(tree);
+
+    /* Build registry from cross-file defs + stdlib (per-file). */
+    CBMTypeRegistry reg;
+    rust_populate_cross_registry(&reg, arena, defs, def_count, module_qn);
 
     RustLSPContext ctx;
     rust_lsp_init(&ctx, arena, source, source_len, &reg, module_qn, out);

--- a/internal/cbm/lsp/rust_lsp.h
+++ b/internal/cbm/lsp/rust_lsp.h
@@ -174,6 +174,18 @@ typedef struct {
 
     /* CBM_LSP_DEBUG=1 in env enables verbose stderr trace. */
     bool debug;
+
+    /* Per-ROOT-invocation macro-expansion memo. Kernel macro_rules are often
+     * self-recursive (define_sizes! re-invokes itself with @internal/@impls
+     * args) and the expansion fallback ("no pattern matched — still expand the
+     * first rule") makes that recursion non-convergent: with an unbounded
+     * BREADTH under the depth-8 guard, 2-44 source invocations exploded into
+     * ~200k expansions (each a full tree-sitter parse) ≈ 63 s per file.
+     * Within one expansion chain an identical (macro, substituted body) is
+     * walked once — identical text implies an identical walk, and recursive
+     * re-invocations have no distinct source site to attribute. Reset at each
+     * top-level invocation so distinct source sites keep their attribution. */
+    CBMNegMemo macro_memo;
 } RustLSPContext;
 
 /* Initialise an empty context for processing one file. */

--- a/internal/cbm/lsp/rust_lsp.h
+++ b/internal/cbm/lsp/rust_lsp.h
@@ -27,6 +27,7 @@
 #include "type_rep.h"
 #include "scope.h"
 #include "type_registry.h"
+#include "lsp_neg_memo.h"
 #include "../cbm.h"
 #include "go_lsp.h" // for CBMLSPDef (pipeline def), used by the Tier-2 builder
 
@@ -57,6 +58,12 @@ typedef struct {
 
     const CBMTypeRegistry *registry;
     CBMScope *current_scope;
+
+    /* Negative-lookup memo for the registry-pure resolve cascades (trait
+     * method / sole-trait-impl / free-func fallback). Active ONLY when the
+     * registry is sealed (read_only) — see lsp_neg_memo.h. Arena-backed,
+     * dies with the file. Zeroed by rust_lsp_init's memset (lazy alloc). */
+    CBMNegMemo neg_memo;
 
     /* `use` map: parallel arrays mapping a local-name (the last segment, or
      * the `as` alias) to its full module path (`std::collections::HashMap`,

--- a/internal/cbm/lsp/rust_lsp.h
+++ b/internal/cbm/lsp/rust_lsp.h
@@ -28,6 +28,7 @@
 #include "scope.h"
 #include "type_registry.h"
 #include "../cbm.h"
+#include "go_lsp.h" // for CBMLSPDef (pipeline def), used by the Tier-2 builder
 
 /* Forward declaration — defined in rust_cargo.h. We keep it forward
  * here to avoid pulling rust_cargo.h into every consumer that only
@@ -295,6 +296,22 @@ void cbm_run_rust_lsp_cross_with_manifest(CBMArena *arena, const char *source, i
                                           int import_count, TSTree *cached_tree,
                                           const struct CBMCargoManifest *manifest,
                                           CBMResolvedCallArray *out);
+
+/* Tier-2: build the project-wide Rust cross registry ONCE from all defs, finalize,
+ * and seal read-only. Shared across every Rust file's resolve (mirrors C/py/cs/ts).
+ * Def-driven → byte-identical entries to the per-file build. */
+CBMTypeRegistry *cbm_rust_build_cross_registry(CBMArena *arena, CBMLSPDef *defs, int def_count);
+
+/* Cross-file Rust resolve using a pre-built shared registry (Tier-2). Skips the
+ * per-file registry build; just parse + resolve. `manifest` = the same Cargo manifest
+ * the per-file path uses (cross-crate #56). `result` may be NULL (the cross path does
+ * not synthesise proc-macro edges). Mirrors cbm_run_c_lsp_cross_with_registry. */
+void cbm_run_rust_lsp_cross_with_registry(CBMArena *arena, const char *source, int source_len,
+                                          const char *module_qn, const CBMTypeRegistry *reg,
+                                          const char **import_names, const char **import_qns,
+                                          int import_count, TSTree *cached_tree,
+                                          const struct CBMCargoManifest *manifest,
+                                          CBMResolvedCallArray *out, CBMFileResult *result);
 
 /* Per-file input for batch cross-file Rust LSP processing. */
 typedef struct {

--- a/internal/cbm/lsp/type_registry.c
+++ b/internal/cbm/lsp/type_registry.c
@@ -115,12 +115,185 @@ static void build_method_index(CBMTypeRegistry *reg, CBMArena *idx_arena) {
     reg->method_entry_count = idx;
 }
 
+/* Index: bare(embedded_type) -> chain of TYPE indices declaring it. One entry per
+ * (type, embedded_type). Types are iterated DESCENDING and prepended so each bucket
+ * chain ends up in ASCENDING type-index order (preserves the Rust loops' first-match
+ * tie-break); a type's multiple entries land adjacent so the iterator can dedup them. */
+static void build_type_embed_index(CBMTypeRegistry *reg, CBMArena *idx_arena) {
+    int ecount = 0;
+    for (int i = 0; i < reg->type_count; i++) {
+        const char **e = reg->types[i].embedded_types;
+        if (!e)
+            continue;
+        for (int j = 0; e[j]; j++)
+            ecount++;
+    }
+    if (ecount == 0)
+        return;
+    int bucket_count = next_pow2(ecount * 2);
+    if (bucket_count < 16)
+        bucket_count = 16;
+    int *buckets = (int *)cbm_arena_alloc(idx_arena, (size_t)bucket_count * sizeof(int));
+    CBMRegistryHashEntry *entries = (CBMRegistryHashEntry *)cbm_arena_alloc(
+        idx_arena, (size_t)ecount * sizeof(CBMRegistryHashEntry));
+    if (!buckets || !entries)
+        return;
+    for (int i = 0; i < bucket_count; i++)
+        buckets[i] = -1;
+    int idx = 0;
+    for (int i = reg->type_count - 1; i >= 0; i--) {
+        const char **e = reg->types[i].embedded_types;
+        if (!e)
+            continue;
+        for (int j = 0; e[j]; j++) {
+            const char *s = e[j];
+            if (!s)
+                continue;
+            const char *dot = strrchr(s, '.');
+            const char *bare = dot ? dot + 1 : s;
+            uint64_t h = fnv1a(bare);
+            int slot = (int)(h & (uint64_t)(bucket_count - 1));
+            entries[idx].hash = h;
+            entries[idx].payload_index = i;
+            entries[idx].next_index = buckets[slot];
+            entries[idx].slot = slot;
+            buckets[slot] = idx;
+            idx++;
+        }
+    }
+    reg->type_embed_buckets = buckets;
+    reg->type_embed_entries = entries;
+    reg->type_embed_bucket_count = bucket_count;
+    reg->type_embed_entry_count = idx;
+}
+
+/* Index: short_name -> chain of FREE-function (receiver_type==NULL) indices.
+ * Descending-iterate + prepend for ascending chain order (as above). */
+static void build_ffunc_short_index(CBMTypeRegistry *reg, CBMArena *idx_arena) {
+    int fcount = 0;
+    for (int i = 0; i < reg->func_count; i++) {
+        const CBMRegisteredFunc *f = &reg->funcs[i];
+        if (!f->receiver_type && f->short_name)
+            fcount++;
+    }
+    if (fcount == 0)
+        return;
+    int bucket_count = next_pow2(fcount * 2);
+    if (bucket_count < 16)
+        bucket_count = 16;
+    int *buckets = (int *)cbm_arena_alloc(idx_arena, (size_t)bucket_count * sizeof(int));
+    CBMRegistryHashEntry *entries = (CBMRegistryHashEntry *)cbm_arena_alloc(
+        idx_arena, (size_t)fcount * sizeof(CBMRegistryHashEntry));
+    if (!buckets || !entries)
+        return;
+    for (int i = 0; i < bucket_count; i++)
+        buckets[i] = -1;
+    int idx = 0;
+    for (int i = reg->func_count - 1; i >= 0; i--) {
+        const CBMRegisteredFunc *f = &reg->funcs[i];
+        if (f->receiver_type || !f->short_name)
+            continue;
+        uint64_t h = fnv1a(f->short_name);
+        int slot = (int)(h & (uint64_t)(bucket_count - 1));
+        entries[idx].hash = h;
+        entries[idx].payload_index = i;
+        entries[idx].next_index = buckets[slot];
+        entries[idx].slot = slot;
+        buckets[slot] = idx;
+        idx++;
+    }
+    reg->ffunc_short_buckets = buckets;
+    reg->ffunc_short_entries = entries;
+    reg->ffunc_short_bucket_count = bucket_count;
+    reg->ffunc_short_entry_count = idx;
+}
+
+void cbm_registry_types_by_embedded_bare(const CBMTypeRegistry *reg, const char *bare,
+                                         CBMTypeEmbedIter *out) {
+    out->reg = reg;
+    out->hash = fnv1a(bare);
+    out->prev_type = -1;
+    if (reg->type_qn_buckets && reg->type_qn_bucket_count > 0) {
+        /* finalized: walk the embed chain (if built) then the post-finalize tail */
+        if (reg->type_embed_buckets && reg->type_embed_bucket_count > 0) {
+            int slot = (int)(out->hash & (uint64_t)(reg->type_embed_bucket_count - 1));
+            out->chain_idx = reg->type_embed_buckets[slot];
+        } else {
+            out->chain_idx = -1;
+        }
+        out->tail_i = reg->type_qn_entry_count;
+        out->tail_end = reg->type_count;
+    } else {
+        /* unfinalized: full linear scan over all types (identical candidate set) */
+        out->chain_idx = -1;
+        out->tail_i = 0;
+        out->tail_end = reg->type_count;
+    }
+}
+
+int cbm_type_embed_iter_next(CBMTypeEmbedIter *it) {
+    const CBMTypeRegistry *reg = it->reg;
+    while (it->chain_idx >= 0) {
+        const CBMRegistryHashEntry *e = &reg->type_embed_entries[it->chain_idx];
+        int p = e->payload_index;
+        uint64_t h = e->hash;
+        it->chain_idx = e->next_index;
+        if (h != it->hash)
+            continue; /* hash collision */
+        if (p == it->prev_type)
+            continue; /* same type, multiple matching embeds — yield once */
+        it->prev_type = p;
+        return p;
+    }
+    if (it->tail_i < it->tail_end)
+        return it->tail_i++;
+    return -1;
+}
+
+void cbm_registry_free_funcs_by_short_name(const CBMTypeRegistry *reg, const char *short_name,
+                                           CBMFreeFuncIter *out) {
+    out->reg = reg;
+    out->hash = fnv1a(short_name);
+    if (reg->func_qn_buckets && reg->func_qn_bucket_count > 0) {
+        if (reg->ffunc_short_buckets && reg->ffunc_short_bucket_count > 0) {
+            int slot = (int)(out->hash & (uint64_t)(reg->ffunc_short_bucket_count - 1));
+            out->chain_idx = reg->ffunc_short_buckets[slot];
+        } else {
+            out->chain_idx = -1;
+        }
+        out->tail_i = reg->func_qn_entry_count;
+        out->tail_end = reg->func_count;
+    } else {
+        out->chain_idx = -1;
+        out->tail_i = 0;
+        out->tail_end = reg->func_count;
+    }
+}
+
+int cbm_free_func_iter_next(CBMFreeFuncIter *it) {
+    const CBMTypeRegistry *reg = it->reg;
+    while (it->chain_idx >= 0) {
+        const CBMRegistryHashEntry *e = &reg->ffunc_short_entries[it->chain_idx];
+        int p = e->payload_index;
+        uint64_t h = e->hash;
+        it->chain_idx = e->next_index;
+        if (h != it->hash)
+            continue;
+        return p; /* each free func has one short_name → no dedup needed */
+    }
+    if (it->tail_i < it->tail_end)
+        return it->tail_i++;
+    return -1;
+}
+
 void cbm_registry_finalize_into(CBMTypeRegistry *reg, CBMArena *idx_arena) {
     if (!reg || !idx_arena)
         return;
     build_qn_index(reg, idx_arena, /*for_funcs=*/true);
     build_qn_index(reg, idx_arena, /*for_funcs=*/false);
     build_method_index(reg, idx_arena);
+    build_type_embed_index(reg, idx_arena);
+    build_ffunc_short_index(reg, idx_arena);
 }
 
 void cbm_registry_finalize(CBMTypeRegistry *reg) {

--- a/internal/cbm/lsp/type_registry.h
+++ b/internal/cbm/lsp/type_registry.h
@@ -101,6 +101,23 @@ typedef struct CBMTypeRegistry {
     int method_bucket_count;
     int method_entry_count;
 
+    // Auxiliary short-name / embedded-type indexes (built by finalize alongside the
+    // QN buckets). Turn the Rust trait- and free-function fallback scans from
+    // O(type_count)/O(func_count) into O(chain). Read-only after finalize.
+    // Embedded-type index: fnv1a(bare last-'.'-segment of each embedded_type) -> chain
+    // of TYPE indices declaring it. payload_index = type index (a type may appear once
+    // per embedded entry; consumers dedup adjacent same-type via the iterator).
+    int *type_embed_buckets;
+    CBMRegistryHashEntry *type_embed_entries;
+    int type_embed_bucket_count;
+    int type_embed_entry_count;
+    // Free-function short-name index: fnv1a(short_name) -> chain of FREE-function
+    // (receiver_type==NULL) indices. payload_index = func index.
+    int *ffunc_short_buckets;
+    CBMRegistryHashEntry *ffunc_short_entries;
+    int ffunc_short_bucket_count;
+    int ffunc_short_entry_count;
+
     /* Sealed / read-only. Set true by the cbm_X_build_cross_registry builders
      * (c/cpp, python, c#, ts, go) right after finalize: a Tier-2 cross-registry
      * is built ONCE and shared READ-ONLY across the parallel resolve workers.
@@ -187,6 +204,43 @@ const CBMRegisteredFunc *cbm_registry_lookup_symbol_by_types(const CBMTypeRegist
                                                              const char *name,
                                                              const CBMType **arg_types,
                                                              int arg_count);
+
+// --- Auxiliary index iterators (Rust trait / free-function fallback fast paths) ---
+//
+// Iterate registry TYPE indices whose embedded_types contain an entry whose BARE
+// name (last '.'-segment) equals `bare`. On a finalized registry this walks the
+// embedded-type index plus any post-finalize tail; on an unfinalized registry it
+// degrades to a full linear scan over all types (identical candidate set). Each
+// matching type index is yielded at most once, in ascending registry order. The
+// index is a bare-name PREFILTER — the caller MUST still apply its own exact
+// predicate on each yielded type. Read-only, allocation-free. Usage:
+//   CBMTypeEmbedIter it; cbm_registry_types_by_embedded_bare(reg, bare, &it);
+//   int ti; while ((ti = cbm_type_embed_iter_next(&it)) >= 0) { ... reg->types[ti] ... }
+typedef struct {
+    const CBMTypeRegistry *reg;
+    uint64_t hash;
+    int chain_idx; // next entry in the embed chain, or -1
+    int tail_i;    // next tail/linear type index
+    int tail_end;  // reg->type_count snapshot
+    int prev_type; // last yielded type index (adjacent-dedup); -1 = none
+} CBMTypeEmbedIter;
+void cbm_registry_types_by_embedded_bare(const CBMTypeRegistry *reg, const char *bare,
+                                         CBMTypeEmbedIter *out);
+int cbm_type_embed_iter_next(CBMTypeEmbedIter *it);
+
+// Iterate FREE-function (receiver_type==NULL) indices whose short_name equals
+// `short_name`. Same finalized/unfinalized behavior as above; caller re-checks its
+// own predicate. Read-only, allocation-free.
+typedef struct {
+    const CBMTypeRegistry *reg;
+    uint64_t hash;
+    int chain_idx;
+    int tail_i;
+    int tail_end;
+} CBMFreeFuncIter;
+void cbm_registry_free_funcs_by_short_name(const CBMTypeRegistry *reg, const char *short_name,
+                                           CBMFreeFuncIter *out);
+int cbm_free_func_iter_next(CBMFreeFuncIter *it);
 
 // --- TS-specific helpers (return NULL for types without these signatures) ---
 

--- a/src/graph_buffer/graph_buffer.c
+++ b/src/graph_buffer/graph_buffer.c
@@ -75,7 +75,13 @@ struct cbm_gbuf {
     /* Primary index: QN → cbm_gbuf_node_t* */
     CBMHashTable *node_by_qn;
     /* Primary index: "id" string → cbm_gbuf_node_t* */
-    CBMHashTable *node_by_id;
+    /* Dense id → node array (ids are sequential from alloc_next_id, shared
+     * with edges → holes where edges took ids). Replaces a hash table keyed
+     * on STRDUP'D DECIMAL STRINGS of the id — ~0.44 GB of buckets + key
+     * strings at kernel scale, plus a snprintf+strdup+hash on every one of
+     * the ~18 hot find_by_id call sites. */
+    cbm_gbuf_node_t **by_id;
+    int64_t by_id_cap;
 
     /* Secondary node indexes */
     CBMHashTable *nodes_by_label; /* key: label, value: (node_ptr_array_t*) */
@@ -233,7 +239,7 @@ static void free_edge_array(const char *key, void *value, void *ud) {
     free((void *)key);
 }
 
-/* Free keys only (for node_by_id, edge_by_key) */
+/* Free keys only (for edge_by_key, deleted_set) */
 static void free_key_only(const char *key, void *value, void *ud) {
     (void)value;
     (void)ud;
@@ -331,13 +337,21 @@ static void cascade_delete_edges(cbm_gbuf_t *gb, CBMHashTable *deleted_set) {
 static void register_node_in_indexes(cbm_gbuf_t *gb, cbm_gbuf_node_t *node) {
     cbm_ht_set(gb->node_by_qn, node->qualified_name, node);
 
-    char id_buf[CBM_SZ_32];
-    make_id_key(id_buf, sizeof(id_buf), node->id);
-    const char *old_key = cbm_ht_get_key(gb->node_by_id, id_buf);
-    if (old_key) {
-        cbm_ht_set(gb->node_by_id, old_key, node);
-    } else {
-        cbm_ht_set(gb->node_by_id, strdup(id_buf), node);
+    if (node->id >= gb->by_id_cap) {
+        int64_t nc = gb->by_id_cap > 0 ? gb->by_id_cap : CBM_SZ_1K;
+        while (nc <= node->id) {
+            nc *= 2;
+        }
+        cbm_gbuf_node_t **grown = realloc(gb->by_id, (size_t)nc * sizeof(*grown));
+        if (grown) {
+            memset(grown + gb->by_id_cap, 0,
+                   (size_t)(nc - gb->by_id_cap) * sizeof(*grown));
+            gb->by_id = grown;
+            gb->by_id_cap = nc;
+        }
+    }
+    if (node->id >= 0 && node->id < gb->by_id_cap) {
+        gb->by_id[node->id] = node;
     }
 
     node_ptr_array_t *by_label =
@@ -395,9 +409,9 @@ static void rebuild_edge_secondary_indexes(cbm_gbuf_t *gb) {
 static void release_gbuf_indexes(cbm_gbuf_t *gb) {
     cbm_ht_free(gb->node_by_qn);
     gb->node_by_qn = NULL;
-    cbm_ht_foreach(gb->node_by_id, free_key_only, NULL);
-    cbm_ht_free(gb->node_by_id);
-    gb->node_by_id = NULL;
+    free(gb->by_id);
+    gb->by_id = NULL;
+    gb->by_id_cap = 0;
     cbm_ht_foreach(gb->nodes_by_label, free_node_array, NULL);
     cbm_ht_free(gb->nodes_by_label);
     gb->nodes_by_label = NULL;
@@ -432,7 +446,8 @@ cbm_gbuf_t *cbm_gbuf_new(const char *project, const char *root_path) {
     gb->shared_ids = NULL;
 
     gb->node_by_qn = cbm_ht_create(CBM_SZ_256);
-    gb->node_by_id = cbm_ht_create(CBM_SZ_256);
+    gb->by_id = NULL;
+    gb->by_id_cap = 0;
     gb->nodes_by_label = cbm_ht_create(CBM_SZ_32);
     gb->nodes_by_name = cbm_ht_create(CBM_SZ_256);
 
@@ -480,10 +495,7 @@ void cbm_gbuf_free(cbm_gbuf_t *gb) {
     if (gb->node_by_qn) {
         cbm_ht_free(gb->node_by_qn);
     }
-    if (gb->node_by_id) {
-        cbm_ht_foreach(gb->node_by_id, free_key_only, NULL);
-        cbm_ht_free(gb->node_by_id);
-    }
+    free(gb->by_id);
     if (gb->nodes_by_label) {
         cbm_ht_foreach(gb->nodes_by_label, free_node_array, NULL);
         cbm_ht_free(gb->nodes_by_label);
@@ -748,7 +760,6 @@ int64_t cbm_gbuf_upsert_node(cbm_gbuf_t *gb, const char *label, const char *name
 
     int64_t id = alloc_next_id(gb);
     node->id = id;
-    node->project = gb->project;
     node->label = (char *)gb_intern(gb, label);
     node->name = heap_strdup(name);
     node->qualified_name = heap_strdup(qualified_name);
@@ -772,12 +783,10 @@ const cbm_gbuf_node_t *cbm_gbuf_find_by_qn(const cbm_gbuf_t *gb, const char *qn)
 }
 
 const cbm_gbuf_node_t *cbm_gbuf_find_by_id(const cbm_gbuf_t *gb, int64_t id) {
-    if (!gb) {
+    if (!gb || !gb->by_id || id < 0 || id >= gb->by_id_cap) {
         return NULL;
     }
-    char key[CBM_SZ_32];
-    make_id_key(key, sizeof(key), id);
-    return cbm_ht_get(gb->node_by_id, key);
+    return gb->by_id[id];
 }
 
 int cbm_gbuf_find_by_label(const cbm_gbuf_t *gb, const char *label, const cbm_gbuf_node_t ***out,
@@ -838,9 +847,9 @@ int cbm_gbuf_delete_by_label(cbm_gbuf_t *gb, const char *label) {
 
         /* Remove from primary indexes */
         cbm_ht_delete(gb->node_by_qn, n->qualified_name);
-        const char *stored_key = cbm_ht_get_key(gb->node_by_id, id_buf);
-        cbm_ht_delete(gb->node_by_id, id_buf);
-        free((void *)stored_key);
+        if (n->id >= 0 && n->id < gb->by_id_cap) {
+            gb->by_id[n->id] = NULL;
+        }
     }
 
     /* Clear the label array */
@@ -884,9 +893,9 @@ int cbm_gbuf_delete_by_file(cbm_gbuf_t *gb, const char *file_path) {
 
         /* Remove from primary indexes */
         cbm_ht_delete(gb->node_by_qn, n->qualified_name);
-        const char *stored_key = cbm_ht_get_key(gb->node_by_id, id_buf);
-        cbm_ht_delete(gb->node_by_id, id_buf);
-        free((void *)stored_key);
+        if (n->id >= 0 && n->id < gb->by_id_cap) {
+            gb->by_id[n->id] = NULL;
+        }
 
         /* NULL out QN so dump's liveness check (cbm_ht_get by QN) fails
          * even if a new node with the same QN is inserted later via merge. */
@@ -1061,7 +1070,6 @@ int64_t cbm_gbuf_insert_edge(cbm_gbuf_t *gb, int64_t source_id, int64_t target_i
 
     int64_t id = alloc_next_id(gb);
     edge->id = id;
-    edge->project = gb->project;
     edge->source_id = source_id;
     edge->target_id = target_id;
     edge->type = (char *)gb_intern(gb, type);
@@ -1290,7 +1298,6 @@ static void merge_copy_new_node(cbm_gbuf_t *dst, const cbm_gbuf_node_t *sn) {
     }
 
     node->id = sn->id;
-    node->project = dst->project;
     node->label = (char *)gb_intern(dst, sn->label);
     node->name = heap_strdup(sn->name);
     node->qualified_name = heap_strdup(sn->qualified_name);
@@ -1615,10 +1622,6 @@ static void generate_iso_timestamp(char *buf, size_t buf_size) {
 /* Release lookup indexes then remap+sort+dedup vectors for the B-tree writer. */
 static void release_and_remap_vectors(cbm_gbuf_t *gb, const int64_t *temp_to_final,
                                       int64_t max_temp_id) {
-    CBM_PROF_START(t_release_idx);
-    release_gbuf_indexes(gb);
-    CBM_PROF_END("dump", "4_release_gbuf_indexes", t_release_idx);
-
     CBM_PROF_START(t_vec_remap);
     remap_sort_dedup_vectors(gb, temp_to_final, max_temp_id);
     CBM_PROF_END_N("dump", "5_vector_remap_sort", t_vec_remap, gb->dump_vector_count);
@@ -1645,6 +1648,16 @@ int cbm_gbuf_dump_to_sqlite(cbm_gbuf_t *gb, const char *path) {
     CBMDumpNode *dump_nodes =
         build_dump_nodes(gb, live_count, temp_to_final, max_temp_id, &node_idx, &src_nodes);
     CBM_PROF_END_N("dump", "2_build_dump_nodes", t_build_nodes, node_idx);
+
+    /* Release ALL lookup indexes NOW: nothing between here and finalize reads
+     * them (stream-append uses dump_nodes/src_nodes, build_dump_edges uses
+     * temp_to_final + gb->edges, the vector remap uses temp_to_final). At
+     * kernel scale they are ~3.8 GB (hash buckets + key strings + pointer
+     * arrays); releasing them only AFTER edge building made them coexist with
+     * every dump-side transient array — the dump-phase RSS peak. */
+    CBM_PROF_START(t_release_idx);
+    release_gbuf_indexes(gb);
+    CBM_PROF_END("dump", "4_release_gbuf_indexes", t_release_idx);
 
     char indexed_at[CBM_SZ_64];
     generate_iso_timestamp(indexed_at, sizeof(indexed_at));

--- a/src/graph_buffer/graph_buffer.c
+++ b/src/graph_buffer/graph_buffer.c
@@ -652,13 +652,72 @@ int64_t cbm_gbuf_upsert_node(cbm_gbuf_t *gb, const char *label, const char *name
             (strcmp(existing->label, "Project") == 0 || strcmp(existing->label, "Folder") == 0)) {
             return existing->id;
         }
+        /* Same-QN arrival. Two distinct cases:
+         *
+         * 1) The SAME source entity re-upserted (identity fields match) —
+         *    refresh in place, exactly as before.
+         *
+         * 2) A DIFFERENT source entity sharing the QN. In C a struct, a
+         *    function and a macro can all carry one name and the QN scheme
+         *    does not encode the entity kind, so they collide here. The old
+         *    code let the LAST arrival overwrite — under parallel extraction
+         *    the merge order varies run to run, so WHICH entity survived
+         *    (label/name/lines/props) flickered (xfs: Function-node count
+         *    4998 vs 5015 across two runs), and every order-sensitive
+         *    consumer downstream (semantic vectors, LSH, near-threshold
+         *    scores) inherited the flicker. Pick the survivor by a canonical
+         *    CONTENT rule instead — lexicographically smallest
+         *    (label, file_path, start_line, name) — so the outcome is a pure
+         *    function of the colliding entities, not of scheduling. Exactly
+         *    one entity is dropped, as one always was; kind-disambiguated
+         *    QNs (the real cure) are tracked as a follow-up. */
+        bool same_entity =
+            existing->label && label && strcmp(existing->label, label) == 0 &&
+            existing->file_path && file_path && strcmp(existing->file_path, file_path) == 0 &&
+            existing->start_line == start_line && existing->name && name &&
+            strcmp(existing->name, name) == 0;
+        if (!same_entity) {
+            int c = strcmp(label ? label : "", existing->label ? existing->label : "");
+            if (c == 0) {
+                c = strcmp(file_path ? file_path : "",
+                           existing->file_path ? existing->file_path : "");
+            }
+            if (c == 0) {
+                c = start_line - existing->start_line;
+            }
+            if (c == 0) {
+                c = strcmp(name ? name : "", existing->name ? existing->name : "");
+            }
+            if (c >= 0) {
+                return existing->id; /* existing entity is the canonical winner */
+            }
+        }
         /* Update in-place. name/properties are strdup'd BEFORE freeing old ones
          * (callers may pass existing->name as an argument). label/file_path are
          * interned: gb_intern returns a stable pool pointer (idempotent even when
-         * label == existing->label), so the old value is replaced, never freed. */
+         * label == existing->label), so the old value is replaced, never freed.
+         * When the surviving label/name changes, keep the secondary indexes
+         * consistent (the old code left the node listed under its ORIGINAL
+         * label/name — cbm_gbuf_find_by_label/name then missed or mis-listed it,
+         * which is how the flickering Function set reached the semantic pass). */
         char *new_name = heap_strdup(name);
         char *new_props = properties_json ? heap_strdup(properties_json) : NULL;
-        existing->label = (char *)gb_intern(gb, label);
+        const char *new_label_interned = gb_intern(gb, label);
+        bool label_changed = !existing->label || !new_label_interned ||
+                             strcmp(existing->label, new_label_interned) != 0;
+        bool name_changed =
+            !existing->name || !new_name || strcmp(existing->name, new_name) != 0;
+        if (label_changed) {
+            remove_node_from_ptr_array(
+                cbm_ht_get(gb->nodes_by_label, existing->label ? existing->label : ""),
+                existing->id);
+        }
+        if (name_changed) {
+            remove_node_from_ptr_array(
+                cbm_ht_get(gb->nodes_by_name, existing->name ? existing->name : ""),
+                existing->id);
+        }
+        existing->label = (char *)new_label_interned;
         free(existing->name);
         existing->name = new_name;
         existing->file_path = (char *)gb_intern(gb, file_path);
@@ -667,6 +726,16 @@ int64_t cbm_gbuf_upsert_node(cbm_gbuf_t *gb, const char *label, const char *name
         if (new_props) {
             free(existing->properties_json);
             existing->properties_json = new_props;
+        }
+        if (label_changed) {
+            node_ptr_array_t *by_label =
+                get_or_create_node_array(gb->nodes_by_label, existing->label ? existing->label : "");
+            cbm_da_push(by_label, (const cbm_gbuf_node_t *)existing);
+        }
+        if (name_changed) {
+            node_ptr_array_t *by_name =
+                get_or_create_node_array(gb->nodes_by_name, existing->name ? existing->name : "");
+            cbm_da_push(by_name, (const cbm_gbuf_node_t *)existing);
         }
         return existing->id;
     }
@@ -1131,15 +1200,73 @@ static void merge_update_existing(cbm_gbuf_t *dst, cbm_gbuf_node_t *existing,
         existing->label && sn->label && strcmp(sn->label, "Module") == 0 &&
         (strcmp(existing->label, "Project") == 0 || strcmp(existing->label, "Folder") == 0);
     if (!module_on_container) {
-        existing->label = (char *)gb_intern(dst, sn->label);
-        free(existing->name);
-        existing->name = heap_strdup(sn->name);
-        existing->file_path = (char *)gb_intern(dst, sn->file_path);
-        existing->start_line = sn->start_line;
-        existing->end_line = sn->end_line;
-        if (sn->properties_json) {
-            free(existing->properties_json);
-            existing->properties_json = heap_strdup(sn->properties_json);
+        /* Canonical collision winner (determinism) — mirrors
+         * cbm_gbuf_upsert_node. Distinct source entities can share a QN (C:
+         * struct/function/macro with one name); unconditional "src wins" made
+         * the survivor depend on worker merge order, flickering the node set
+         * (and every downstream consumer) run to run. Same entity → refresh;
+         * different entity → keep the lexicographically smallest
+         * (label, file_path, start_line, name). */
+        bool same_entity =
+            existing->label && sn->label && strcmp(existing->label, sn->label) == 0 &&
+            existing->file_path && sn->file_path &&
+            strcmp(existing->file_path, sn->file_path) == 0 &&
+            existing->start_line == sn->start_line && existing->name && sn->name &&
+            strcmp(existing->name, sn->name) == 0;
+        bool sn_wins = true;
+        if (!same_entity) {
+            int c = strcmp(sn->label ? sn->label : "", existing->label ? existing->label : "");
+            if (c == 0) {
+                c = strcmp(sn->file_path ? sn->file_path : "",
+                           existing->file_path ? existing->file_path : "");
+            }
+            if (c == 0) {
+                c = sn->start_line - existing->start_line;
+            }
+            if (c == 0) {
+                c = strcmp(sn->name ? sn->name : "", existing->name ? existing->name : "");
+            }
+            sn_wins = c < 0;
+        }
+        if (sn_wins) {
+            /* Keep the secondary indexes consistent when the surviving
+             * label/name changes (the old code left the node listed under its
+             * original label/name, so find_by_label/name mis-listed it). */
+            const char *new_label = gb_intern(dst, sn->label);
+            bool label_changed = !existing->label || !new_label ||
+                                 strcmp(existing->label, new_label) != 0;
+            bool name_changed = !existing->name || !sn->name ||
+                                strcmp(existing->name, sn->name) != 0;
+            if (label_changed) {
+                remove_node_from_ptr_array(
+                    cbm_ht_get(dst->nodes_by_label, existing->label ? existing->label : ""),
+                    existing->id);
+            }
+            if (name_changed) {
+                remove_node_from_ptr_array(
+                    cbm_ht_get(dst->nodes_by_name, existing->name ? existing->name : ""),
+                    existing->id);
+            }
+            existing->label = (char *)new_label;
+            free(existing->name);
+            existing->name = heap_strdup(sn->name);
+            existing->file_path = (char *)gb_intern(dst, sn->file_path);
+            existing->start_line = sn->start_line;
+            existing->end_line = sn->end_line;
+            if (sn->properties_json) {
+                free(existing->properties_json);
+                existing->properties_json = heap_strdup(sn->properties_json);
+            }
+            if (label_changed) {
+                node_ptr_array_t *by_label = get_or_create_node_array(
+                    dst->nodes_by_label, existing->label ? existing->label : "");
+                cbm_da_push(by_label, (const cbm_gbuf_node_t *)existing);
+            }
+            if (name_changed) {
+                node_ptr_array_t *by_name = get_or_create_node_array(
+                    dst->nodes_by_name, existing->name ? existing->name : "");
+                cbm_da_push(by_name, (const cbm_gbuf_node_t *)existing);
+            }
         }
     }
 

--- a/src/graph_buffer/graph_buffer.h
+++ b/src/graph_buffer/graph_buffer.h
@@ -24,7 +24,6 @@ typedef struct cbm_store cbm_store_t;
 
 typedef struct {
     int64_t id;           /* temp ID (sequential from 1) */
-    const char *project;  /* borrowed from gbuf */
     char *label;          /* heap-owned */
     char *name;           /* heap-owned */
     char *qualified_name; /* heap-owned */
@@ -36,7 +35,6 @@ typedef struct {
 
 typedef struct {
     int64_t id;            /* temp ID */
-    const char *project;   /* borrowed from gbuf */
     int64_t source_id;     /* temp node ID */
     int64_t target_id;     /* temp node ID */
     char *type;            /* heap-owned */

--- a/src/main.c
+++ b/src/main.c
@@ -479,6 +479,16 @@ static int run_cli(int argc, char **argv) {
         } else {
             exit_code = cli_print_mcp_result(result);
         }
+        if (cbm_index_worker_active()) {
+            /* Supervised worker: the response is delivered (file + stdout).
+             * Skip the multi-GB teardown (server/store frees) — the process
+             * dies now and the OS reclaims everything wholesale; piecemeal
+             * free() of a kernel-scale graph costs minutes. _Exit skips
+             * atexit/LSan by design for this prod worker path. */
+            cbm_log_info("index.worker.fast_exit", "action", "_Exit");
+            fflush(NULL);
+            _Exit(exit_code);
+        }
         free(result);
     }
 

--- a/src/mcp/index_supervisor.c
+++ b/src/mcp/index_supervisor.c
@@ -7,6 +7,7 @@
 #include "foundation/compat_fs.h" /* cbm_mkdir_p, cbm_fopen */
 #include "foundation/log.h"
 #include "foundation/platform.h" /* cbm_resolve_cache_dir */
+#include "foundation/profile.h"  /* cbm_profile_active (keep worker log under CBM_PROFILE) */
 #include "ui/http_server.h"      /* cbm_http_server_resolve_binary_path */
 
 #include <stdio.h>
@@ -238,9 +239,15 @@ int cbm_index_spawn_worker(const char *args_json, bool single_thread, const char
      * available post-mortem instead of vanishing. Previously the log was ALWAYS
      * deleted and only outcome+signal were logged, so a worker that exited non-zero
      * left nothing to diagnose — the CI blind spot that hid this bug (a mangled JSON
-     * arg → "repo_path is required" exit) behind a generic "crashed on a file". */
-    if (r.outcome == CBM_PROC_CLEAN) {
+     * arg → "repo_path is required" exit) behind a generic "crashed on a file".
+     *
+     * Exception: under CBM_PROFILE the log IS the deliverable — the worker's
+     * msg=prof pass/sub-phase report is only written there, and deleting it on
+     * success made profiling clean runs impossible. Keep it and say where it is. */
+    if (r.outcome == CBM_PROC_CLEAN && !cbm_profile_active) {
         (void)remove(log_path);
+    } else if (r.outcome == CBM_PROC_CLEAN) {
+        cbm_log_info("index.supervisor.profile_log", "log", log_path);
     } else {
         cbm_log_warn("index.supervisor.worker_failed", "outcome", cbm_proc_outcome_str(r.outcome),
                      "exit_code", exit_buf, "log", log_path);

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -3866,8 +3866,17 @@ static char *handle_index_repository(cbm_mcp_server_t *srv, const char *args) {
 
     char *json = yy_doc_to_str(doc);
     yyjson_mut_doc_free(doc);
-    /* Free the pipeline only after the response doc copied the excluded list. */
-    cbm_pipeline_free(p);
+    /* Free the pipeline only after the response doc copied the excluded list.
+     * Supervised worker: skip the deep free — the process exits right after
+     * handing over the response (main.c fast-exits), and piecemeal-freeing a
+     * multi-GB graph before process death costs minutes on kernel-scale repos;
+     * the OS reclaims it wholesale at exit. In-process paths (tests, kill
+     * switch, degrade) still free normally. */
+    if (cbm_index_worker_active()) {
+        cbm_log_info("index.worker.fast_exit", "skip", "pipeline_free");
+    } else {
+        cbm_pipeline_free(p);
+    }
     free(project_name);
     free(repo_path);
 

--- a/src/pipeline/pass_lsp_cross.c
+++ b/src/pipeline/pass_lsp_cross.c
@@ -492,6 +492,10 @@ void cbm_pxc_set_rust_manifest(const CBMCargoManifest *m) {
     g_pxc_rust_manifest = m;
 }
 
+const struct CBMCargoManifest *cbm_pxc_get_rust_manifest(void) {
+    return g_pxc_rust_manifest;
+}
+
 /* Convert a CBMLSPDef array (the pipeline's lingua franca, go_lsp.h:73)
  * into a CBMRustLSPDef array (rust_lsp.h) inside `arena`. The two structs
  * share their first 9 string fields; CBMRustLSPDef adds `trait_qn` before

--- a/src/pipeline/pass_lsp_cross.h
+++ b/src/pipeline/pass_lsp_cross.h
@@ -108,7 +108,8 @@ typedef struct {
     CBMTypeRegistry *ts;     /* CBM_LANG_JAVASCRIPT, TYPESCRIPT, TSX */
     CBMTypeRegistry *php;    /* CBM_LANG_PHP */
     CBMTypeRegistry *cs;     /* CBM_LANG_CSHARP */
-    CBMTypeRegistry *rust;   /* CBM_LANG_RUST */
+    /* CBM_LANG_RUST: intentionally absent — the shared rust registry is built
+     * LAZILY inside cbm_parallel_resolve (first NULL-filter rust file), not eagerly. */
 } CBMCrossLspRegistries;
 
 /* Return the appropriate pre-built registry for a language, or NULL
@@ -134,10 +135,8 @@ static inline CBMTypeRegistry *cbm_pxc_registry_for_lang(const CBMCrossLspRegist
         return r->php;
     case CBM_LANG_CSHARP:
         return r->cs;
-    case CBM_LANG_RUST:
-        return r->rust;
     default:
-        return NULL;
+        return NULL; /* incl. CBM_LANG_RUST — its shared registry is built lazily */
     }
 }
 

--- a/src/pipeline/pass_lsp_cross.h
+++ b/src/pipeline/pass_lsp_cross.h
@@ -35,6 +35,7 @@
 #include "lsp/c_lsp.h"  /* cbm_c_build_cross_registry / cbm_run_c_lsp_cross_with_registry */
 #include "lsp/cs_lsp.h" /* cbm_cs_build_cross_registry / cbm_run_cs_lsp_cross_with_registry */
 #include "lsp/ts_lsp.h" /* cbm_ts_build_cross_registry / cbm_run_ts_lsp_cross_with_registry */
+#include "lsp/rust_lsp.h" /* cbm_rust_build_cross_registry / cbm_run_rust_lsp_cross_with_registry */
 #include "pipeline/pipeline_internal.h"
 #include <stdbool.h>
 
@@ -107,6 +108,7 @@ typedef struct {
     CBMTypeRegistry *ts;     /* CBM_LANG_JAVASCRIPT, TYPESCRIPT, TSX */
     CBMTypeRegistry *php;    /* CBM_LANG_PHP */
     CBMTypeRegistry *cs;     /* CBM_LANG_CSHARP */
+    CBMTypeRegistry *rust;   /* CBM_LANG_RUST */
 } CBMCrossLspRegistries;
 
 /* Return the appropriate pre-built registry for a language, or NULL
@@ -132,10 +134,18 @@ static inline CBMTypeRegistry *cbm_pxc_registry_for_lang(const CBMCrossLspRegist
         return r->php;
     case CBM_LANG_CSHARP:
         return r->cs;
+    case CBM_LANG_RUST:
+        return r->rust;
     default:
         return NULL;
     }
 }
+
+/* Borrow the (thread-local) Rust Cargo manifest the cross-file LSP pass set for
+ * cross-crate (#56) routing. The Tier-2 prebuilt Rust resolve reads it so it sees
+ * exactly what the per-file fallback (cbm_pxc_run_one) would on the same thread. */
+struct CBMCargoManifest;
+const struct CBMCargoManifest *cbm_pxc_get_rust_manifest(void);
 
 /* Run the cross-file LSP resolver for non-TS languages. Appends
  * resolved CALLS into r->resolved_calls (lives in r->arena). Caller

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -687,7 +687,22 @@ typedef struct {
     CBMFileResult **result_cache;
     _Atomic int64_t *shared_ids;
     _Atomic int *cancelled;
-    _Atomic int next_file_idx;
+    _Atomic int next_file_idx; /* legacy single-cursor (unused when claimed != NULL) */
+
+    /* Dual-ended work queue (peak-RSS control): sorted[] is size-DESCENDING;
+     * a small band of workers (big_workers = f(worker count)) claims from the
+     * BIG end while the rest claim from the SMALL end. The number of giant
+     * parse working-sets in flight is structurally bounded by big_workers —
+     * the old single biggest-first cursor put the 12 largest files of the
+     * kernel into 12 workers at once (global RSS peak 24.4 GB at t=47s, a
+     * ~14 GB transient above the retained floor). Giants still start at t=0
+     * (LPT makespan preserved). Per-file claim flags make the crossover
+     * race-free; hints are advisory scan starts. Output is schedule-
+     * independent (content-canonical since the determinism fix). */
+    _Atomic unsigned char *claimed;
+    _Atomic int big_hint;
+    _Atomic int small_hint;
+    int big_workers;
 
     cbm_pkg_entries_t *pkg_entries; /* per-worker manifest arrays (separate allocation) */
 
@@ -709,6 +724,28 @@ typedef struct {
      * over-budget probe re-arms the gate once RSS drains under budget. */
     _Atomic int bp_futile;
 } extract_ctx_t;
+
+/* Claim the next unclaimed file from one end of the dual-ended queue.
+ * Returns the sorted[] index, or -1 when the queue is exhausted. */
+static int pp_claim_next(extract_ctx_t *ec, bool from_big) {
+    if (from_big) {
+        for (int i = atomic_load_explicit(&ec->big_hint, memory_order_relaxed);
+             i < ec->file_count; i++) {
+            if (!atomic_exchange_explicit(&ec->claimed[i], 1, memory_order_relaxed)) {
+                atomic_store_explicit(&ec->big_hint, i + 1, memory_order_relaxed);
+                return i;
+            }
+        }
+    } else {
+        for (int i = atomic_load_explicit(&ec->small_hint, memory_order_relaxed); i >= 0; i--) {
+            if (!atomic_exchange_explicit(&ec->claimed[i], 1, memory_order_relaxed)) {
+                atomic_store_explicit(&ec->small_hint, i - 1, memory_order_relaxed);
+                return i;
+            }
+        }
+    }
+    return -1;
+}
 
 /* Cap on the number of index.file_oversized WARN lines (the full list still goes
  * to the response/logfile — this only throttles the stderr noise). */
@@ -766,12 +803,22 @@ static void extract_worker(int worker_id, void *ctx_ptr) {
         ws->local_gbuf = cbm_gbuf_new_shared_ids(ec->project_name, ec->repo_path, ec->shared_ids);
     }
 
-    /* Pull files from shared atomic counter */
+    /* Pull files: dual-ended claim queue (see extract_ctx_t), with the
+     * legacy single cursor as fallback when claim flags are unavailable. */
+    bool from_big = worker_id < ec->big_workers;
     while (SKIP_ONE) {
-        int sort_pos =
-            atomic_fetch_add_explicit(&ec->next_file_idx, SKIP_ONE, memory_order_relaxed);
-        if (sort_pos >= ec->file_count) {
-            break;
+        int sort_pos;
+        if (ec->claimed) {
+            sort_pos = pp_claim_next(ec, from_big);
+            if (sort_pos < 0) {
+                break;
+            }
+        } else {
+            sort_pos = atomic_fetch_add_explicit(&ec->next_file_idx, SKIP_ONE,
+                                                 memory_order_relaxed);
+            if (sort_pos >= ec->file_count) {
+                break;
+            }
         }
         if (atomic_load_explicit(ec->cancelled, memory_order_relaxed)) {
             break;
@@ -1116,6 +1163,16 @@ int cbm_parallel_extract_ex(cbm_pipeline_ctx_t *ctx, const cbm_file_info_t *file
     };
     atomic_init(&ec.next_worker_id, 0);
     atomic_init(&ec.next_file_idx, 0);
+    ec.claimed = calloc((size_t)file_count, sizeof(_Atomic unsigned char));
+    atomic_init(&ec.big_hint, 0);
+    atomic_init(&ec.small_hint, file_count - 1);
+    ec.big_workers = worker_count / 6;
+    if (ec.big_workers < 1) {
+        ec.big_workers = 1;
+    }
+    if (ec.big_workers > 3) {
+        ec.big_workers = 3;
+    }
     atomic_init(&ec.retained_bytes, 0);
     atomic_init(&ec.retain_cap_warned, 0);
     atomic_init(&ec.oversized_warned, 0);
@@ -1126,6 +1183,8 @@ int cbm_parallel_extract_ex(cbm_pipeline_ctx_t *ctx, const cbm_file_info_t *file
     cbm_parallel_for_opts_t parallel_opts = {.max_workers = worker_count, .force_pthreads = false};
     cbm_parallel_for(worker_count, extract_worker, &ec, parallel_opts);
     CBM_PROF_END_N("parallel_extract", "3_dispatch_workers_parallel", t_dispatch, file_count);
+    free((void *)ec.claimed);
+    ec.claimed = NULL;
 
     /* Sub-phase: Merge all local gbufs into main gbuf (SEQUENTIAL, gbuf not thread-safe) */
     CBM_PROF_START(t_merge);

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -1393,6 +1393,16 @@ typedef struct {
      * Stored as CBMCrossLspRegistries* (typedef from pass_lsp_cross.h). */
     CBMCrossLspRegistries *cross_registries;
 
+    /* F4: LAZILY-built shared Rust registry (built ONCE, on the first NULL-filter
+     * rust file — the ~all_defs amplifier files). Not eager: repos whose rust files
+     * all filter to subsets never pay the O(all_defs) build + multi-GB RSS. Built
+     * under rust_shared_mu into rust_shared_arena, published via rust_shared_reg;
+     * torn down after the worker dispatch. */
+    _Atomic(CBMTypeRegistry *) rust_shared_reg;
+    cbm_mutex_t rust_shared_mu;
+    CBMArena rust_shared_arena;
+    bool rust_shared_arena_live;
+
     /* Counters for parallel.resolve.lsp_cross_done summary. */
     _Atomic int lsp_cross_processed;
     _Atomic int lsp_cross_skipped_no_source;
@@ -2546,6 +2556,34 @@ static void resolve_file_semantic(resolve_ctx_t *rc, resolve_worker_state_t *ws,
     }
 }
 
+/* F4: get (or lazily build ONCE) the shared all_defs Rust registry. Called by the
+ * first worker that hits a NULL-filter rust file; later null-files reuse it. Fast
+ * path is a lock-free atomic load; the build happens under rust_shared_mu into the
+ * dedicated rust_shared_arena (never a shared pipeline arena from a worker thread).
+ * Returns NULL if there are no defs (caller falls back to the per-file build). */
+static CBMTypeRegistry *pp_rust_shared_registry(resolve_ctx_t *rc) {
+    CBMTypeRegistry *p = atomic_load_explicit(&rc->rust_shared_reg, memory_order_acquire);
+    if (p)
+        return p;
+    if (!rc->all_defs || rc->def_count <= 0)
+        return NULL;
+    cbm_mutex_lock(&rc->rust_shared_mu);
+    p = atomic_load_explicit(&rc->rust_shared_reg, memory_order_relaxed);
+    if (!p) {
+        cbm_arena_init(&rc->rust_shared_arena);
+        rc->rust_shared_arena_live = true;
+        p = cbm_rust_build_cross_registry(&rc->rust_shared_arena, rc->all_defs, rc->def_count);
+        if (p) {
+            char sb[96];
+            snprintf(sb, sizeof(sb), "types=%d funcs=%d", p->type_count, p->func_count);
+            cbm_log_info("cross_lsp.rust_registry", "scale", sb);
+        }
+        atomic_store_explicit(&rc->rust_shared_reg, p, memory_order_release);
+    }
+    cbm_mutex_unlock(&rc->rust_shared_mu);
+    return p;
+}
+
 static void resolve_worker(int worker_id, void *ctx_ptr) {
     resolve_ctx_t *rc = ctx_ptr;
     resolve_worker_state_t *ws = &rc->workers[worker_id];
@@ -2738,36 +2776,6 @@ static void resolve_worker(int worker_id, void *ctx_ptr) {
                             result->cached_tree, &result->resolved_calls);
                         used_prebuilt = true;
                         break;
-                    case CBM_LANG_RUST: {
-                        /* Byte-identity-preserving Tier-2. The rust per-file build uses
-                         * all_defs ONLY when the filter returns NULL (the ~90s amplifier
-                         * files, e.g. rust kernel modules); those share the once-built all_defs
-                         * registry. Files that filter to a SUBSET (the majority) resolve
-                         * against that subset today, so they keep their per-file build —
-                         * feeding them the shared all_defs registry would be a SUPERSET and
-                         * could change the graph. (See report cc799e17.) Both paths read the
-                         * same worker-thread manifest as the fallback. */
-                        CBMLSPDef *r_filtered = NULL;
-                        int r_fc = 0;
-                        if (rc->module_def_index) {
-                            r_filtered = cbm_pxc_filter_defs_for_file(
-                                rc->module_def_index, rc->all_defs, lang, result->namespace_name,
-                                def_module, imp_vals, imp_count, &r_fc);
-                        }
-                        if (!r_filtered) {
-                            cbm_run_rust_lsp_cross_with_registry(
-                                &result->arena, lsp_source, lsp_source_len, def_module, prebuilt,
-                                imp_keys, imp_vals, imp_count, result->cached_tree,
-                                cbm_pxc_get_rust_manifest(), &result->resolved_calls,
-                                /*result=*/NULL);
-                        } else {
-                            cbm_pxc_run_one(lang, result, lsp_source, lsp_source_len, def_module,
-                                            r_filtered, r_fc, imp_keys, imp_vals, imp_count);
-                            free(r_filtered);
-                        }
-                        used_prebuilt = true;
-                        break;
-                    }
                     case CBM_LANG_CSHARP:
                         cbm_run_cs_lsp_cross_with_registry(
                             &result->arena, lsp_source, lsp_source_len, def_module, prebuilt,
@@ -2828,8 +2836,26 @@ static void resolve_worker(int worker_id, void *ctx_ptr) {
                             file_def_count = filtered_count;
                         }
                     }
-                    if (lang == CBM_LANG_JAVASCRIPT || lang == CBM_LANG_TYPESCRIPT ||
-                        lang == CBM_LANG_TSX) {
+                    if (lang == CBM_LANG_RUST && !filtered) {
+                        /* Rust NULL-filter file (the ~all_defs amplifier) → resolve against
+                         * the LAZILY-built shared registry instead of rebuilding all_defs
+                         * per file. Byte-identical: a per-file all_defs build == the shared
+                         * all_defs build (def_module_qn always set). SUBSET rust files
+                         * (filtered != NULL) fall to the per-file build below, unchanged.
+                         * Manifest via the getter = same value cbm_pxc_run_one reads here. */
+                        CBMTypeRegistry *shared = pp_rust_shared_registry(rc);
+                        if (shared) {
+                            cbm_run_rust_lsp_cross_with_registry(
+                                &result->arena, lsp_source, lsp_source_len, def_module, shared,
+                                imp_keys, imp_vals, imp_count, result->cached_tree,
+                                cbm_pxc_get_rust_manifest(), &result->resolved_calls,
+                                /*result=*/NULL);
+                        } else {
+                            cbm_pxc_run_one(lang, result, lsp_source, lsp_source_len, def_module,
+                                            file_defs, file_def_count, imp_keys, imp_vals, imp_count);
+                        }
+                    } else if (lang == CBM_LANG_JAVASCRIPT || lang == CBM_LANG_TYPESCRIPT ||
+                               lang == CBM_LANG_TSX) {
                         bool js, jsx, dts;
                         cbm_pxc_ts_modes(lang, rel, &js, &jsx, &dts);
                         cbm_pxc_run_one_ts(result, lsp_source, lsp_source_len, def_module,
@@ -2968,6 +2994,10 @@ int cbm_parallel_resolve(cbm_pipeline_ctx_t *ctx, const cbm_file_info_t *files, 
     atomic_init(&rc.next_file_idx, 0);
     atomic_init(&rc.lsp_cross_processed, 0);
     atomic_init(&rc.lsp_cross_skipped_no_source, 0);
+    /* F4 lazy shared Rust registry: mutex up before workers spawn. */
+    atomic_init(&rc.rust_shared_reg, NULL);
+    cbm_mutex_init(&rc.rust_shared_mu);
+    rc.rust_shared_arena_live = false;
 
     /* Sub-phase: Dispatch resolve workers (per-file call/usage resolution, PARALLEL) */
     CBM_PROF_START(t_resolve_dispatch);
@@ -2975,6 +3005,14 @@ int cbm_parallel_resolve(cbm_pipeline_ctx_t *ctx, const cbm_file_info_t *files, 
     cbm_parallel_for(worker_count, resolve_worker, &rc, opts);
     CBM_PROF_END_N("parallel_resolve", "1_dispatch_workers_parallel", t_resolve_dispatch,
                    file_count);
+    /* Workers joined: the shared Rust registry (if built) is no longer read.
+     * Free its dedicated arena + the lock (registry was self-contained: it strdup'd
+     * all QNs, so freeing all_defs afterward is safe). */
+    if (rc.rust_shared_arena_live) {
+        cbm_arena_destroy(&rc.rust_shared_arena);
+        rc.rust_shared_arena_live = false;
+    }
+    cbm_mutex_destroy(&rc.rust_shared_mu);
 
     /* Sub-phase: Merge all local edge bufs into main gbuf (SEQUENTIAL) */
     CBM_PROF_START(t_resolve_merge);

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -687,22 +687,7 @@ typedef struct {
     CBMFileResult **result_cache;
     _Atomic int64_t *shared_ids;
     _Atomic int *cancelled;
-    _Atomic int next_file_idx; /* legacy single-cursor (unused when claimed != NULL) */
-
-    /* Dual-ended work queue (peak-RSS control): sorted[] is size-DESCENDING;
-     * a small band of workers (big_workers = f(worker count)) claims from the
-     * BIG end while the rest claim from the SMALL end. The number of giant
-     * parse working-sets in flight is structurally bounded by big_workers —
-     * the old single biggest-first cursor put the 12 largest files of the
-     * kernel into 12 workers at once (global RSS peak 24.4 GB at t=47s, a
-     * ~14 GB transient above the retained floor). Giants still start at t=0
-     * (LPT makespan preserved). Per-file claim flags make the crossover
-     * race-free; hints are advisory scan starts. Output is schedule-
-     * independent (content-canonical since the determinism fix). */
-    _Atomic unsigned char *claimed;
-    _Atomic int big_hint;
-    _Atomic int small_hint;
-    int big_workers;
+    _Atomic int next_file_idx;
 
     cbm_pkg_entries_t *pkg_entries; /* per-worker manifest arrays (separate allocation) */
 
@@ -724,28 +709,6 @@ typedef struct {
      * over-budget probe re-arms the gate once RSS drains under budget. */
     _Atomic int bp_futile;
 } extract_ctx_t;
-
-/* Claim the next unclaimed file from one end of the dual-ended queue.
- * Returns the sorted[] index, or -1 when the queue is exhausted. */
-static int pp_claim_next(extract_ctx_t *ec, bool from_big) {
-    if (from_big) {
-        for (int i = atomic_load_explicit(&ec->big_hint, memory_order_relaxed);
-             i < ec->file_count; i++) {
-            if (!atomic_exchange_explicit(&ec->claimed[i], 1, memory_order_relaxed)) {
-                atomic_store_explicit(&ec->big_hint, i + 1, memory_order_relaxed);
-                return i;
-            }
-        }
-    } else {
-        for (int i = atomic_load_explicit(&ec->small_hint, memory_order_relaxed); i >= 0; i--) {
-            if (!atomic_exchange_explicit(&ec->claimed[i], 1, memory_order_relaxed)) {
-                atomic_store_explicit(&ec->small_hint, i - 1, memory_order_relaxed);
-                return i;
-            }
-        }
-    }
-    return -1;
-}
 
 /* Cap on the number of index.file_oversized WARN lines (the full list still goes
  * to the response/logfile — this only throttles the stderr noise). */
@@ -803,22 +766,12 @@ static void extract_worker(int worker_id, void *ctx_ptr) {
         ws->local_gbuf = cbm_gbuf_new_shared_ids(ec->project_name, ec->repo_path, ec->shared_ids);
     }
 
-    /* Pull files: dual-ended claim queue (see extract_ctx_t), with the
-     * legacy single cursor as fallback when claim flags are unavailable. */
-    bool from_big = worker_id < ec->big_workers;
+    /* Pull files from shared atomic counter */
     while (SKIP_ONE) {
-        int sort_pos;
-        if (ec->claimed) {
-            sort_pos = pp_claim_next(ec, from_big);
-            if (sort_pos < 0) {
-                break;
-            }
-        } else {
-            sort_pos = atomic_fetch_add_explicit(&ec->next_file_idx, SKIP_ONE,
-                                                 memory_order_relaxed);
-            if (sort_pos >= ec->file_count) {
-                break;
-            }
+        int sort_pos =
+            atomic_fetch_add_explicit(&ec->next_file_idx, SKIP_ONE, memory_order_relaxed);
+        if (sort_pos >= ec->file_count) {
+            break;
         }
         if (atomic_load_explicit(ec->cancelled, memory_order_relaxed)) {
             break;
@@ -1163,16 +1116,6 @@ int cbm_parallel_extract_ex(cbm_pipeline_ctx_t *ctx, const cbm_file_info_t *file
     };
     atomic_init(&ec.next_worker_id, 0);
     atomic_init(&ec.next_file_idx, 0);
-    ec.claimed = calloc((size_t)file_count, sizeof(_Atomic unsigned char));
-    atomic_init(&ec.big_hint, 0);
-    atomic_init(&ec.small_hint, file_count - 1);
-    ec.big_workers = worker_count / 6;
-    if (ec.big_workers < 1) {
-        ec.big_workers = 1;
-    }
-    if (ec.big_workers > 3) {
-        ec.big_workers = 3;
-    }
     atomic_init(&ec.retained_bytes, 0);
     atomic_init(&ec.retain_cap_warned, 0);
     atomic_init(&ec.oversized_warned, 0);
@@ -1183,8 +1126,6 @@ int cbm_parallel_extract_ex(cbm_pipeline_ctx_t *ctx, const cbm_file_info_t *file
     cbm_parallel_for_opts_t parallel_opts = {.max_workers = worker_count, .force_pthreads = false};
     cbm_parallel_for(worker_count, extract_worker, &ec, parallel_opts);
     CBM_PROF_END_N("parallel_extract", "3_dispatch_workers_parallel", t_dispatch, file_count);
-    free((void *)ec.claimed);
-    ec.claimed = NULL;
 
     /* Sub-phase: Merge all local gbufs into main gbuf (SEQUENTIAL, gbuf not thread-safe) */
     CBM_PROF_START(t_merge);

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -98,6 +98,20 @@ enum { PP_CSHARP_M_PREFIX_LEN = 2 };
 #include <string.h>
 #include <time.h>
 
+/* Back-pressure nap-cycle counter (test observability): each execution of the
+ * over-budget collect+nap gate counts one cycle. Lets tests assert the gate does
+ * not re-pay the full nap tax on every file pull when napping cannot reclaim
+ * memory (the resident floor, not in-flight transients, holds the budget). */
+static _Atomic long g_bp_nap_cycles = 0;
+
+long cbm_pp_bp_nap_cycles(void) {
+    return atomic_load_explicit(&g_bp_nap_cycles, memory_order_relaxed);
+}
+
+void cbm_pp_bp_nap_cycles_reset(void) {
+    atomic_store_explicit(&g_bp_nap_cycles, 0, memory_order_relaxed);
+}
+
 /* Parse a positive MB-valued retention env knob (CBM_RETAIN_*_MB) into bytes.
  * Follows the limits.c strtol convention: unset / unparseable / non-positive
  * → return 0 so the caller keeps its derived default. */
@@ -687,6 +701,13 @@ typedef struct {
      * path lock). Merged into the pipeline in the sequential merge loop. */
     pp_err_list_t *err_lists;
     _Atomic int oversized_warned; /* throttle for the index.file_oversized WARN */
+
+    /* Back-pressure futility latch: set when a full collect+nap cycle ended
+     * still over budget — the resident floor (graph + retained sources), not
+     * in-flight transients, holds the memory, so napping cannot reclaim it.
+     * While set, pulls skip the nap (the designed soft overshoot); the cheap
+     * over-budget probe re-arms the gate once RSS drains under budget. */
+    _Atomic int bp_futile;
 } extract_ctx_t;
 
 /* Cap on the number of index.file_oversized WARN lines (the full list still goes
@@ -763,14 +784,37 @@ static void extract_worker(int worker_id, void *ctx_ptr) {
          * near the budget instead of letting all workers parse their biggest
          * files at once. Self-disabling when the budget is unset (tests) or RSS
          * is under budget; bounded spins avoid deadlock when the resident graph
-         * is itself near budget (then proceed with a soft overshoot). */
-        if (cbm_mem_budget() > 0 && cbm_mem_over_budget()) {
-            cbm_mem_collect();
-            for (int bp = 0; bp < PP_BACKPRESSURE_MAX_SPINS && cbm_mem_over_budget() &&
-                             !atomic_load_explicit(ec->cancelled, memory_order_relaxed);
-                 bp++) {
-                struct timespec nap = {0, PP_BACKPRESSURE_NAP_NS};
-                cbm_nanosleep(&nap, NULL);
+         * is itself near budget (then proceed with a soft overshoot).
+         *
+         * Futility latch: when a FULL nap cycle ends still over budget, the
+         * resident floor — not transients — holds the memory; napping again on
+         * the next pull cannot reclaim it and only idles workers (linux kernel:
+         * one full cycle per pull ≈ 390 s at 79% avg CPU). Latch bp_futile and
+         * proceed with the soft overshoot; the over-budget probe below re-arms
+         * the gate as soon as RSS drains under budget. */
+        if (cbm_mem_budget() > 0) {
+            bool over = cbm_mem_over_budget();
+            bool futile = atomic_load_explicit(&ec->bp_futile, memory_order_relaxed) != 0;
+            if (over && !futile) {
+                cbm_mem_collect();
+                atomic_fetch_add_explicit(&g_bp_nap_cycles, SKIP_ONE, memory_order_relaxed);
+                int bp = 0;
+                for (; bp < PP_BACKPRESSURE_MAX_SPINS && cbm_mem_over_budget() &&
+                       !atomic_load_explicit(ec->cancelled, memory_order_relaxed);
+                     bp++) {
+                    struct timespec nap = {0, PP_BACKPRESSURE_NAP_NS};
+                    cbm_nanosleep(&nap, NULL);
+                }
+                if (bp == PP_BACKPRESSURE_MAX_SPINS && cbm_mem_over_budget()) {
+                    /* Log only the 0→1 transition: all workers race into the
+                     * gate before anyone latches, so a plain store would WARN
+                     * once per worker (12 lines per latch event). */
+                    if (atomic_exchange_explicit(&ec->bp_futile, 1, memory_order_relaxed) == 0) {
+                        cbm_log_warn("mem.backpressure.futile", "action", "soft_overshoot");
+                    }
+                }
+            } else if (!over && futile) {
+                atomic_store_explicit(&ec->bp_futile, 0, memory_order_relaxed);
             }
         }
 
@@ -1075,6 +1119,7 @@ int cbm_parallel_extract_ex(cbm_pipeline_ctx_t *ctx, const cbm_file_info_t *file
     atomic_init(&ec.retained_bytes, 0);
     atomic_init(&ec.retain_cap_warned, 0);
     atomic_init(&ec.oversized_warned, 0);
+    atomic_init(&ec.bp_futile, 0);
 
     /* Sub-phase: Dispatch workers (parse + extract per file, PARALLEL) */
     CBM_PROF_START(t_dispatch);

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -2738,6 +2738,36 @@ static void resolve_worker(int worker_id, void *ctx_ptr) {
                             result->cached_tree, &result->resolved_calls);
                         used_prebuilt = true;
                         break;
+                    case CBM_LANG_RUST: {
+                        /* Byte-identity-preserving Tier-2. The rust per-file build uses
+                         * all_defs ONLY when the filter returns NULL (the ~90s amplifier
+                         * files, e.g. rust kernel modules); those share the once-built all_defs
+                         * registry. Files that filter to a SUBSET (the majority) resolve
+                         * against that subset today, so they keep their per-file build —
+                         * feeding them the shared all_defs registry would be a SUPERSET and
+                         * could change the graph. (See report cc799e17.) Both paths read the
+                         * same worker-thread manifest as the fallback. */
+                        CBMLSPDef *r_filtered = NULL;
+                        int r_fc = 0;
+                        if (rc->module_def_index) {
+                            r_filtered = cbm_pxc_filter_defs_for_file(
+                                rc->module_def_index, rc->all_defs, lang, result->namespace_name,
+                                def_module, imp_vals, imp_count, &r_fc);
+                        }
+                        if (!r_filtered) {
+                            cbm_run_rust_lsp_cross_with_registry(
+                                &result->arena, lsp_source, lsp_source_len, def_module, prebuilt,
+                                imp_keys, imp_vals, imp_count, result->cached_tree,
+                                cbm_pxc_get_rust_manifest(), &result->resolved_calls,
+                                /*result=*/NULL);
+                        } else {
+                            cbm_pxc_run_one(lang, result, lsp_source, lsp_source_len, def_module,
+                                            r_filtered, r_fc, imp_keys, imp_vals, imp_count);
+                            free(r_filtered);
+                        }
+                        used_prebuilt = true;
+                        break;
+                    }
                     case CBM_LANG_CSHARP:
                         cbm_run_cs_lsp_cross_with_registry(
                             &result->arena, lsp_source, lsp_source_len, def_module, prebuilt,

--- a/src/pipeline/pass_pkgmap.c
+++ b/src/pipeline/pass_pkgmap.c
@@ -1515,6 +1515,14 @@ const cbm_gbuf_node_t *cbm_pipeline_resolve_import_node(const cbm_pipeline_ctx_t
             const cbm_gbuf_node_t **hits = NULL;
             int n = 0;
             if (cbm_gbuf_find_by_name(ctx->gbuf, cands[ci], &hits, &n) == 0 && hits) {
+                /* Deterministic winner: hits[] is in node-registration order,
+                 * which under parallel extraction varies run to run — taking
+                 * the FIRST targetable hit made the same import resolve to
+                 * different same-named nodes across runs (xfs: 360 flickering
+                 * IMPORTS diff lines between two MT runs). Pick the candidate
+                 * with the lexicographically smallest qualified name instead:
+                 * stable, content-derived, identical for ST and MT. */
+                const cbm_gbuf_node_t *best = NULL;
                 for (int i = 0; i < n; i++) {
                     const cbm_gbuf_node_t *cand = hits[i];
                     if (!cand || !import_targetable_label(cand->label)) {
@@ -1524,7 +1532,13 @@ const cbm_gbuf_node_t *cbm_pipeline_resolve_import_node(const cbm_pipeline_ctx_t
                         strcmp(cand->qualified_name, source_file_qn) == 0) {
                         continue; /* self */
                     }
-                    return cand;
+                    if (!best || (cand->qualified_name && best->qualified_name &&
+                                  strcmp(cand->qualified_name, best->qualified_name) < 0)) {
+                        best = cand;
+                    }
+                }
+                if (best) {
+                    return best;
                 }
             }
         }

--- a/src/pipeline/pass_semantic_edges.c
+++ b/src/pipeline/pass_semantic_edges.c
@@ -663,21 +663,25 @@ static void vec_build_worker(int worker_id, void *ctx_ptr) {
         vc->funcs[f].tfidf_weights = weights;
         vc->funcs[f].tfidf_len = tfidf_len;
 
-        /* RI vector: sum of enriched token vectors weighted by IDF */
-        memset(&vc->funcs[f].ri_vec, 0, sizeof(cbm_sem_vec_t));
+        /* RI vector: sum of enriched token vectors weighted by IDF. Built in a
+         * LOCAL dense buffer; only the quantized code is retained per func
+         * (the resident dense floats were ~9.4 GB on the kernel). */
+        cbm_sem_vec_t ri_dense;
+        memset(&ri_dense, 0, sizeof(cbm_sem_vec_t));
         for (int t = 0; t < tc; t++) {
             const cbm_sem_vec_t *ri = cbm_sem_corpus_ri_vec(vc->corpus, tokens[t]);
             if (ri) {
                 float idf = cbm_sem_corpus_idf(vc->corpus, tokens[t]);
-                cbm_sem_vec_add_scaled(&vc->funcs[f].ri_vec, ri, idf);
+                cbm_sem_vec_add_scaled(&ri_dense, ri, idf);
             }
         }
-        cbm_sem_normalize(&vc->funcs[f].ri_vec);
+        cbm_sem_normalize(&ri_dense);
+        cbm_rsq_encode(ri_dense.v, &vc->funcs[f].ri_code);
 
         /* Int8 quantize into pre-allocated output array (parallel-safe) */
         uint8_t *qv = &vc->qvecs[(ptrdiff_t)f * CBM_SEM_DIM];
         for (int d = 0; d < CBM_SEM_DIM; d++) {
-            float v = vc->funcs[f].ri_vec.v[d];
+            float v = ri_dense.v[d];
             if (v > PSE_UNIT_POS) {
                 v = PSE_UNIT_POS;
             }
@@ -701,8 +705,11 @@ enum {
     SEM_MAX_CANDIDATES = 200,
 };
 
-/* Row of a hyperplane matrix: float[CBM_SEM_DIM]. */
-typedef float hyperplane_row_t[CBM_SEM_DIM];
+/* Row of a hyperplane matrix in the ROTATED (quantized) basis: LSH only
+ * needs signs of dots against random directions, and a random direction in
+ * the rotated basis is as random as one in the original — so signatures are
+ * computed from dequantized codes without keeping dense originals. */
+typedef float hyperplane_row_t[CBM_RSQ_DIM];
 
 typedef struct {
     cbm_sem_func_t *funcs;
@@ -721,11 +728,13 @@ static void sig_build_worker(int worker_id, void *ctx_ptr) {
             break;
         }
 
+        float dec[CBM_RSQ_DIM];
+        cbm_rsq_decode(&sc->funcs[f].ri_code, dec);
         uint64_t sig = 0;
         for (int h = 0; h < NUM_HYPERPLANES; h++) {
             float dot = 0.0F;
-            for (int d = 0; d < CBM_SEM_DIM; d++) {
-                dot += sc->funcs[f].ri_vec.v[d] * sc->hyperplanes[h][d];
+            for (int d = 0; d < CBM_RSQ_DIM; d++) {
+                dot += dec[d] * sc->hyperplanes[h][d];
             }
             if (dot > 0.0F) {
                 sig |= (PSE_ONE_ULL << h);
@@ -880,9 +889,13 @@ static void collect_worker(int worker_id, void *ctx_ptr) {
             const cbm_gbuf_node_t *n = cc->node_ptrs[i];
             decode_minhash(n->properties_json, &cc->funcs[i]);
             decode_struct_profile(n->properties_json, cc->funcs[i].struct_profile);
-            build_api_vec(cc->gbuf, n->id, &cc->funcs[i].api_vec);
-            build_type_vec(n->properties_json, &cc->funcs[i].type_vec);
-            build_deco_vec(n->properties_json, &cc->funcs[i].deco_vec);
+            cbm_sem_vec_t tmp_vec;
+            build_api_vec(cc->gbuf, n->id, &tmp_vec);
+            cbm_rsq_encode(tmp_vec.v, &cc->funcs[i].api_code);
+            build_type_vec(n->properties_json, &tmp_vec);
+            cbm_rsq_encode(tmp_vec.v, &cc->funcs[i].type_code);
+            build_deco_vec(n->properties_json, &tmp_vec);
+            cbm_rsq_encode(tmp_vec.v, &cc->funcs[i].deco_code);
         }
     }
 }
@@ -1101,8 +1114,8 @@ static hyperplane_row_t *phase5a_build_hyperplanes(void) {
         return NULL;
     }
     for (int h = 0; h < NUM_HYPERPLANES; h++) {
-        for (int d = 0; d < CBM_SEM_DIM; d++) {
-            uint64_t seed = XXH3_64bits_withSeed(&d, sizeof(d), (uint64_t)h * CBM_SEM_DIM);
+        for (int d = 0; d < CBM_RSQ_DIM; d++) {
+            uint64_t seed = XXH3_64bits_withSeed(&d, sizeof(d), (uint64_t)h * CBM_RSQ_DIM);
             hyperplanes[h][d] = ((float)(seed & UINT32_MAX) / (float)UINT32_MAX) - PSE_ROUND_BIAS;
         }
     }

--- a/src/pipeline/pass_semantic_edges.c
+++ b/src/pipeline/pass_semantic_edges.c
@@ -17,6 +17,7 @@
 #include "semantic/semantic.h"
 #include "semantic/ast_profile.h"
 #include "simhash/minhash.h"
+#include "foundation/hash_table.h"
 #include "foundation/log.h"
 #include "foundation/compat.h"
 #define XXH_INLINE_ALL
@@ -600,10 +601,14 @@ typedef struct {
     int *token_counts;                 /* output: token count per function */
     int func_count;
     _Atomic int next_idx;
+    /* Per-worker token intern pools (key==value==the one owned strdup):
+     * identical tokens ("xfs", "error", ...) recur across hundreds of
+     * thousands of functions; per-func strdups made all_tokens hold every
+     * instance. Interned, it holds at most workers x unique tokens. */
+    CBMHashTable **pools;
 } tokenize_ctx_t;
 
 static void tokenize_worker(int worker_id, void *ctx_ptr) {
-    (void)worker_id;
     tokenize_ctx_t *tc = ctx_ptr;
     while (true) {
         int f = atomic_fetch_add_explicit(&tc->next_idx, SKIP_ONE, memory_order_relaxed);
@@ -619,6 +624,18 @@ static void tokenize_worker(int worker_id, void *ctx_ptr) {
         char **dst = &tc->all_tokens[(ptrdiff_t)f * CBM_SEM_MAX_TOKENS];
         int count = tokenize_node(n, tc->gbuf, dst, CBM_SEM_MAX_TOKENS);
         count = inject_pattern_tokens(n, tc->gbuf, dst, count, CBM_SEM_MAX_TOKENS);
+        if (tc->pools && tc->pools[worker_id]) {
+            CBMHashTable *pool = tc->pools[worker_id];
+            for (int t = 0; t < count; t++) {
+                char *canon = cbm_ht_get(pool, dst[t]);
+                if (canon) {
+                    free(dst[t]);
+                    dst[t] = canon;
+                } else {
+                    cbm_ht_set(pool, dst[t], dst[t]); /* key borrows the value */
+                }
+            }
+        }
         tc->token_counts[f] = count;
     }
 }
@@ -1144,13 +1161,15 @@ static void phase1b_decode_and_build(cbm_sem_func_t *funcs, const cbm_gbuf_node_
 /* Phase 2: tokenize each function's metadata in parallel, filling
  * all_tokens[] and token_counts[].  Caller allocates the arrays. */
 static void phase2_tokenize(const cbm_gbuf_node_t **node_ptrs, cbm_gbuf_t *gbuf, char **all_tokens,
-                            int *token_counts, int func_count, int worker_count) {
+                            int *token_counts, int func_count, int worker_count,
+                            CBMHashTable **pools) {
     tokenize_ctx_t tc = {
         .node_ptrs = node_ptrs,
         .gbuf = gbuf,
         .all_tokens = all_tokens,
         .token_counts = token_counts,
         .func_count = func_count,
+        .pools = pools,
     };
     atomic_init(&tc.next_idx, 0);
     cbm_parallel_for_opts_t opts = {.max_workers = worker_count, .force_pthreads = false};
@@ -1307,18 +1326,33 @@ static int run_scoring_phase(cbm_gbuf_t *gbuf, cbm_sem_func_t *funcs, uint64_t *
 }
 
 /* Free the per-function arrays malloc'd during phases 1b and 4a. */
+static void free_token_pool_entry(const char *key, void *value, void *ud) {
+    (void)key; /* key == value: one owned string per unique token */
+    (void)ud;
+    free(value);
+}
+
+/* all_tokens slots BORROW their strings from the per-worker intern pools;
+ * the pools own exactly one copy per unique token per worker. */
 static void free_funcs_and_tokens(cbm_sem_func_t *funcs, int func_count, char **all_tokens,
-                                  const int *token_counts) {
+                                  const int *token_counts, CBMHashTable **pools,
+                                  int worker_count) {
+    (void)token_counts;
     for (int f = 0; f < func_count; f++) {
         free(funcs[f].tfidf_indices);
         free(funcs[f].tfidf_weights);
-        int tc = token_counts[f];
-        for (int t = 0; t < tc; t++) {
-            free(all_tokens[((ptrdiff_t)f * CBM_SEM_MAX_TOKENS) + t]);
-        }
     }
     free(all_tokens);
     free(funcs);
+    if (pools) {
+        for (int w = 0; w < worker_count; w++) {
+            if (pools[w]) {
+                cbm_ht_foreach(pools[w], free_token_pool_entry, NULL);
+                cbm_ht_free(pools[w]);
+            }
+        }
+        free(pools);
+    }
 }
 
 /* ── Pass entry point ────────────────────────────────────────────── */
@@ -1356,7 +1390,14 @@ int cbm_pipeline_pass_semantic_edges(cbm_pipeline_ctx_t *ctx) {
     int *token_counts = calloc((size_t)func_count, sizeof(int));
 
     CBM_PROF_START(t_phase2);
-    phase2_tokenize(node_ptrs, gbuf, all_tokens, token_counts, func_count, worker_count);
+    CBMHashTable **token_pools = calloc((size_t)worker_count, sizeof(CBMHashTable *));
+    if (token_pools) {
+        for (int w = 0; w < worker_count; w++) {
+            token_pools[w] = cbm_ht_create(CBM_SZ_1K);
+        }
+    }
+    phase2_tokenize(node_ptrs, gbuf, all_tokens, token_counts, func_count, worker_count,
+                    token_pools);
     CBM_PROF_END_N("semantic_edges", "2_tokenize_parallel", t_phase2, func_count);
     free(node_ptrs);
 
@@ -1391,7 +1432,8 @@ int cbm_pipeline_pass_semantic_edges(cbm_pipeline_ctx_t *ctx) {
     free_lsh_buckets(band_buckets);
     free(signatures);
     cbm_log_info("pass.done", "pass", "semantic_edges", "edges", itoa_log(total_edges));
-    free_funcs_and_tokens(funcs, func_count, all_tokens, token_counts);
+    free_funcs_and_tokens(funcs, func_count, all_tokens, token_counts, token_pools,
+                          worker_count);
     free(token_counts);
     cbm_sem_corpus_free(corpus);
     CBM_PROF_END("semantic_edges", "7_cleanup", t_phase7);

--- a/src/pipeline/pass_semantic_edges.c
+++ b/src/pipeline/pass_semantic_edges.c
@@ -67,6 +67,13 @@ typedef struct {
     int64_t target_id;
     float score;
     bool same_file;
+    /* Canonical admission keys (determinism): func index of the discovering
+     * side, its candidate rank, and the partner's func index. The sequential
+     * admission pass replays pairs in (i, c) order so which pairs win the
+     * per-node max_edges budget no longer depends on worker scheduling. */
+    int i;
+    int j;
+    int c;
 } deferred_edge_t;
 
 typedef struct {
@@ -82,7 +89,7 @@ static void deferred_buf_init(deferred_edge_buf_t *buf) {
 }
 
 static void deferred_buf_push(deferred_edge_buf_t *buf, int64_t src, int64_t tgt, float score,
-                              bool same_file) {
+                              bool same_file, int i, int j, int c) {
     if (buf->count >= buf->cap) {
         int nc = buf->cap < CBM_SZ_256 ? CBM_SZ_256 : buf->cap * GROW;
         deferred_edge_t *grown = realloc(buf->edges, (size_t)nc * sizeof(deferred_edge_t));
@@ -92,8 +99,13 @@ static void deferred_buf_push(deferred_edge_buf_t *buf, int64_t src, int64_t tgt
         buf->edges = grown;
         buf->cap = nc;
     }
-    buf->edges[buf->count++] = (deferred_edge_t){
-        .source_id = src, .target_id = tgt, .score = score, .same_file = same_file};
+    buf->edges[buf->count++] = (deferred_edge_t){.source_id = src,
+                                                 .target_id = tgt,
+                                                 .score = score,
+                                                 .same_file = same_file,
+                                                 .i = i,
+                                                 .j = j,
+                                                 .c = c};
 }
 
 static void deferred_buf_free(deferred_edge_buf_t *buf) {
@@ -393,25 +405,59 @@ static int tokenize_json_array_field(const char *json, const char *key, char **t
 /* Walk the CALLS edges rooted at n (either outbound or inbound depending on
  * `outbound`) and tokenize the names of the target/source nodes.  Caller-side
  * caps via max_tokens and MAX_CALLEES. */
+static int cmp_name_ptr(const void *pa, const void *pb) {
+    const char *a = *(const char *const *)pa;
+    const char *b = *(const char *const *)pb;
+    return strcmp(a, b);
+}
+
+/* Collect the CALLS-neighbor names of `node_id`, SORTED by name. The edge
+ * arrays are in insertion order — which under parallel extraction varies run
+ * to run — and both consumers truncate (MAX_CALLEES / max_tokens), so an
+ * unstable order changed WHICH neighbors contribute to the semantic vectors
+ * and flickered near-threshold SEMANTICALLY_RELATED edges (determinism).
+ * Returns a malloc'd array of borrowed name pointers; caller frees the array. */
+static const char **collect_sorted_call_neighbors(const cbm_gbuf_t *gbuf, int64_t node_id,
+                                                  bool outbound, int *out_n) {
+    *out_n = 0;
+    const cbm_gbuf_edge_t **edges = NULL;
+    int ec = 0;
+    int rc = outbound ? cbm_gbuf_find_edges_by_source_type(gbuf, node_id, "CALLS", &edges, &ec)
+                      : cbm_gbuf_find_edges_by_target_type(gbuf, node_id, "CALLS", &edges, &ec);
+    if (rc != 0 || ec <= 0) {
+        return NULL;
+    }
+    const char **names = malloc((size_t)ec * sizeof(char *));
+    if (!names) {
+        return NULL;
+    }
+    int n = 0;
+    for (int e = 0; e < ec; e++) {
+        int64_t id = outbound ? edges[e]->target_id : edges[e]->source_id;
+        const cbm_gbuf_node_t *neighbor = cbm_gbuf_find_by_id(gbuf, id);
+        if (neighbor && neighbor->name) {
+            names[n++] = neighbor->name;
+        }
+    }
+    qsort(names, (size_t)n, sizeof(char *), cmp_name_ptr);
+    *out_n = n;
+    return names;
+}
+
 static int tokenize_call_neighbors(const cbm_gbuf_node_t *n, const cbm_gbuf_t *gbuf, bool outbound,
                                    char **tokens, int count, int max_tokens) {
     if (!gbuf || count >= max_tokens) {
         return count;
     }
-    const cbm_gbuf_edge_t **edges = NULL;
-    int ec = 0;
-    int rc = outbound ? cbm_gbuf_find_edges_by_source_type(gbuf, n->id, "CALLS", &edges, &ec)
-                      : cbm_gbuf_find_edges_by_target_type(gbuf, n->id, "CALLS", &edges, &ec);
-    if (rc != 0) {
+    int nn = 0;
+    const char **names = collect_sorted_call_neighbors(gbuf, n->id, outbound, &nn);
+    if (!names) {
         return count;
     }
-    for (int e = 0; e < ec && e < MAX_CALLEES && count < max_tokens; e++) {
-        int64_t id = outbound ? edges[e]->target_id : edges[e]->source_id;
-        const cbm_gbuf_node_t *neighbor = cbm_gbuf_find_by_id(gbuf, id);
-        if (neighbor && neighbor->name) {
-            count += cbm_sem_tokenize(neighbor->name, tokens + count, max_tokens - count);
-        }
+    for (int e = 0; e < nn && e < MAX_CALLEES && count < max_tokens; e++) {
+        count += cbm_sem_tokenize(names[e], tokens + count, max_tokens - count);
     }
+    free((void *)names);
     return count;
 }
 
@@ -452,21 +498,19 @@ static int tokenize_node(const cbm_gbuf_node_t *n, const cbm_gbuf_t *gbuf, char 
 
 static void build_api_vec(const cbm_gbuf_t *gbuf, int64_t node_id, cbm_sem_vec_t *out) {
     memset(out, 0, sizeof(*out));
-    const cbm_gbuf_edge_t **edges = NULL;
-    int edge_count = 0;
-    if (cbm_gbuf_find_edges_by_source_type(gbuf, node_id, "CALLS", &edges, &edge_count) != 0) {
+    /* Sorted neighbors: stable MAX_CALLEES subset + stable float-accumulation
+     * order (see collect_sorted_call_neighbors). */
+    int n = 0;
+    const char **names = collect_sorted_call_neighbors(gbuf, node_id, /*outbound=*/true, &n);
+    if (!names) {
         return;
     }
-    int added = 0;
-    for (int i = 0; i < edge_count && added < MAX_CALLEES; i++) {
-        const cbm_gbuf_node_t *target = cbm_gbuf_find_by_id(gbuf, edges[i]->target_id);
-        if (target && target->name) {
-            cbm_sem_vec_t callee_ri;
-            cbm_sem_random_index(target->name, &callee_ri);
-            cbm_sem_vec_add_scaled(out, &callee_ri, PSE_UNIT_POS);
-            added++;
-        }
+    for (int i = 0; i < n && i < MAX_CALLEES; i++) {
+        cbm_sem_vec_t callee_ri;
+        cbm_sem_random_index(names[i], &callee_ri);
+        cbm_sem_vec_add_scaled(out, &callee_ri, PSE_UNIT_POS);
     }
+    free((void *)names);
     cbm_sem_normalize(out);
 }
 
@@ -696,7 +740,7 @@ static void sig_build_worker(int worker_id, void *ctx_ptr) {
 typedef struct {
     cbm_sem_func_t *funcs;
     uint64_t *signatures;
-    int *edge_counts; /* shared, atomically updated */
+    int *edge_counts; /* budget applied sequentially in phase6b (determinism) */
     cbm_sem_config_t cfg;
     int func_count;
 
@@ -767,14 +811,15 @@ static int score_collect_candidates(score_ctx_t *sc, int i, int *seen, int *cand
     return cand_count;
 }
 
-/* Score one candidate pair (i, j) and push a deferred edge if the score
- * passes the threshold and both endpoints still have edge budget. */
-static void score_try_emit(score_ctx_t *sc, int i, int j, deferred_edge_buf_t *my_buf) {
-    int ei = atomic_load_explicit((_Atomic int *)&sc->edge_counts[i], memory_order_relaxed);
-    int ej = atomic_load_explicit((_Atomic int *)&sc->edge_counts[j], memory_order_relaxed);
-    if (ei >= sc->cfg.max_edges || ej >= sc->cfg.max_edges) {
-        return;
-    }
+/* Score one candidate pair (i, j) and push a deferred candidate edge if the
+ * score passes the threshold. ADMISSION (the per-node max_edges budget) is
+ * deliberately NOT decided here: the old check-then-increment on shared
+ * atomic counts made the admitted edge SET depend on worker scheduling —
+ * multi-threaded runs lost edges vs single-threaded and differed run-to-run
+ * (repro_parallel_edge_determinism). Scoring is pure math and stays parallel;
+ * the budget is applied afterwards in one sequential pass over the pairs in
+ * canonical (i, candidate-rank) order. */
+static void score_try_emit(score_ctx_t *sc, int i, int j, int c, deferred_edge_buf_t *my_buf) {
     if (strcmp(sc->funcs[i].file_ext, sc->funcs[j].file_ext) != 0) {
         return;
     }
@@ -784,9 +829,8 @@ static void score_try_emit(score_ctx_t *sc, int i, int j, deferred_edge_buf_t *m
     }
     bool same_file = sc->funcs[i].file_path && sc->funcs[j].file_path &&
                      strcmp(sc->funcs[i].file_path, sc->funcs[j].file_path) == 0;
-    deferred_buf_push(my_buf, sc->funcs[i].node_id, sc->funcs[j].node_id, score, same_file);
-    atomic_fetch_add_explicit((_Atomic int *)&sc->edge_counts[i], SKIP_ONE, memory_order_relaxed);
-    atomic_fetch_add_explicit((_Atomic int *)&sc->edge_counts[j], SKIP_ONE, memory_order_relaxed);
+    deferred_buf_push(my_buf, sc->funcs[i].node_id, sc->funcs[j].node_id, score, same_file, i, j,
+                      c);
 }
 
 static void score_worker(int worker_id, void *ctx_ptr) {
@@ -798,11 +842,6 @@ static void score_worker(int worker_id, void *ctx_ptr) {
         if (i >= sc->func_count) {
             break;
         }
-        int my_edges =
-            atomic_load_explicit((_Atomic int *)&sc->edge_counts[i], memory_order_relaxed);
-        if (my_edges >= sc->cfg.max_edges) {
-            continue;
-        }
         int seen[SCORE_SEEN_CAP];
         for (int s = 0; s < SCORE_SEEN_CAP; s++) {
             seen[s] = SCORE_SEEN_EMPTY;
@@ -810,7 +849,7 @@ static void score_worker(int worker_id, void *ctx_ptr) {
         int candidates[SEM_MAX_CANDIDATES];
         int cand_count = score_collect_candidates(sc, i, seen, candidates, SEM_MAX_CANDIDATES);
         for (int c = 0; c < cand_count; c++) {
-            score_try_emit(sc, i, candidates[c], my_buf);
+            score_try_emit(sc, i, candidates[c], c, my_buf);
         }
     }
 }
@@ -856,6 +895,24 @@ typedef struct {
     int cap;
 } sem_bucket_t;
 
+/* Canonical node order: by qualified name (unique per node), id tie-break
+ * for defensiveness. Gives the semantic pass a stable, content-derived input
+ * order regardless of how parallel extraction merged the graph buffer. */
+static int cmp_node_ptr_by_qn(const void *pa, const void *pb) {
+    const cbm_gbuf_node_t *a = *(const cbm_gbuf_node_t *const *)pa;
+    const cbm_gbuf_node_t *b = *(const cbm_gbuf_node_t *const *)pb;
+    const char *qa = a->qualified_name ? a->qualified_name : "";
+    const char *qb = b->qualified_name ? b->qualified_name : "";
+    int r = strcmp(qa, qb);
+    if (r != 0) {
+        return r;
+    }
+    if (a->id != b->id) {
+        return a->id < b->id ? -1 : 1;
+    }
+    return 0;
+}
+
 /* Phase 1a: seed the funcs[] / node_ptrs[] arrays from all Function and
  * Method nodes in the graph buffer.  Returns the number of functions collected
  * (0 on OOM), and fills *out_funcs / *out_nodes with newly malloc'd arrays. */
@@ -898,6 +955,20 @@ static int phase1_scan_functions(cbm_gbuf_t *gbuf, cbm_sem_func_t **out_funcs,
             func_count++;
         }
     }
+    /* Canonicalize the func order (determinism): the label-index order above
+     * is gbuf insertion order = parallel-extraction merge order, which varies
+     * run to run. Everything downstream is order-sensitive — LSH bucket chain
+     * order, the SEM_MAX_CANDIDATES truncation, seen[] and the admission
+     * sequence — so an unstable order changes WHICH semantic edges are
+     * emitted. Sort the cheap pointer array by qualified name (unique) and
+     * re-derive the three fields set so far; the heavy per-func payloads are
+     * filled in later phases, so no 12.7 KB structs are moved. */
+    qsort(node_ptrs, (size_t)func_count, sizeof(node_ptrs[0]), cmp_node_ptr_by_qn);
+    for (int k = 0; k < func_count; k++) {
+        funcs[k].node_id = node_ptrs[k]->id;
+        funcs[k].file_path = node_ptrs[k]->file_path;
+        funcs[k].file_ext = file_ext(node_ptrs[k]->file_path);
+    }
     *out_funcs = funcs;
     *out_nodes = node_ptrs;
     return func_count;
@@ -932,20 +1003,66 @@ static void phase5c_build_lsh_buckets(const uint64_t *signatures, int func_count
 
 /* Phase 6b: serialize deferred edges from all worker buffers into the graph
  * buffer (sequential because gbuf isn't thread-safe). */
+/* Canonical order for candidate pairs: ascending discovering-func index,
+ * then ascending candidate rank — the order a sequential scoring loop over
+ * canonically-sorted funcs would have produced. */
+static int cmp_deferred_edge_canonical(const void *pa, const void *pb) {
+    const deferred_edge_t *a = pa;
+    const deferred_edge_t *b = pb;
+    if (a->i != b->i) {
+        return a->i < b->i ? -1 : 1;
+    }
+    if (a->c != b->c) {
+        return a->c < b->c ? -1 : 1;
+    }
+    return 0;
+}
+
+/* Sequential, deterministic admission + merge: gather every above-threshold
+ * pair from the worker buffers, replay them in canonical (i, rank) order,
+ * and apply the per-node max_edges budget HERE — single-threaded — so the
+ * admitted edge set is a pure function of the (canonically sorted) inputs,
+ * independent of worker count and scheduling. */
 static int phase6b_merge_edges(cbm_gbuf_t *gbuf, deferred_edge_buf_t *worker_bufs,
-                               int worker_count) {
-    int total_edges = 0;
+                               int worker_count, int *edge_counts, int max_edges) {
+    int total_pairs = 0;
     for (int w = 0; w < worker_count; w++) {
-        for (int e = 0; e < worker_bufs[w].count; e++) {
-            deferred_edge_t *de = &worker_bufs[w].edges[e];
-            char props[PROPS_BUF];
-            snprintf(props, sizeof(props), "{\"score\":%.3f,\"same_file\":%s}", de->score,
-                     de->same_file ? "true" : "false");
-            cbm_gbuf_insert_edge(gbuf, de->source_id, de->target_id, "SEMANTICALLY_RELATED", props);
-            total_edges++;
+        total_pairs += worker_bufs[w].count;
+    }
+    deferred_edge_t *pairs = NULL;
+    if (total_pairs > 0) {
+        pairs = malloc((size_t)total_pairs * sizeof(deferred_edge_t));
+    }
+    if (!pairs) {
+        for (int w = 0; w < worker_count; w++) {
+            deferred_buf_free(&worker_bufs[w]);
         }
+        return 0;
+    }
+    int n = 0;
+    for (int w = 0; w < worker_count; w++) {
+        memcpy(&pairs[n], worker_bufs[w].edges,
+               (size_t)worker_bufs[w].count * sizeof(deferred_edge_t));
+        n += worker_bufs[w].count;
         deferred_buf_free(&worker_bufs[w]);
     }
+    qsort(pairs, (size_t)n, sizeof(deferred_edge_t), cmp_deferred_edge_canonical);
+
+    int total_edges = 0;
+    for (int e = 0; e < n; e++) {
+        deferred_edge_t *de = &pairs[e];
+        if (edge_counts[de->i] >= max_edges || edge_counts[de->j] >= max_edges) {
+            continue;
+        }
+        char props[PROPS_BUF];
+        snprintf(props, sizeof(props), "{\"score\":%.3f,\"same_file\":%s}", de->score,
+                 de->same_file ? "true" : "false");
+        cbm_gbuf_insert_edge(gbuf, de->source_id, de->target_id, "SEMANTICALLY_RELATED", props);
+        edge_counts[de->i]++;
+        edge_counts[de->j]++;
+        total_edges++;
+    }
+    free(pairs);
     return total_edges;
 }
 
@@ -1168,7 +1285,7 @@ static int run_scoring_phase(cbm_gbuf_t *gbuf, cbm_sem_func_t *funcs, uint64_t *
     CBM_PROF_END_N("semantic_edges", "6a_score_parallel", t_phase6a, func_count);
 
     CBM_PROF_START(t_phase6b);
-    int total = phase6b_merge_edges(gbuf, worker_bufs, worker_count);
+    int total = phase6b_merge_edges(gbuf, worker_bufs, worker_count, edge_counts, cfg.max_edges);
     CBM_PROF_END_N("semantic_edges", "6b_edge_merge_seq", t_phase6b, total);
 
     free(worker_bufs);
@@ -1238,6 +1355,7 @@ int cbm_pipeline_pass_semantic_edges(cbm_pipeline_ctx_t *ctx) {
     phase4_build_and_store_vectors(gbuf, funcs, all_tokens, token_counts, corpus, func_count,
                                    worker_count);
     CBM_PROF_END_N("semantic_edges", "4_build_and_store_vec", t_phase4, func_count);
+
 
     cbm_log_info("pass.semantic.vectors_stored", "count", itoa_log(func_count));
 

--- a/src/pipeline/pass_similarity.c
+++ b/src/pipeline/pass_similarity.c
@@ -89,7 +89,27 @@ typedef struct {
     cbm_minhash_t fp;
     const char *file_path;
     const char *ext;
+    const char *qn; /* canonical ordering + pair-ownership (determinism) */
 } fp_entry_t;
+
+/* Canonical entry order: by qualified name (unique). The label-index order
+ * from collect_fp_entries is gbuf insertion order = parallel-extraction merge
+ * order, which varies run to run; LSH bucket chains and the per-node edge-cap
+ * truncation both inherit it, flickering WHICH SIMILAR_TO edges are emitted. */
+static int cmp_fp_entry_by_qn(const void *pa, const void *pb) {
+    const fp_entry_t *a = pa;
+    const fp_entry_t *b = pb;
+    const char *qa = a->qn ? a->qn : "";
+    const char *qb = b->qn ? b->qn : "";
+    int r = strcmp(qa, qb);
+    if (r != 0) {
+        return r;
+    }
+    if (a->node_id != b->node_id) {
+        return a->node_id < b->node_id ? -1 : 1;
+    }
+    return 0;
+}
 
 /* Collect all Function/Method nodes with fingerprints from graph buffer. */
 static int collect_fp_entries(cbm_gbuf_t *gbuf, fp_entry_t **out_entries) {
@@ -124,9 +144,12 @@ static int collect_fp_entries(cbm_gbuf_t *gbuf, fp_entry_t **out_entries) {
                 .fp = fp,
                 .file_path = n->file_path,
                 .ext = file_ext(n->file_path),
+                .qn = n->qualified_name,
             };
         }
     }
+    /* Canonicalize (determinism) — see cmp_fp_entry_by_qn. */
+    qsort(entries, (size_t)count, sizeof(fp_entry_t), cmp_fp_entry_by_qn);
     *out_entries = entries;
     return count;
 }
@@ -203,7 +226,12 @@ static void sim_query_worker(int worker_id, void *ctx_ptr) {
             if (strcmp(src->ext, cand->file_ext) != 0) {
                 continue;
             }
-            if (src->node_id >= cand->node_id) {
+            /* Pair ownership by canonical QN order, not node id: ids are
+             * assigned in parallel-merge order and vary run to run, which
+             * flipped which side owned a pair and (with the per-source edge
+             * cap) flickered the emitted set (determinism). */
+            if (!src->qn || !cand->qualified_name ||
+                strcmp(src->qn, cand->qualified_name) >= 0) {
                 continue;
             }
 
@@ -283,6 +311,7 @@ int cbm_pipeline_pass_similarity(cbm_pipeline_ctx_t *ctx) {
             .fingerprint = &entries[i].fp,
             .file_path = entries[i].file_path,
             .file_ext = entries[i].ext,
+            .qualified_name = entries[i].qn,
         };
         cbm_lsh_insert(lsh, &lsh_entries[i]);
     }

--- a/src/pipeline/pipeline.c
+++ b/src/pipeline/pipeline.c
@@ -903,13 +903,9 @@ static int run_parallel_pipeline(cbm_pipeline_t *p, cbm_pipeline_ctx_t *ctx,
         cross_registries.c = cbm_c_build_cross_registry(&cross_lsp_arena, all_defs, def_count);
         cross_registries.cs = cbm_cs_build_cross_registry(&cross_lsp_arena, all_defs, def_count);
         cross_registries.ts = cbm_ts_build_cross_registry(&cross_lsp_arena, all_defs, def_count);
-        cross_registries.rust = cbm_rust_build_cross_registry(&cross_lsp_arena, all_defs, def_count);
-        if (cross_registries.rust) {
-            char _rsb[96];
-            snprintf(_rsb, sizeof(_rsb), "types=%d funcs=%d", cross_registries.rust->type_count,
-                     cross_registries.rust->func_count);
-            cbm_log_info("cross_lsp.rust_registry", "scale", _rsb);
-        }
+        /* Rust: NOT built here. The shared all_defs registry is built LAZILY on the
+         * first NULL-filter rust file (the amplifier files) inside cbm_parallel_resolve
+         * — repos whose rust files all filter to subsets never pay the build/RSS. */
     }
     cbm_log_info("pass.timing", "pass", "lsp_cross_prepare", "elapsed_ms",
                  itoa_buf((int)elapsed_ms(*t)));

--- a/src/pipeline/pipeline.c
+++ b/src/pipeline/pipeline.c
@@ -1046,30 +1046,71 @@ static int dump_and_persist_hashes(cbm_pipeline_t *p, const cbm_file_info_t *fil
         return rc;
     }
     cbm_log_info("pass.timing", "pass", "dump", "elapsed_ms", itoa_buf((int)elapsed_ms(*t)));
+    /* Persist-tail spans (phase "persist"): attribute the ~60s that lands here
+     * AFTER cbm_gbuf_dump_to_sqlite returns. Active only under CBM_PROFILE. */
+    CBM_PROF_START(t_reopen);
     cbm_store_t *hash_store = cbm_store_open_path(db_path);
+    CBM_PROF_END("persist", "1_reopen", t_reopen);
     if (hash_store) {
+        CBM_PROF_START(t_delhash);
         cbm_store_delete_file_hashes(hash_store, p->project_name);
+        CBM_PROF_END("persist", "2_delete_file_hashes", t_delhash);
 
         /* Restore the ADR captured before the dump. Surface a failed restore
          * rather than silently dropping the ADR (the original #516 symptom). */
+        CBM_PROF_START(t_adr);
         if (p->saved_adr) {
             if (cbm_store_adr_store(hash_store, p->project_name, p->saved_adr) != CBM_STORE_OK) {
                 cbm_log_error("pipeline.err", "phase", "adr_restore", "project", p->project_name);
             }
         }
-        for (int i = 0; i < file_count; i++) {
-            struct stat fst;
-            if (stat(files[i].path, &fst) == 0) {
-                cbm_store_upsert_file_hash(hash_store, p->project_name, files[i].rel_path, "",
-                                           stat_mtime_ns(&fst), fst.st_size);
+        CBM_PROF_END("persist", "3_adr_restore", t_adr);
+
+        /* Batch the per-file hash upserts into ONE transaction. The per-file
+         * cbm_store_upsert_file_hash path autocommits, i.e. file_count fsyncs
+         * (~89k on the kernel); cbm_store_upsert_file_hash_batch wraps the same
+         * cached INSERT ... ON CONFLICT upsert in a single begin/commit. Same
+         * (project, rel_path, sha256="", mtime_ns, size) tuples, same replace
+         * semantics — only the transaction boundary changes. */
+        CBM_PROF_START(t_fh);
+        cbm_file_hash_t *fhashes = (cbm_file_hash_t *)malloc(
+            (size_t)(file_count > 0 ? file_count : 1) * sizeof(cbm_file_hash_t));
+        if (fhashes) {
+            int fh_n = 0;
+            for (int i = 0; i < file_count; i++) {
+                struct stat fst;
+                if (stat(files[i].path, &fst) == 0) {
+                    fhashes[fh_n].project = p->project_name;
+                    fhashes[fh_n].rel_path = files[i].rel_path;
+                    fhashes[fh_n].sha256 = "";
+                    fhashes[fh_n].mtime_ns = stat_mtime_ns(&fst);
+                    fhashes[fh_n].size = fst.st_size;
+                    fh_n++;
+                }
+            }
+            if (cbm_store_upsert_file_hash_batch(hash_store, fhashes, fh_n) != CBM_STORE_OK) {
+                cbm_log_error("pipeline.err", "phase", "persist_file_hashes", "project",
+                              p->project_name);
+            }
+            free(fhashes);
+        } else {
+            /* OOM fallback: the original per-file path (identical result, slower). */
+            for (int i = 0; i < file_count; i++) {
+                struct stat fst;
+                if (stat(files[i].path, &fst) == 0) {
+                    cbm_store_upsert_file_hash(hash_store, p->project_name, files[i].rel_path, "",
+                                               stat_mtime_ns(&fst), fst.st_size);
+                }
             }
         }
+        CBM_PROF_END_N("persist", "4_file_hashes", t_fh, file_count);
 
         /* FTS5 backfill: populate nodes_fts with camelCase-split names.
          * Contentless FTS5 requires the special 'delete-all' command instead of
          * DELETE FROM to wipe prior rows (there's no underlying content table).
          * Falls back to plain names if cbm_camel_split is unavailable (which
          * shouldn't happen because we always register it, but we stay defensive). */
+        CBM_PROF_START(t_fts);
         cbm_store_exec(hash_store, "INSERT INTO nodes_fts(nodes_fts) VALUES('delete-all');");
         if (cbm_store_exec(hash_store,
                            "INSERT INTO nodes_fts(rowid, name, qualified_name, label, file_path) "
@@ -1079,6 +1120,7 @@ static int dump_and_persist_hashes(cbm_pipeline_t *p, const cbm_file_info_t *fil
                            "INSERT INTO nodes_fts(rowid, name, qualified_name, label, file_path) "
                            "SELECT id, name, qualified_name, label, file_path FROM nodes;");
         }
+        CBM_PROF_END("persist", "5_fts_backfill", t_fts);
 
         cbm_store_close(hash_store);
         cbm_log_info("pass.timing", "pass", "persist_hashes", "files", itoa_buf(file_count));
@@ -1088,7 +1130,9 @@ static int dump_and_persist_hashes(cbm_pipeline_t *p, const cbm_file_info_t *fil
 
     /* Export persistent artifact if enabled */
     if (p->persistence) {
+        CBM_PROF_START(t_art);
         int arc = cbm_artifact_export(db_path, p->repo_path, p->project_name, CBM_ARTIFACT_BEST);
+        CBM_PROF_END("persist", "6_artifact_export", t_art);
         if (arc != 0) {
             const char *err = cbm_artifact_export_last_error();
             cbm_log_error("pipeline.err", "phase", "artifact_export", "err", err ? err : "unknown");

--- a/src/pipeline/pipeline.c
+++ b/src/pipeline/pipeline.c
@@ -903,6 +903,13 @@ static int run_parallel_pipeline(cbm_pipeline_t *p, cbm_pipeline_ctx_t *ctx,
         cross_registries.c = cbm_c_build_cross_registry(&cross_lsp_arena, all_defs, def_count);
         cross_registries.cs = cbm_cs_build_cross_registry(&cross_lsp_arena, all_defs, def_count);
         cross_registries.ts = cbm_ts_build_cross_registry(&cross_lsp_arena, all_defs, def_count);
+        cross_registries.rust = cbm_rust_build_cross_registry(&cross_lsp_arena, all_defs, def_count);
+        if (cross_registries.rust) {
+            char _rsb[96];
+            snprintf(_rsb, sizeof(_rsb), "types=%d funcs=%d", cross_registries.rust->type_count,
+                     cross_registries.rust->func_count);
+            cbm_log_info("cross_lsp.rust_registry", "scale", _rsb);
+        }
     }
     cbm_log_info("pass.timing", "pass", "lsp_cross_prepare", "elapsed_ms",
                  itoa_buf((int)elapsed_ms(*t)));

--- a/src/pipeline/pipeline_internal.h
+++ b/src/pipeline/pipeline_internal.h
@@ -614,4 +614,11 @@ void cbm_pipeline_set_committed_counts(cbm_pipeline_t *p, int nodes, int edges);
 bool extract_grpc_service_method(const char *callee, char *service, size_t srv_sz, char *method,
                                  size_t meth_sz);
 
+/* Extraction back-pressure observability (pass_parallel.c): nap-cycle counter
+ * for the over-budget collect+nap gate. Test hook — asserts the gate stops
+ * re-paying the nap tax once a full cycle failed to reclaim under budget
+ * (futile: the resident floor, not transients, holds the memory). */
+long cbm_pp_bp_nap_cycles(void);
+void cbm_pp_bp_nap_cycles_reset(void);
+
 #endif /* CBM_PIPELINE_INTERNAL_H */

--- a/src/pipeline/registry.c
+++ b/src/pipeline/registry.c
@@ -75,6 +75,11 @@ const char *cbm_confidence_band(double score) {
 typedef CBM_DYN_ARRAY(char *) qn_array_t;
 
 struct cbm_registry {
+    /* Interned label strings (<=~30 distinct labels; owned here, freed in
+     * _free). The exact map's VALUES point into this pool instead of one
+     * strdup per registered definition (~8.5M strdups on the kernel). */
+    char *label_pool[64];
+    int label_pool_n;
     /* exact: qualifiedName → label string (heap-owned copies) */
     CBMHashTable *exact;
 
@@ -464,17 +469,15 @@ cbm_registry_t *cbm_registry_new(void) {
 
 static void free_label(const char *key, void *value, void *ud) {
     (void)ud;
+    (void)value; /* interned in the registry's label_pool */
     free((void *)key);
-    free(value);
 }
 
 static void free_qn_array(const char *key, void *value, void *ud) {
     (void)ud;
     qn_array_t *arr = value;
     if (arr) {
-        for (int i = 0; i < arr->count; i++) {
-            free(arr->items[i]);
-        }
+        /* items borrow the exact map's keys — freed there, not here */
         cbm_da_free(arr);
         free(arr);
     }
@@ -485,10 +488,14 @@ void cbm_registry_free(cbm_registry_t *r) {
     if (!r) {
         return;
     }
-    cbm_ht_foreach(r->exact, free_label, NULL);
-    cbm_ht_free(r->exact);
+    /* by_name first: its items borrow exact's keys. */
     cbm_ht_foreach(r->by_name, free_qn_array, NULL);
     cbm_ht_free(r->by_name);
+    cbm_ht_foreach(r->exact, free_label, NULL);
+    cbm_ht_free(r->exact);
+    for (int i = 0; i < r->label_pool_n; i++) {
+        free(r->label_pool[i]);
+    }
     free(r);
 }
 
@@ -506,8 +513,28 @@ void cbm_registry_add(cbm_registry_t *r, const char *name, const char *qualified
         return;
     }
 
-    /* Store in exact map: QN → label */
-    cbm_ht_set(r->exact, strdup(qualified_name), strdup(label));
+    /* Intern the label (bounded set; linear scan is fine at this size). */
+    const char *interned = NULL;
+    for (int i = 0; i < r->label_pool_n; i++) {
+        if (strcmp(r->label_pool[i], label) == 0) {
+            interned = r->label_pool[i];
+            break;
+        }
+    }
+    if (!interned && r->label_pool_n < (int)(sizeof(r->label_pool) / sizeof(r->label_pool[0]))) {
+        r->label_pool[r->label_pool_n] = strdup(label);
+        interned = r->label_pool[r->label_pool_n];
+        r->label_pool_n++;
+    }
+    if (!interned) {
+        return; /* pool exhausted (cannot happen with sane label sets) */
+    }
+
+    /* Store in exact map: QN → interned label. The key is the registry's ONE
+     * owned copy of the QN; by_name below borrows it (same lifetime) instead
+     * of a second strdup — this pair of copies was ~280 MB on the kernel. */
+    cbm_ht_set(r->exact, strdup(qualified_name), (void *)interned);
+    const char *owned_qn = cbm_ht_get_key(r->exact, qualified_name);
 
     /* Index by simple name.
      * No array dedup needed: exact-map check above guarantees uniqueness. */
@@ -517,7 +544,7 @@ void cbm_registry_add(cbm_registry_t *r, const char *name, const char *qualified
         arr = calloc(CBM_ALLOC_ONE, sizeof(qn_array_t));
         cbm_ht_set(r->by_name, strdup(simple), arr);
     }
-    cbm_da_push(arr, strdup(qualified_name));
+    cbm_da_push(arr, (char *)owned_qn);
 }
 
 /* ── Lookup ──────────────────────────────────────────────────────── */

--- a/src/semantic/rotsq.c
+++ b/src/semantic/rotsq.c
@@ -1,0 +1,127 @@
+/*
+ * rotsq.c — see rotsq.h. From-paper implementation, no dependencies.
+ */
+#include "semantic/rotsq.h"
+
+#include <string.h>
+
+#define XXH_INLINE_ALL
+#include "xxhash/xxhash.h"
+
+/* ── Deterministic ±1 diagonal (seeded, generated once) ─────────────── */
+
+static float g_rsq_diag[CBM_RSQ_DIM];
+static int g_rsq_diag_ready = 0;
+
+static void rsq_init_diag(void) {
+    if (g_rsq_diag_ready) {
+        return;
+    }
+    for (int d = 0; d < CBM_RSQ_DIM; d++) {
+        uint64_t h = XXH3_64bits_withSeed(&d, sizeof(d), 0x5bd1e995u);
+        g_rsq_diag[d] = (h & 1u) ? 1.0F : -1.0F;
+    }
+    g_rsq_diag_ready = 1;
+}
+
+/* ── Fast Walsh–Hadamard Transform (in place, unnormalized) ─────────── */
+
+static void rsq_fwht(float *v) {
+    for (int len = 1; len < CBM_RSQ_DIM; len <<= 1) {
+        for (int i = 0; i < CBM_RSQ_DIM; i += len << 1) {
+            for (int j = i; j < i + len; j++) {
+                float a = v[j];
+                float b = v[j + len];
+                v[j] = a + b;
+                v[j + len] = a - b;
+            }
+        }
+    }
+}
+
+/* ── Encode ─────────────────────────────────────────────────────────── */
+
+void cbm_rsq_encode(const float *v, cbm_rsq_code_t *out) {
+    rsq_init_diag();
+
+    float rot[CBM_RSQ_DIM];
+    for (int d = 0; d < CBM_RSQ_IN_DIM; d++) {
+        rot[d] = v[d] * g_rsq_diag[d];
+    }
+    for (int d = CBM_RSQ_IN_DIM; d < CBM_RSQ_DIM; d++) {
+        rot[d] = 0.0F;
+    }
+    rsq_fwht(rot);
+    /* Normalize the transform so the rotation is orthonormal (H/√D): keeps
+     * the coordinates in a data-independent range and makes the estimated IP
+     * directly comparable to the pre-rotation IP. */
+    const float inv_sqrt_d = 1.0F / 32.0F; /* 1/√1024 */
+    float lo = rot[0] * inv_sqrt_d;
+    float hi = lo;
+    for (int d = 0; d < CBM_RSQ_DIM; d++) {
+        rot[d] *= inv_sqrt_d;
+        if (rot[d] < lo) {
+            lo = rot[d];
+        }
+        if (rot[d] > hi) {
+            hi = rot[d];
+        }
+    }
+
+    /* Per-vector scalar quantization over [lo, hi] at CBM_RSQ_BITS. */
+    float range = hi - lo;
+    float step = range > 0.0F ? range / (float)CBM_RSQ_LEVELS : 1.0F;
+    out->offset = lo;
+    out->scale = step;
+
+    int32_t sum = 0;
+    memset(out->codes, 0, sizeof(out->codes));
+    for (int d = 0; d < CBM_RSQ_DIM; d++) {
+        float q = (rot[d] - lo) / step;
+        int32_t c = (int32_t)(q + 0.5F);
+        if (c < 0) {
+            c = 0;
+        }
+        if (c > CBM_RSQ_LEVELS) {
+            c = CBM_RSQ_LEVELS;
+        }
+        sum += c;
+        if (d & 1) {
+            out->codes[d >> 1] |= (uint8_t)(c << 4);
+        } else {
+            out->codes[d >> 1] |= (uint8_t)c;
+        }
+    }
+    out->code_sum = sum;
+}
+
+/* ── Estimated inner product from two codes ─────────────────────────── */
+
+float cbm_rsq_ip(const cbm_rsq_code_t *a, const cbm_rsq_code_t *b) {
+    /* Integer dot of the 4-bit codes. */
+    int64_t dot = 0;
+    for (int i = 0; i < CBM_RSQ_CODE_BYTES; i++) {
+        uint8_t ba = a->codes[i];
+        uint8_t bb = b->codes[i];
+        dot += (int64_t)(ba & 0x0F) * (bb & 0x0F);
+        dot += (int64_t)(ba >> 4) * (bb >> 4);
+    }
+    /* x_i ≈ oa + sa·ca_i, y_i ≈ ob + sb·cb_i (in the rotated space, where the
+     * IP equals the original IP because the rotation is orthonormal). */
+    double d = (double)CBM_RSQ_DIM;
+    double ip = d * (double)a->offset * (double)b->offset +
+                (double)a->offset * (double)b->scale * (double)b->code_sum +
+                (double)b->offset * (double)a->scale * (double)a->code_sum +
+                (double)a->scale * (double)b->scale * (double)dot;
+    return (float)ip;
+}
+
+/* ── Dequantize into the rotated basis ──────────────────────────────── */
+
+void cbm_rsq_decode(const cbm_rsq_code_t *c, float *out) {
+    for (int i = 0; i < CBM_RSQ_CODE_BYTES; i++) {
+        uint8_t b = c->codes[i];
+        out[i * 2] = c->offset + c->scale * (float)(b & 0x0F);
+        out[i * 2 + 1] = c->offset + c->scale * (float)(b >> 4);
+    }
+}

--- a/src/semantic/rotsq.h
+++ b/src/semantic/rotsq.h
@@ -1,0 +1,65 @@
+/*
+ * rotsq.h — RaBitQ-style B-bit vector quantization (from-paper, plain C11).
+ *
+ * Implements the core of Extended RaBitQ (Gao et al., SIGMOD 2024/2025;
+ * arXiv:2405.12497, arXiv:2409.09913) without the reference library (which is
+ * C++ and bundles Eigen/MPL-2.0). Named rotsq, not rabitq: this is the
+ * FAMILY core (randomized rotation + per-vector scalar quantization + exact
+ * code-expansion estimator), not the papers' exact codebook construction —
+ * the name should not overclaim fidelity. Rotate each vector with a deterministic
+ * randomized transform, then scalar-quantize the rotated coordinates to B
+ * bits. The rotation spreads a vector's mass evenly across coordinates
+ * (rotated coords of a unit vector are near-Gaussian), which makes plain
+ * scalar quantization behave near-optimally — that observation IS RaBitQ.
+ *
+ * Rotation: random ±1 diagonal (XXH3-seeded, reproducible — same idiom as the
+ * LSH hyperplanes) followed by a Fast Walsh–Hadamard Transform, inputs padded
+ * to the next power of two (768 → 1024). Orthogonal up to a known 1/√D scale.
+ *
+ * Inner product between two ENCODED vectors is estimated from the codes with
+ * the exact SQ expansion (deterministic — a pure function of the two codes):
+ *   x_i ≈ ox + sx·cx_i  ⇒  ⟨x,y⟩ ≈ D·ox·oy + ox·sy·Σcy + oy·sx·Σcx
+ *                                   + sx·sy·Σ(cx_i·cy_i)
+ * with Σcx/Σcy precomputed per vector, so scoring one pair is one integer
+ * dot product (u8×u8) plus four multiplies.
+ *
+ * Memory at B=4, D=1024: 512 B codes + 12 B metadata per vector, vs 3 072 B
+ * for 768 raw floats — ~6× per vector. Cosine of normalized inputs is the
+ * estimated IP directly (rotation preserves norms up to the fixed scale,
+ * which cancels in the scale factors).
+ */
+#ifndef CBM_SEMANTIC_ROTSQ_H
+#define CBM_SEMANTIC_ROTSQ_H
+
+#include <stdint.h>
+
+enum {
+    CBM_RSQ_IN_DIM = 768,   /* input dimension (CBM_SEM_DIM) */
+    CBM_RSQ_DIM = 1024,     /* padded pow2 rotation dimension */
+    CBM_RSQ_BITS = 4,       /* bits per coordinate */
+    CBM_RSQ_LEVELS = 15,    /* (1 << CBM_RSQ_BITS) - 1 */
+    CBM_RSQ_CODE_BYTES = CBM_RSQ_DIM / 2, /* two 4-bit codes per byte */
+};
+
+typedef struct {
+    uint8_t codes[CBM_RSQ_CODE_BYTES]; /* packed 4-bit codes, little nibble first */
+    float scale;                       /* per-vector dequant scale  */
+    float offset;                      /* per-vector dequant offset */
+    int32_t code_sum;                  /* Σ codes (for the IP expansion) */
+} cbm_rsq_code_t;
+
+/* Encode a CBM_RSQ_IN_DIM float vector (zero-padded to CBM_RSQ_DIM, rotated,
+ * quantized). Deterministic: the rotation is fixed at build time. */
+void cbm_rsq_encode(const float *v, cbm_rsq_code_t *out);
+
+/* Estimated inner product of the two ORIGINAL vectors from their codes.
+ * Deterministic pure function of the codes. */
+float cbm_rsq_ip(const cbm_rsq_code_t *a, const cbm_rsq_code_t *b);
+
+/* Dequantize a code into the ROTATED space (CBM_RSQ_DIM floats). Note: this
+ * is the rotated basis, not the original one — fine for basis-agnostic
+ * consumers (LSH hyperplane signs), wrong for anything expecting original
+ * coordinates. */
+void cbm_rsq_decode(const cbm_rsq_code_t *c, float *out);
+
+#endif /* CBM_SEMANTIC_ROTSQ_H */

--- a/src/semantic/semantic.c
+++ b/src/semantic/semantic.c
@@ -1620,7 +1620,7 @@ float cbm_sem_combined_score(const cbm_sem_func_t *a, const cbm_sem_func_t *b,
     float score = cfg->w_tfidf * sparse_tfidf_cosine(a, b);
 
     /* Signal 2: Random Indexing */
-    score += cfg->w_ri * cbm_sem_cosine(&a->ri_vec, &b->ri_vec);
+    score += cfg->w_ri * cbm_rsq_ip(&a->ri_code, &b->ri_code);
 
     /* Signal 3: MinHash Jaccard */
     if (a->has_minhash && b->has_minhash) {
@@ -1630,13 +1630,13 @@ float cbm_sem_combined_score(const cbm_sem_func_t *a, const cbm_sem_func_t *b,
     }
 
     /* Signal 4: API Signatures */
-    score += cfg->w_api * cbm_sem_cosine(&a->api_vec, &b->api_vec);
+    score += cfg->w_api * cbm_rsq_ip(&a->api_code, &b->api_code);
 
     /* Signal 5: Type Signatures */
-    score += cfg->w_type * cbm_sem_cosine(&a->type_vec, &b->type_vec);
+    score += cfg->w_type * cbm_rsq_ip(&a->type_code, &b->type_code);
 
     /* Signal 7: Decorator Pattern */
-    score += cfg->w_decorator * cbm_sem_cosine(&a->deco_vec, &b->deco_vec);
+    score += cfg->w_decorator * cbm_rsq_ip(&a->deco_code, &b->deco_code);
 
     /* Signal 8+9+11: Structural profile + data flow + Halstead */
     float sp_score = small_cosine(a->struct_profile, b->struct_profile, CBM_SEM_AST_PROFILE_DIMS);

--- a/src/semantic/semantic.h
+++ b/src/semantic/semantic.h
@@ -27,6 +27,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "semantic/rotsq.h"
+
 /* ── Configuration ───────────────────────────────────────────────── */
 
 /* Random Indexing dimension. 256 is sufficient for <500K functions. */
@@ -134,10 +136,15 @@ typedef struct {
     int tfidf_len;
 
     /* Dense vectors for RI, API, Type, Decorator. */
-    cbm_sem_vec_t ri_vec;
-    cbm_sem_vec_t api_vec;
-    cbm_sem_vec_t type_vec;
-    cbm_sem_vec_t deco_vec;
+    /* Quantized semantic vectors (rotated 4-bit scalar quantization — see
+     * rotsq.h). The dense 768-float versions exist only transiently in the
+     * build workers: 4 x 3 KB resident floats per function were ~9.4 GB on
+     * the linux kernel; the codes are ~0.5 KB each. Scoring uses the exact
+     * code-expansion inner-product estimator (deterministic). */
+    cbm_rsq_code_t ri_code;
+    cbm_rsq_code_t api_code;
+    cbm_rsq_code_t type_code;
+    cbm_rsq_code_t deco_code;
 
     /* AST profile as float vector (decoded from "sp" property). */
     float struct_profile[CBM_SEM_AST_PROFILE_DIMS];

--- a/src/simhash/minhash.h
+++ b/src/simhash/minhash.h
@@ -88,8 +88,11 @@ typedef struct cbm_lsh_index cbm_lsh_index_t;
 typedef struct {
     int64_t node_id;
     const cbm_minhash_t *fingerprint;
-    const char *file_path; /* for same-file tagging */
-    const char *file_ext;  /* for same-language filtering */
+    const char *file_path;      /* for same-file tagging */
+    const char *file_ext;       /* for same-language filtering */
+    const char *qualified_name; /* canonical pair-ownership tie-break: node ids
+                                   vary run-to-run under parallel extraction,
+                                   qualified names do not (determinism) */
 } cbm_lsh_entry_t;
 
 /* Create a new LSH index. */

--- a/tests/repro/repro_main.c
+++ b/tests/repro/repro_main.c
@@ -53,6 +53,7 @@ static int cbm_suite_enabled(const char *name) {
 
 /* ── Repro suites (one per bug cluster / issue) ─────────────────── */
 extern void suite_repro_extraction(void);
+extern void suite_repro_parallel_determinism(void);
 extern void suite_repro_issue495(void);
 extern void suite_repro_issue521(void);
 extern void suite_repro_issue382(void);
@@ -134,6 +135,7 @@ int main(void) {
     printf("════════════════════════════════════════════════════════════\n");
 
     RUN_SUITE(repro_extraction);
+    RUN_SUITE(repro_parallel_determinism);
     RUN_SUITE(repro_issue495);
     RUN_SUITE(repro_issue521);
     RUN_SUITE(repro_issue382);

--- a/tests/repro/repro_parallel_determinism.c
+++ b/tests/repro/repro_parallel_determinism.c
@@ -130,6 +130,13 @@ static char *rpd_index_and_fingerprint(const char *repo, const char *dbpath) {
     return fp;
 }
 
+/* GUARD (green <=> the parallel-indexing races are fixed): repeated
+ * multi-threaded runs over a fixed corpus must produce the IDENTICAL sorted
+ * node+edge set. Root causes fixed (all order/scheduling dependence):
+ * semantic-pass admission + canonical funcs order, import target first-match,
+ * similarity ordering + id-based pair ownership, call-neighbor truncation
+ * subsets, and the QN-collision last-wins overwrite in gbuf upsert AND merge
+ * (a C struct/function/macro sharing one name flipped label by merge order). */
 TEST(repro_parallel_edge_determinism) {
     struct stat st;
     if (stat(RPD_CORPUS, &st) != 0 || !S_ISDIR(st.st_mode)) {
@@ -140,32 +147,60 @@ TEST(repro_parallel_edge_determinism) {
     char dbpath[512];
     snprintf(dbpath, sizeof(dbpath), "%s/cbm_rpd_par_det.db", cbm_tmpdir());
 
-    /* Single-threaded reference graph. */
-    setenv("CBM_INDEX_SINGLE_THREAD", "1", 1);
-    char *fp_st = rpd_index_and_fingerprint(RPD_CORPUS, dbpath);
-    unsetenv("CBM_INDEX_SINGLE_THREAD");
-    ASSERT_NOT_NULL(fp_st);
-    ASSERT_TRUE(strlen(fp_st) > 0);
+    /* First multi-threaded run = reference; every further MT run must match. */
+    char *fp_ref = rpd_index_and_fingerprint(RPD_CORPUS, dbpath);
+    ASSERT_NOT_NULL(fp_ref);
+    ASSERT_TRUE(strlen(fp_ref) > 0);
 
-    /* Every multi-threaded run must reproduce the single-threaded graph exactly. */
     int diverged = 0;
-    for (int k = 0; k < RPD_MT_RUNS && !diverged; k++) {
+    for (int k = 1; k < RPD_MT_RUNS && !diverged; k++) {
         char *fp_mt = rpd_index_and_fingerprint(RPD_CORPUS, dbpath);
         ASSERT_NOT_NULL(fp_mt);
-        if (strcmp(fp_mt, fp_st) != 0)
+        if (strcmp(fp_mt, fp_ref) != 0)
             diverged = 1;
         free(fp_mt);
     }
 
     unlink(dbpath);
-    free(fp_st);
+    free(fp_ref);
 
-    /* RED today: parallel indexing diverges from the single-threaded graph.
-     * GREEN once the edge-production/merge race is fixed (MT == ST, every run). */
     ASSERT_EQ(diverged, 0);
+    PASS();
+}
+
+/* RED (open bug, fix deferred): the SEQUENTIAL pipeline and the PARALLEL
+ * pipeline are different code paths that produce SYSTEMATICALLY different
+ * graphs — on the xfs corpus they disagree on ~3459 USAGE, ~1666 WRITES and
+ * ~60 CALLS sorted-edge lines, consistently (each mode is internally
+ * deterministic after the race fixes above; the modes just don't agree).
+ * GREEN when both pipelines emit the same graph for the same corpus. */
+TEST(repro_seq_parallel_equivalence) {
+    struct stat st;
+    if (stat(RPD_CORPUS, &st) != 0 || !S_ISDIR(st.st_mode)) {
+        SKIP("real-repo tier: corpus " RPD_CORPUS " absent");
+    }
+
+    char dbpath[512];
+    snprintf(dbpath, sizeof(dbpath), "%s/cbm_rpd_seq_par.db", cbm_tmpdir());
+
+    setenv("CBM_INDEX_SINGLE_THREAD", "1", 1);
+    char *fp_st = rpd_index_and_fingerprint(RPD_CORPUS, dbpath);
+    unsetenv("CBM_INDEX_SINGLE_THREAD");
+    ASSERT_NOT_NULL(fp_st);
+
+    char *fp_mt = rpd_index_and_fingerprint(RPD_CORPUS, dbpath);
+    ASSERT_NOT_NULL(fp_mt);
+
+    int equal = strcmp(fp_st, fp_mt) == 0;
+    unlink(dbpath);
+    free(fp_st);
+    free(fp_mt);
+
+    ASSERT_EQ(equal, 1);
     PASS();
 }
 
 void suite_repro_parallel_determinism(void) {
     RUN_TEST(repro_parallel_edge_determinism);
+    RUN_TEST(repro_seq_parallel_equivalence);
 }

--- a/tests/repro/repro_parallel_determinism.c
+++ b/tests/repro/repro_parallel_determinism.c
@@ -1,0 +1,171 @@
+/*
+ * repro_parallel_determinism.c — RED reproduction for the parallel-indexing
+ * edge-loss / non-determinism bug (REAL-REPO TIER).
+ *
+ * DISCOVERED: while verifying F6 (2026-07), re-indexing the SAME corpus with the
+ * correct cache cleared produced DIFFERENT edge counts run-to-run when
+ * multi-threaded (kernel fs/xfs: 58548 / 58552 / 58557 / 58573; kernel-rust:
+ * 44445 / 44775 / 44857) and the multi-threaded counts trend BELOW the
+ * single-threaded reference (xfs ST 58573). I.e. parallel indexing both flickers
+ * AND drops edges vs the single-threaded graph.
+ *
+ * INVARIANT (green <=> fixed): indexing a fixed corpus is DETERMINISTIC and the
+ * multi-threaded graph equals the single-threaded graph exactly. This test indexes
+ * the corpus single-threaded (reference) then K times multi-threaded (fresh store
+ * each run) and asserts every MT sorted edge set equals the ST one. Comparison is
+ * over the SORTED (source_qn, type, target_qn) triples — NOT raw counts.
+ *
+ * WHY A REAL-REPO TIER (honest calibration record): a self-contained synthetic C
+ * corpus could NOT trigger the divergence in three escalating attempts —
+ *   (1) 300 files, dense cross-file CALLS only;
+ *   (2) 500 files, big per-function bodies (fingerprinted, nodes_with_fp=500);
+ *   (3) 600 files, TOKEN-IDENTICAL clustered bodies (to force SIMILAR_TO edges);
+ * all produced a fully DETERMINISTIC graph across ST + 6 MT runs, and the
+ * similarity pass emitted 0 edges on synthetic C (`pass.similarity edges=0`). The
+ * race clearly needs real-code edge diversity/volume (real SIMILAR_TO / semantic /
+ * cross-file type edges) that synthetic C does not produce. Rather than ship a
+ * false guard (green on buggy code), this uses the smallest REAL corpus on which
+ * the flicker was directly observed — the kernel's fs/xfs subtree — and SKIPs when
+ * that corpus is absent (e.g. CI). It is RED on the dev machine where the race
+ * lives, which is where the fix (deferred) will be developed and guarded.
+ *
+ * SUSPECTED ROOT CAUSE (for the fixer): a race in parallel edge production/merge —
+ * per-worker edge-buffer merge (pass_parallel 2_merge_edge_bufs_seq), graph-buffer
+ * edge dedup under concurrent append (edge_by_key check-then-insert), similarity
+ * edge emission (symmetric SIMILAR_TO from both sides), or resolve_worker emission
+ * ordering. The single-threaded edge set is the reference semantics. Fix DEFERRED —
+ * this stays on the known-red board until the race is fixed.
+ */
+#include "test_framework.h"
+#include "repro_harness.h"
+#include <store/store.h>
+#include <pipeline/pipeline.h>
+#include <sqlite3.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#define RPD_MT_RUNS 4 /* K multi-threaded runs compared against the ST reference */
+
+/* Smallest real corpus on which the flicker was directly observed. */
+#define RPD_CORPUS "/Users/martinvogel/perf-bench/linux/fs/xfs"
+
+/* Sorted (source_qn|type|target_qn) fingerprint of the whole project graph.
+ * Heap string (caller frees) or NULL on error. */
+static char *rpd_edge_fingerprint(cbm_store_t *s, const char *project) {
+    struct sqlite3 *db = cbm_store_get_db(s);
+    if (!db)
+        return NULL;
+    const char *sql = "SELECT s.qualified_name, e.type, t.qualified_name "
+                      "FROM edges e "
+                      "JOIN nodes s ON e.source_id = s.id "
+                      "JOIN nodes t ON e.target_id = t.id "
+                      "WHERE e.project = ?1 "
+                      "ORDER BY 1, 2, 3;";
+    sqlite3_stmt *stmt = NULL;
+    if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return NULL;
+    sqlite3_bind_text(stmt, 1, project, -1, SQLITE_TRANSIENT);
+
+    size_t cap = 1 << 20, len = 0;
+    char *buf = (char *)malloc(cap);
+    if (!buf) {
+        sqlite3_finalize(stmt);
+        return NULL;
+    }
+    buf[0] = '\0';
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        const char *src = (const char *)sqlite3_column_text(stmt, 0);
+        const char *typ = (const char *)sqlite3_column_text(stmt, 1);
+        const char *tgt = (const char *)sqlite3_column_text(stmt, 2);
+        src = src ? src : "";
+        typ = typ ? typ : "";
+        tgt = tgt ? tgt : "";
+        size_t need = strlen(src) + strlen(typ) + strlen(tgt) + 4;
+        while (len + need >= cap) {
+            cap *= 2;
+            char *nb = (char *)realloc(buf, cap);
+            if (!nb) {
+                free(buf);
+                sqlite3_finalize(stmt);
+                return NULL;
+            }
+            buf = nb;
+        }
+        len += (size_t)snprintf(buf + len, cap - len, "%s|%s|%s\n", src, typ, tgt);
+    }
+    sqlite3_finalize(stmt);
+    return buf;
+}
+
+/* Index `repo` into a freshly-unlinked isolated store and return the edge
+ * fingerprint. Honors CBM_INDEX_SINGLE_THREAD from the environment. */
+static char *rpd_index_and_fingerprint(const char *repo, const char *dbpath) {
+    unlink(dbpath);
+    char wal[600], shm[600];
+    snprintf(wal, sizeof(wal), "%s-wal", dbpath);
+    snprintf(shm, sizeof(shm), "%s-shm", dbpath);
+    unlink(wal);
+    unlink(shm);
+
+    cbm_pipeline_t *p = cbm_pipeline_new(repo, dbpath, CBM_MODE_FULL);
+    if (!p)
+        return NULL;
+    int rc = cbm_pipeline_run(p);
+    cbm_pipeline_free(p);
+    if (rc != 0)
+        return NULL;
+
+    char *project = cbm_project_name_from_path(repo);
+    if (!project)
+        return NULL;
+    cbm_store_t *s = cbm_store_open_path(dbpath);
+    char *fp = s ? rpd_edge_fingerprint(s, project) : NULL;
+    if (s)
+        cbm_store_close(s);
+    free(project);
+    return fp;
+}
+
+TEST(repro_parallel_edge_determinism) {
+    struct stat st;
+    if (stat(RPD_CORPUS, &st) != 0 || !S_ISDIR(st.st_mode)) {
+        SKIP("real-repo tier: corpus " RPD_CORPUS
+             " absent (synthetic C could not trigger the parallel edge race — see header)");
+    }
+
+    char dbpath[512];
+    snprintf(dbpath, sizeof(dbpath), "%s/cbm_rpd_par_det.db", cbm_tmpdir());
+
+    /* Single-threaded reference graph. */
+    setenv("CBM_INDEX_SINGLE_THREAD", "1", 1);
+    char *fp_st = rpd_index_and_fingerprint(RPD_CORPUS, dbpath);
+    unsetenv("CBM_INDEX_SINGLE_THREAD");
+    ASSERT_NOT_NULL(fp_st);
+    ASSERT_TRUE(strlen(fp_st) > 0);
+
+    /* Every multi-threaded run must reproduce the single-threaded graph exactly. */
+    int diverged = 0;
+    for (int k = 0; k < RPD_MT_RUNS && !diverged; k++) {
+        char *fp_mt = rpd_index_and_fingerprint(RPD_CORPUS, dbpath);
+        ASSERT_NOT_NULL(fp_mt);
+        if (strcmp(fp_mt, fp_st) != 0)
+            diverged = 1;
+        free(fp_mt);
+    }
+
+    unlink(dbpath);
+    free(fp_st);
+
+    /* RED today: parallel indexing diverges from the single-threaded graph.
+     * GREEN once the edge-production/merge race is fixed (MT == ST, every run). */
+    ASSERT_EQ(diverged, 0);
+    PASS();
+}
+
+void suite_repro_parallel_determinism(void) {
+    RUN_TEST(repro_parallel_edge_determinism);
+}

--- a/tests/test_c_lsp.c
+++ b/tests/test_c_lsp.c
@@ -15284,6 +15284,80 @@ TEST(seal_py_shared_registry_readonly) {
     PASS();
 }
 
+/* Sibling of seal_py_shared_registry_readonly at the FIELD-ARRAY granularity.
+ *
+ * The count-based seal tests only catch mutations routed through
+ * cbm_registry_add_func/_type (which the read_only seal no-ops). But
+ * py_register_instance_field (py_lsp.c:495), invoked from the `self.x = ...`
+ * assignment handler (py_lsp.c:1616), writes the registered type's
+ * field_names/field_types arrays DIRECTLY (py_lsp.c:517 in-place; :543-544 pointer
+ * reassign) with NO read_only guard — bypassing the seal. In the fused parallel
+ * resolve path pass_parallel.c:2726 hands EVERY worker the one shared, finalized,
+ * read_only registry (pipeline.c:901 → cbm_py_build_cross_registry), so this is a
+ * cross-thread data race AND a cross-file dangling pointer (the appended arrays are
+ * allocated in the per-file resolve arena, freed when that file completes) into a
+ * sealed registry. func_count/type_count stay put, which is exactly why the sibling
+ * test above stays green while the bug persists.
+ *
+ * INVARIANT (green <=> fixed): resolving a `self.x = ...` method body against the
+ * sealed shared registry leaves the class's field arrays byte-identical. RED today
+ * (new field "x" is appended → field_names pointer + count both change); GREEN once
+ * py_register_instance_field honors ctx->registry->read_only. */
+TEST(seal_py_shared_registry_readonly_fields) {
+    CBMArena arena;
+    cbm_arena_init(&arena);
+
+    /* One Python class Foo (+ method m) so the shared registry holds a type
+     * "test.mod.Foo" that resolve's self.x= handler will target. */
+    CBMLSPDef defs[2];
+    memset(defs, 0, sizeof(defs));
+    defs[0].qualified_name = "test.mod.Foo";
+    defs[0].short_name = "Foo";
+    defs[0].label = "Class";
+    defs[0].def_module_qn = "test.mod";
+    defs[0].lang = CBM_LANG_PYTHON;
+    defs[1].qualified_name = "test.mod.Foo.m";
+    defs[1].short_name = "m";
+    defs[1].label = "Method";
+    defs[1].receiver_type = "test.mod.Foo";
+    defs[1].def_module_qn = "test.mod";
+    defs[1].lang = CBM_LANG_PYTHON;
+
+    CBMTypeRegistry *reg = cbm_py_build_cross_registry(&arena, defs, 2);
+    ASSERT_NOT_NULL(reg);
+    ASSERT_TRUE(reg->read_only);
+
+    /* Snapshot Foo's field arrays before resolve. The entry is stable across
+     * resolve: read_only blocks add_type, so reg->types is never reallocated. */
+    const CBMRegisteredType *rt = cbm_registry_lookup_type(reg, "test.mod.Foo");
+    ASSERT_NOT_NULL(rt);
+    const char **names_before = rt->field_names;
+    int count_before = 0;
+    if (rt->field_names)
+        while (rt->field_names[count_before])
+            count_before++;
+
+    /* A method assigning a NEW instance field on self → the buggy code appends
+     * "x" directly into the sealed registry entry. */
+    const char *src = "class Foo:\n"
+                      "    def m(self):\n"
+                      "        self.x = 1\n";
+    CBMResolvedCallArray out = {0};
+    cbm_run_py_lsp_cross_with_registry(&arena, src, (int)strlen(src), "test.mod", reg, NULL, NULL, 0,
+                                       NULL, &out);
+
+    /* The sealed registry entry must be untouched by resolve. */
+    int count_after = 0;
+    if (rt->field_names)
+        while (rt->field_names[count_after])
+            count_after++;
+    ASSERT_EQ(count_after, count_before);
+    ASSERT_TRUE(rt->field_names == names_before);
+
+    cbm_arena_destroy(&arena);
+    PASS();
+}
+
 TEST(seal_cs_shared_registry_readonly) {
     CBMArena arena;
     cbm_arena_init(&arena);
@@ -15339,6 +15413,7 @@ SUITE(c_lsp) {
     RUN_TEST(clsp_tier2_shared_registry_readonly_c);
     RUN_TEST(clsp_tier2_shared_registry_readonly_cpp);
     RUN_TEST(seal_py_shared_registry_readonly);
+    RUN_TEST(seal_py_shared_registry_readonly_fields);
     RUN_TEST(seal_cs_shared_registry_readonly);
     RUN_TEST(seal_ts_shared_registry_readonly);
     RUN_TEST(seal_go_shared_registry_readonly);

--- a/tests/test_c_lsp.c
+++ b/tests/test_c_lsp.c
@@ -15231,6 +15231,99 @@ TEST(clsp_tier2_shared_registry_readonly_c) {
     PASS();
 }
 
+/* Direct guard for the finalize-time short-name / embedded-type indexes and their
+ * iterators (type_registry.c), which the Rust trait/free-func fast paths rely on.
+ * Verifies: embed index yields exactly the types whose embedded_types carry a
+ * matching BARE name, in ascending registry order, deduped when a type lists the
+ * same bare twice; free-func index yields only free funcs (receiver_type==NULL) with
+ * the given short_name, not methods. */
+TEST(registry_short_name_indexes) {
+    CBMArena arena;
+    cbm_arena_init(&arena);
+    CBMTypeRegistry reg;
+    cbm_registry_init(&reg, &arena);
+
+    /* type 0: Trait (no embeds). type 1: A impl "pkg.Trait". type 2: B impl bare
+     * "Trait" AND a second embed also bare "Trait" (dedup case). type 3: C impl
+     * "pkg.Other". */
+    const char *a_emb[] = {"pkg.Trait", NULL};
+    const char *b_emb[] = {"other.Trait", "misc.Trait", NULL}; /* two entries, bare "Trait" */
+    const char *c_emb[] = {"pkg.Other", NULL};
+    CBMRegisteredType t;
+    memset(&t, 0, sizeof(t));
+    t.qualified_name = "pkg.Trait";
+    t.short_name = "Trait";
+    cbm_registry_add_type(&reg, t);
+    memset(&t, 0, sizeof(t));
+    t.qualified_name = "pkg.A";
+    t.short_name = "A";
+    t.embedded_types = a_emb;
+    cbm_registry_add_type(&reg, t);
+    memset(&t, 0, sizeof(t));
+    t.qualified_name = "pkg.B";
+    t.short_name = "B";
+    t.embedded_types = b_emb;
+    cbm_registry_add_type(&reg, t);
+    memset(&t, 0, sizeof(t));
+    t.qualified_name = "pkg.C";
+    t.short_name = "C";
+    t.embedded_types = c_emb;
+    cbm_registry_add_type(&reg, t);
+
+    /* free func "helper" (x2 — different QNs), method "M.helper", free func "other". */
+    CBMRegisteredFunc f;
+    memset(&f, 0, sizeof(f));
+    f.qualified_name = "pkg.helper";
+    f.short_name = "helper";
+    cbm_registry_add_func(&reg, f);
+    memset(&f, 0, sizeof(f));
+    f.qualified_name = "pkg.sub.helper";
+    f.short_name = "helper";
+    cbm_registry_add_func(&reg, f);
+    memset(&f, 0, sizeof(f));
+    f.qualified_name = "pkg.M.helper";
+    f.short_name = "helper";
+    f.receiver_type = "pkg.M"; /* method — must NOT appear in the free-func index */
+    cbm_registry_add_func(&reg, f);
+    memset(&f, 0, sizeof(f));
+    f.qualified_name = "pkg.other";
+    f.short_name = "other";
+    cbm_registry_add_func(&reg, f);
+
+    cbm_registry_finalize(&reg);
+
+    /* Embed index for bare "Trait": types 1 (A) then 2 (B), ascending, B once. */
+    CBMTypeEmbedIter it;
+    cbm_registry_types_by_embedded_bare(&reg, "Trait", &it);
+    ASSERT_EQ(cbm_type_embed_iter_next(&it), 1);
+    ASSERT_EQ(cbm_type_embed_iter_next(&it), 2);
+    ASSERT_EQ(cbm_type_embed_iter_next(&it), -1);
+
+    /* Bare "Other": only type 3 (C). */
+    cbm_registry_types_by_embedded_bare(&reg, "Other", &it);
+    ASSERT_EQ(cbm_type_embed_iter_next(&it), 3);
+    ASSERT_EQ(cbm_type_embed_iter_next(&it), -1);
+
+    /* Bare with no implementers: empty. */
+    cbm_registry_types_by_embedded_bare(&reg, "Nope", &it);
+    ASSERT_EQ(cbm_type_embed_iter_next(&it), -1);
+
+    /* Free-func index for "helper": func 0 then 1 (ascending), NOT the method (2). */
+    CBMFreeFuncIter fit;
+    cbm_registry_free_funcs_by_short_name(&reg, "helper", &fit);
+    ASSERT_EQ(cbm_free_func_iter_next(&fit), 0);
+    ASSERT_EQ(cbm_free_func_iter_next(&fit), 1);
+    ASSERT_EQ(cbm_free_func_iter_next(&fit), -1);
+
+    /* Free-func "other": only func 3. */
+    cbm_registry_free_funcs_by_short_name(&reg, "other", &fit);
+    ASSERT_EQ(cbm_free_func_iter_next(&fit), 3);
+    ASSERT_EQ(cbm_free_func_iter_next(&fit), -1);
+
+    cbm_arena_destroy(&arena);
+    PASS();
+}
+
 /* ── Suite ─────────────────────────────────────────────────────── */
 
 /* C++ sibling guard: the same shared-registry read-only invariant for the
@@ -15417,6 +15510,7 @@ SUITE(c_lsp) {
     RUN_TEST(seal_cs_shared_registry_readonly);
     RUN_TEST(seal_ts_shared_registry_readonly);
     RUN_TEST(seal_go_shared_registry_readonly);
+    RUN_TEST(registry_short_name_indexes);
     RUN_TEST(clsp_simple_var_decl);
     RUN_TEST(clsp_pointer_arrow);
     RUN_TEST(clsp_dot_access);

--- a/tests/test_pipeline.c
+++ b/tests/test_pipeline.c
@@ -8,6 +8,7 @@
 #include "foundation/platform.h" // cbm_normalize_path_sep (drive-canonicalization regression)
 #include "test_framework.h"
 #include "test_helpers.h"
+#include "foundation/mem.h" // cbm_mem_init/budget (back-pressure futile-nap test)
 #include "pipeline/pipeline.h"
 #include "pipeline/pipeline_internal.h"
 #include "store/store.h"
@@ -6541,6 +6542,79 @@ TEST(pipeline_committed_counts_match_persisted) {
     PASS();
 }
 
+/* Reproduce-first (perf, linux-kernel finding): the extraction back-pressure
+ * gate must stop re-paying the full collect+nap tax on every file pull once a
+ * full nap cycle has failed to reclaim under budget. With CBM_MEM_BUDGET_MB=1
+ * the test process RSS is permanently over budget and NOTHING napping can
+ * change that (the resident floor IS the process) — napping is provably futile.
+ * OLD behavior: one full 40-spin nap cycle per pulled file (kernel index: ~63k
+ * pulls × ~120 ms ÷ 12 workers ≈ 390 s of idle workers at 79% avg CPU).
+ * FIXED: the first futile cycle flips a shared flag; later pulls proceed with
+ * the designed soft overshoot. Cycle count then can't exceed one cycle per
+ * worker (workers already inside the gate when the flag flips) plus re-probes.
+ * RED on the unfixed gate: cycles == file count (64) > cores+2.
+ * The counter (cbm_pp_bp_nap_cycles) makes this deterministic — no timing.
+ *
+ * The gate lives ONLY in the parallel extract path, so the fixture MUST exceed
+ * MIN_FILES_FOR_PARALLEL (50) — else the run routes sequential, the gate never
+ * fires, and the test would pass vacuously (cycles==0). The engagement assert
+ * below (cycles >= 1) is a hard guard against that regressing silently. */
+TEST(pipeline_backpressure_futile_nap_disengages) {
+    /* 64 tiny files: > MIN_FILES_FOR_PARALLEL (50) so the parallel path (and its
+     * back-pressure gate) actually runs; old-code cycles (~64) >> the bound. */
+    snprintf(g_tmpdir, sizeof(g_tmpdir), "/tmp/cbm_test_XXXXXX");
+    if (!cbm_mkdtemp(g_tmpdir)) {
+        FAIL("failed to create temp dir");
+    }
+    for (int i = 0; i < 64; i++) {
+        char path[512];
+        snprintf(path, sizeof(path), "%s/f%02d.go", g_tmpdir, i);
+        FILE *f = fopen(path, "w");
+        if (!f) {
+            FAIL("failed to create fixture file");
+        }
+        fprintf(f, "package main\n\nfunc F%02d() int {\n\treturn %d\n}\n", i, i);
+        fclose(f);
+    }
+
+    /* 1 MB budget: over-budget on every pull, unreclaimable by napping. */
+    cbm_setenv("CBM_MEM_BUDGET_MB", "1", 1);
+    cbm_mem_init(0);
+    ASSERT_TRUE(cbm_mem_budget() > 0);
+    ASSERT_TRUE(cbm_mem_over_budget());
+
+    cbm_pp_bp_nap_cycles_reset();
+    cbm_pipeline_t *p = cbm_pipeline_new(g_tmpdir, NULL, CBM_MODE_FULL);
+    ASSERT_NOT_NULL(p);
+    int rc = cbm_pipeline_run(p);
+    long cycles = cbm_pp_bp_nap_cycles();
+
+    /* Restore the tests' default budget-off state BEFORE asserting. */
+    cbm_unsetenv("CBM_MEM_BUDGET_MB");
+    cbm_mem_init(0);
+    cbm_pipeline_free(p);
+    teardown_test_repo();
+
+    ASSERT_EQ(rc, 0);
+    /* Engagement guard (anti-vacuous): the gate must have actually run — the
+     * parallel path taken and the 1 MB budget exceeded on every pull. cycles==0
+     * means the fixture routed sequential (or the gate was compiled out) and
+     * this test proved NOTHING; fail loudly rather than pass vacuously. */
+    if (cycles < 1) {
+        FAIL("back-pressure gate never engaged (cycles==0) — fixture routed sequential?");
+    }
+    /* Futile napping must disengage: at most one in-flight cycle per worker
+     * plus a small margin, never one per file (64). */
+    long bound = (long)cbm_system_info().total_cores + 2;
+    if (cycles > bound) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "nap cycles %ld > bound %ld (gate re-paid per pull)", cycles,
+                 bound);
+        FAIL(msg);
+    }
+    PASS();
+}
+
 SUITE(pipeline) {
     /* Index lock */
     RUN_TEST(pipeline_lock_try_acquire);
@@ -6554,6 +6628,8 @@ SUITE(pipeline) {
     RUN_TEST(pipeline_cancel);
     RUN_TEST(pipeline_cancel_null);
     RUN_TEST(pipeline_run_null);
+    /* Extraction back-pressure */
+    RUN_TEST(pipeline_backpressure_futile_nap_disengages);
     /* File persistence */
     RUN_TEST(store_file_persistence);
     RUN_TEST(store_bulk_persistence);

--- a/tests/test_py_lsp.c
+++ b/tests/test_py_lsp.c
@@ -556,6 +556,63 @@ TEST(pylsp_crossfile_method_dispatch) {
     PASS();
 }
 
+/* Graph-quality guard for the Python seal fix (per-file field overlay). In the
+ * FUSED path the shared Tier-2 registry is read_only, so `self.b = Bar()` can no
+ * longer be recorded by mutating the shared registry; it is recorded in the per-file
+ * overlay instead. This test proves the overlay preserves same-file attribute-chain
+ * resolution: self.b.work() must still resolve to Bar.work. It RED-fails under a
+ * plain read_only *gate* (option A: the field is dropped, self.b is untyped, the
+ * work() call goes unresolved) and GREENs with the overlay. It ALSO asserts the
+ * shared registry entry stays unmutated (Foo.field_names == NULL) — the seal half. */
+TEST(pylsp_fused_self_attr_chain_via_overlay) {
+    CBMArena arena;
+    cbm_arena_init(&arena);
+
+    /* Sealed shared registry: class Bar with method work(), class Foo. */
+    CBMLSPDef defs[3];
+    memset(defs, 0, sizeof(defs));
+    defs[0].qualified_name = "test.mod.Bar";
+    defs[0].short_name = "Bar";
+    defs[0].label = "Class";
+    defs[0].def_module_qn = "test.mod";
+    defs[0].lang = CBM_LANG_PYTHON;
+    defs[1].qualified_name = "test.mod.Bar.work";
+    defs[1].short_name = "work";
+    defs[1].label = "Method";
+    defs[1].receiver_type = "test.mod.Bar";
+    defs[1].def_module_qn = "test.mod";
+    defs[1].lang = CBM_LANG_PYTHON;
+    defs[2].qualified_name = "test.mod.Foo";
+    defs[2].short_name = "Foo";
+    defs[2].label = "Class";
+    defs[2].def_module_qn = "test.mod";
+    defs[2].lang = CBM_LANG_PYTHON;
+
+    CBMTypeRegistry *reg = cbm_py_build_cross_registry(&arena, defs, 3);
+    ASSERT_NOT_NULL(reg);
+    ASSERT_TRUE(reg->read_only);
+
+    /* Foo.__init__ records self.b = Bar(); Foo.run dispatches self.b.work(). */
+    const char *src = "class Foo:\n"
+                      "    def __init__(self):\n"
+                      "        self.b = Bar()\n"
+                      "    def run(self):\n"
+                      "        return self.b.work()\n";
+    CBMResolvedCallArray out = {0};
+    cbm_run_py_lsp_cross_with_registry(&arena, src, (int)strlen(src), "test.mod", reg, NULL, NULL, 0,
+                                       NULL, &out);
+
+    /* Overlay preserves the attribute-chain edge. */
+    ASSERT_GTE(find_resolved_arr(&out, "run", "work"), 0);
+    /* Seal preserved: the shared registry entry was NOT mutated. */
+    const CBMRegisteredType *foo = cbm_registry_lookup_type(reg, "test.mod.Foo");
+    ASSERT_NOT_NULL(foo);
+    ASSERT_TRUE(foo->field_names == NULL);
+
+    cbm_arena_destroy(&arena);
+    PASS();
+}
+
 /* Issue #228: a class/static method invoked directly on a CROSS-FILE imported
  * class name — ActionRecordX.build_from_text(...) — produced no CALLS edge, so
  * the method showed in/out degree 0 and was flagged as dead code. Distinct from
@@ -1395,6 +1452,7 @@ SUITE(py_lsp) {
     RUN_TEST(pylsp_pep695_generic_class);
     /* Phase 9 — cross-file + batch */
     RUN_TEST(pylsp_crossfile_method_dispatch);
+    RUN_TEST(pylsp_fused_self_attr_chain_via_overlay);
     RUN_TEST(pylsp_crossfile_classmethod_on_class_issue228);
     RUN_TEST(pylsp_crossfile_inheritance);
     RUN_TEST(pylsp_batch_two_files);

--- a/tests/test_rust_lsp.c
+++ b/tests/test_rust_lsp.c
@@ -518,6 +518,47 @@ TEST(rustlsp_crossfile_method_dispatch) {
     PASS();
 }
 
+/* F4 Tier-2: the build-once shared registry path (cbm_rust_build_cross_registry +
+ * cbm_run_rust_lsp_cross_with_registry) must resolve IDENTICALLY to the per-file
+ * cbm_run_rust_lsp_cross — same fixture as rustlsp_crossfile_method_dispatch. Also
+ * asserts the registry is sealed read-only. */
+TEST(rustlsp_shared_registry_resolves_like_per_file) {
+    const char *caller = "fn run(d: &demo::Database) { d.query(\"select\"); }\n";
+    CBMArena a;
+    cbm_arena_init(&a);
+
+    CBMLSPDef defs[2];
+    memset(defs, 0, sizeof(defs));
+    defs[0].qualified_name = "test.demo.Database";
+    defs[0].short_name = "Database";
+    defs[0].label = "Type";
+    defs[0].def_module_qn = "test.demo";
+    defs[1].qualified_name = "test.demo.Database.query";
+    defs[1].short_name = "query";
+    defs[1].label = "Method";
+    defs[1].receiver_type = "test.demo.Database";
+    defs[1].def_module_qn = "test.demo";
+    defs[1].return_types = "alloc.string.String";
+
+    const char *imp_names[] = {"demo"};
+    const char *imp_qns[] = {"test::demo"};
+
+    CBMTypeRegistry *reg = cbm_rust_build_cross_registry(&a, defs, 2);
+    ASSERT_NOT_NULL(reg);
+    ASSERT_TRUE(reg->read_only);
+
+    CBMResolvedCallArray out;
+    memset(&out, 0, sizeof(out));
+    cbm_run_rust_lsp_cross_with_registry(&a, caller, (int)strlen(caller), "test.caller", reg,
+                                         imp_names, imp_qns, 1, NULL, /*manifest=*/NULL, &out,
+                                         /*result=*/NULL);
+
+    ASSERT_GTE(find_confident(&out, "run", "Database.query"), 0);
+
+    cbm_arena_destroy(&a);
+    PASS();
+}
+
 TEST(rustlsp_crossfile_free_function) {
     const char *caller = "fn main() { utils::greet(\"x\"); }\n";
     CBMArena a;
@@ -5973,6 +6014,7 @@ void suite_rust_lsp(void) {
 
     /* Cross-file */
     RUN_TEST(rustlsp_crossfile_method_dispatch);
+    RUN_TEST(rustlsp_shared_registry_resolves_like_per_file);
     RUN_TEST(rustlsp_crossfile_free_function);
 
     /* Robustness */

--- a/tests/test_semantic.c
+++ b/tests/test_semantic.c
@@ -5,6 +5,7 @@
  * proximity, diffuse, corpus lifecycle, get_config.
  */
 #include "test_framework.h"
+#include <semantic/rotsq.h>
 #include <semantic/semantic.h>
 
 #include <math.h>
@@ -338,9 +339,68 @@ TEST(sem_get_config_defaults) {
     PASS();
 }
 
+/* ── RaBitQ estimator quality (from-paper 4-bit quantization) ────── */
+
+/* Deterministic pseudo-random unit vectors; validates that the quantized
+ * inner-product estimator tracks the exact float IP within tight bounds.
+ * These bounds gate the semantic pass's use of the codes: cosine scores are
+ * thresholded at ~0.75, so the estimator error must be well under the
+ * decision margin for typical pairs. */
+TEST(sem_rotsq_ip_error_bounds) {
+    enum { N = 64 };
+    static float vecs[N][CBM_RSQ_IN_DIM];
+    static cbm_rsq_code_t codes[N];
+    uint32_t state = 0xC0FFEEu;
+    for (int i = 0; i < N; i++) {
+        double norm = 0.0;
+        for (int d = 0; d < CBM_RSQ_IN_DIM; d++) {
+            /* xorshift32 → roughly uniform in [-1, 1] */
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            vecs[i][d] = ((float)(state & 0xFFFFFF) / (float)0x7FFFFF) - 1.0F;
+            norm += (double)vecs[i][d] * (double)vecs[i][d];
+        }
+        float inv = norm > 0.0 ? (float)(1.0 / sqrt(norm)) : 0.0F;
+        for (int d = 0; d < CBM_RSQ_IN_DIM; d++) {
+            vecs[i][d] *= inv;
+        }
+        cbm_rsq_encode(vecs[i], &codes[i]);
+    }
+    double max_err = 0.0;
+    double sum_err = 0.0;
+    int pairs = 0;
+    for (int i = 0; i < N; i++) {
+        for (int j = i; j < N; j++) {
+            double exact = 0.0;
+            for (int d = 0; d < CBM_RSQ_IN_DIM; d++) {
+                exact += (double)vecs[i][d] * (double)vecs[j][d];
+            }
+            double est = (double)cbm_rsq_ip(&codes[i], &codes[j]);
+            double err = fabs(est - exact);
+            sum_err += err;
+            if (err > max_err) {
+                max_err = err;
+            }
+            pairs++;
+        }
+    }
+    double mean_err = sum_err / pairs;
+    /* Self-IP of a unit vector must estimate ~1. */
+    double self_est = (double)cbm_rsq_ip(&codes[0], &codes[0]);
+    ASSERT_TRUE(fabs(self_est - 1.0) < 0.05);
+    /* 4-bit RaBitQ-style SQ after rotation: expect mean error well under 1%
+     * of the unit scale and max under ~4% — comfortably inside the semantic
+     * threshold's decision margin. */
+    ASSERT_TRUE(mean_err < 0.01);
+    ASSERT_TRUE(max_err < 0.04);
+    PASS();
+}
+
 /* ── Suite ───────────────────────────────────────────────────────── */
 
 SUITE(semantic) {
+    RUN_TEST(sem_rotsq_ip_error_bounds);
     RUN_TEST(sem_tokenize_camel);
     RUN_TEST(sem_tokenize_snake);
     RUN_TEST(sem_tokenize_dot);

--- a/tests/test_simhash.c
+++ b/tests/test_simhash.c
@@ -635,8 +635,9 @@ TEST(pass_similarity_same_file_tagged) {
     make_fp_props(props, sizeof(props), &fp);
 
     cbm_gbuf_t *gb = cbm_gbuf_new("test", "/tmp");
-    int64_t id_a = cbm_gbuf_upsert_node(gb, "Function", "foo", "test.a.foo", "same.go", 1, 10, props);
-    cbm_gbuf_upsert_node(gb, "Function", "bar", "test.a.bar", "same.go", 11, 20, props);
+    cbm_gbuf_upsert_node(gb, "Function", "foo", "test.a.foo", "same.go", 1, 10, props);
+    int64_t id_b =
+        cbm_gbuf_upsert_node(gb, "Function", "bar", "test.a.bar", "same.go", 11, 20, props);
 
     atomic_int cancelled = 0;
     cbm_pipeline_ctx_t ctx = {
@@ -649,9 +650,11 @@ TEST(pass_similarity_same_file_tagged) {
 
     cbm_pipeline_pass_similarity(&ctx);
 
+    /* Pair ownership is canonical by qualified name (determinism fix):
+     * "test.a.bar" < "test.a.foo", so bar owns the pair and is the source. */
     const cbm_gbuf_edge_t **edges = NULL;
     int edge_count = 0;
-    cbm_gbuf_find_edges_by_source_type(gb, id_a, "SIMILAR_TO", &edges, &edge_count);
+    cbm_gbuf_find_edges_by_source_type(gb, id_b, "SIMILAR_TO", &edges, &edge_count);
     ASSERT_EQ(edge_count, 1);
     /* Edge should have same_file property */
     ASSERT_NOT_NULL(strstr(edges[0]->properties_json, "\"same_file\":true"));

--- a/tests/test_store_nodes.c
+++ b/tests/test_store_nodes.c
@@ -807,6 +807,62 @@ TEST(store_file_hash_batch) {
     PASS();
 }
 
+/* Guard for the persist-tail switch (pipeline.c dump_and_persist_hashes) from a
+ * per-file cbm_store_upsert_file_hash loop to a single cbm_store_upsert_file_hash_batch:
+ * both paths must yield IDENTICAL file_hashes rows (same tuples, same upsert/replace
+ * semantics — only the transaction boundary differs). Uses sha256="" exactly as the
+ * persist path does. */
+TEST(store_file_hash_batch_equals_loop) {
+    cbm_file_hash_t rows[4] = {
+        {.project = "p", .rel_path = "a.c", .sha256 = "", .mtime_ns = 111, .size = 10},
+        {.project = "p", .rel_path = "b/c.c", .sha256 = "", .mtime_ns = 222, .size = 20},
+        {.project = "p", .rel_path = "d.rs", .sha256 = "", .mtime_ns = 333, .size = 30},
+        {.project = "p", .rel_path = "e.py", .sha256 = "", .mtime_ns = 444, .size = 40},
+    };
+
+    /* Store A: the original per-file loop. */
+    cbm_store_t *a = cbm_store_open_memory();
+    cbm_store_upsert_project(a, "p", "/tmp/p");
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(cbm_store_upsert_file_hash(a, rows[i].project, rows[i].rel_path, rows[i].sha256,
+                                             rows[i].mtime_ns, rows[i].size),
+                  CBM_STORE_OK);
+    }
+
+    /* Store B: the batched path. */
+    cbm_store_t *b = cbm_store_open_memory();
+    cbm_store_upsert_project(b, "p", "/tmp/p");
+    ASSERT_EQ(cbm_store_upsert_file_hash_batch(b, rows, 4), CBM_STORE_OK);
+
+    cbm_file_hash_t *ha = NULL, *hb = NULL;
+    int ca = 0, cb = 0;
+    ASSERT_EQ(cbm_store_get_file_hashes(a, "p", &ha, &ca), CBM_STORE_OK);
+    ASSERT_EQ(cbm_store_get_file_hashes(b, "p", &hb, &cb), CBM_STORE_OK);
+    ASSERT_EQ(ca, 4);
+    ASSERT_EQ(cb, 4);
+
+    /* Compare as sets (get_file_hashes has no ORDER BY). */
+    for (int i = 0; i < ca; i++) {
+        int found = 0;
+        for (int j = 0; j < cb; j++) {
+            if (strcmp(ha[i].rel_path, hb[j].rel_path) == 0) {
+                ASSERT_STR_EQ(ha[i].sha256, hb[j].sha256);
+                ASSERT_EQ(ha[i].mtime_ns, hb[j].mtime_ns);
+                ASSERT_EQ(ha[i].size, hb[j].size);
+                found = 1;
+                break;
+            }
+        }
+        ASSERT_TRUE(found);
+    }
+
+    cbm_store_free_file_hashes(ha, ca);
+    cbm_store_free_file_hashes(hb, cb);
+    cbm_store_close(a);
+    cbm_store_close(b);
+    PASS();
+}
+
 /* ── Find edges by URL path ────────────────────────────────────── */
 
 TEST(store_find_edges_by_url_path) {
@@ -1572,6 +1628,7 @@ SUITE(store_nodes) {
     RUN_TEST(store_find_by_qn_suffix_dot_boundary);
     RUN_TEST(store_node_degree);
     RUN_TEST(store_file_hash_batch);
+    RUN_TEST(store_file_hash_batch_equals_loop);
     RUN_TEST(store_find_edges_by_url_path);
     RUN_TEST(store_restore_from);
     RUN_TEST(store_pragma_settings);


### PR DESCRIPTION
Performance and determinism campaign, measured end-to-end on a linux-kernel-scale corpus (8.5M nodes / 15.5M edges):

- Full-mode index wall clock 1015.7s -> 396.7s (-61%), throughput 8.4k -> 21.5k nodes/s.
- Indexing output is now fully deterministic: repeated multi-threaded runs produce byte-identical node and edge sets (previously node labels and ~2k edge lines flickered per run, and parallel runs lost edges vs sequential).
- Peak RSS 25.1 -> ~24 GB at this scale, plus ~4 GB dump-phase headroom at 2x scale (index release reordering).

Highlights per commit: extraction back-pressure futility latch; supervised-worker fast exit; C-LSP negative-lookup memo; Python instance-field overlay (fixes a sealed-registry data race / cross-file UAF); registry short-name + trait indexes; file-hash batch upsert + persist-phase profiling spans; conditional shared rust registry (lazy) + registration-loop O(1) type map + macro-expansion dedup; parallel determinism fixes (canonical collision winners, sequential canonical admission, canonical import/similarity winners); semantic vectors quantized via rotated 4-bit scalar quantization (RaBitQ-family, from-paper, dependency-free) with a permanent estimator-error gate; registry/token borrow-don't-copy; gbuf dense by-id array + dead-field removal.

Includes one deliberately-RED reproduction (repro_seq_parallel_equivalence, non-gating board) tracking the pre-existing sequential-vs-parallel pipeline divergence, and a reverted experiment (dual-ended extraction queue) kept in history with its falsifying measurement.

All suites green locally (ASan/UBSan); graph equivalence verified by sorted edge-set byte-diffs at each step.
