### PR TITLE
fix(ci): clang-format drift and license-gate false positive from the perf merge

### DIFF
--- a/src/graph_buffer/graph_buffer.c
+++ b/src/graph_buffer/graph_buffer.c
@@ -344,8 +344,7 @@ static void register_node_in_indexes(cbm_gbuf_t *gb, cbm_gbuf_node_t *node) {
         }
         cbm_gbuf_node_t **grown = realloc(gb->by_id, (size_t)nc * sizeof(*grown));
         if (grown) {
-            memset(grown + gb->by_id_cap, 0,
-                   (size_t)(nc - gb->by_id_cap) * sizeof(*grown));
+            memset(grown + gb->by_id_cap, 0, (size_t)(nc - gb->by_id_cap) * sizeof(*grown));
             gb->by_id = grown;
             gb->by_id_cap = nc;
         }
@@ -683,11 +682,11 @@ int64_t cbm_gbuf_upsert_node(cbm_gbuf_t *gb, const char *label, const char *name
          *    function of the colliding entities, not of scheduling. Exactly
          *    one entity is dropped, as one always was; kind-disambiguated
          *    QNs (the real cure) are tracked as a follow-up. */
-        bool same_entity =
-            existing->label && label && strcmp(existing->label, label) == 0 &&
-            existing->file_path && file_path && strcmp(existing->file_path, file_path) == 0 &&
-            existing->start_line == start_line && existing->name && name &&
-            strcmp(existing->name, name) == 0;
+        bool same_entity = existing->label && label && strcmp(existing->label, label) == 0 &&
+                           existing->file_path && file_path &&
+                           strcmp(existing->file_path, file_path) == 0 &&
+                           existing->start_line == start_line && existing->name && name &&
+                           strcmp(existing->name, name) == 0;
         if (!same_entity) {
             int c = strcmp(label ? label : "", existing->label ? existing->label : "");
             if (c == 0) {
@@ -717,8 +716,7 @@ int64_t cbm_gbuf_upsert_node(cbm_gbuf_t *gb, const char *label, const char *name
         const char *new_label_interned = gb_intern(gb, label);
         bool label_changed = !existing->label || !new_label_interned ||
                              strcmp(existing->label, new_label_interned) != 0;
-        bool name_changed =
-            !existing->name || !new_name || strcmp(existing->name, new_name) != 0;
+        bool name_changed = !existing->name || !new_name || strcmp(existing->name, new_name) != 0;
         if (label_changed) {
             remove_node_from_ptr_array(
                 cbm_ht_get(gb->nodes_by_label, existing->label ? existing->label : ""),
@@ -726,8 +724,7 @@ int64_t cbm_gbuf_upsert_node(cbm_gbuf_t *gb, const char *label, const char *name
         }
         if (name_changed) {
             remove_node_from_ptr_array(
-                cbm_ht_get(gb->nodes_by_name, existing->name ? existing->name : ""),
-                existing->id);
+                cbm_ht_get(gb->nodes_by_name, existing->name ? existing->name : ""), existing->id);
         }
         existing->label = (char *)new_label_interned;
         free(existing->name);
@@ -740,8 +737,8 @@ int64_t cbm_gbuf_upsert_node(cbm_gbuf_t *gb, const char *label, const char *name
             existing->properties_json = new_props;
         }
         if (label_changed) {
-            node_ptr_array_t *by_label =
-                get_or_create_node_array(gb->nodes_by_label, existing->label ? existing->label : "");
+            node_ptr_array_t *by_label = get_or_create_node_array(
+                gb->nodes_by_label, existing->label ? existing->label : "");
             cbm_da_push(by_label, (const cbm_gbuf_node_t *)existing);
         }
         if (name_changed) {
@@ -1215,12 +1212,11 @@ static void merge_update_existing(cbm_gbuf_t *dst, cbm_gbuf_node_t *existing,
          * (and every downstream consumer) run to run. Same entity → refresh;
          * different entity → keep the lexicographically smallest
          * (label, file_path, start_line, name). */
-        bool same_entity =
-            existing->label && sn->label && strcmp(existing->label, sn->label) == 0 &&
-            existing->file_path && sn->file_path &&
-            strcmp(existing->file_path, sn->file_path) == 0 &&
-            existing->start_line == sn->start_line && existing->name && sn->name &&
-            strcmp(existing->name, sn->name) == 0;
+        bool same_entity = existing->label && sn->label &&
+                           strcmp(existing->label, sn->label) == 0 && existing->file_path &&
+                           sn->file_path && strcmp(existing->file_path, sn->file_path) == 0 &&
+                           existing->start_line == sn->start_line && existing->name && sn->name &&
+                           strcmp(existing->name, sn->name) == 0;
         bool sn_wins = true;
         if (!same_entity) {
             int c = strcmp(sn->label ? sn->label : "", existing->label ? existing->label : "");
@@ -1241,10 +1237,10 @@ static void merge_update_existing(cbm_gbuf_t *dst, cbm_gbuf_node_t *existing,
              * label/name changes (the old code left the node listed under its
              * original label/name, so find_by_label/name mis-listed it). */
             const char *new_label = gb_intern(dst, sn->label);
-            bool label_changed = !existing->label || !new_label ||
-                                 strcmp(existing->label, new_label) != 0;
-            bool name_changed = !existing->name || !sn->name ||
-                                strcmp(existing->name, sn->name) != 0;
+            bool label_changed =
+                !existing->label || !new_label || strcmp(existing->label, new_label) != 0;
+            bool name_changed =
+                !existing->name || !sn->name || strcmp(existing->name, sn->name) != 0;
             if (label_changed) {
                 remove_node_from_ptr_array(
                     cbm_ht_get(dst->nodes_by_label, existing->label ? existing->label : ""),

--- a/src/pipeline/pass_lsp_cross.h
+++ b/src/pipeline/pass_lsp_cross.h
@@ -31,10 +31,10 @@
  * — type_rep.h covers the type-representation primitives while
  * go_lsp.h was where the project-wide def descriptor landed first. */
 #include "lsp/go_lsp.h"
-#include "lsp/py_lsp.h" /* cbm_py_build_cross_registry / cbm_run_py_lsp_cross_with_registry */
-#include "lsp/c_lsp.h"  /* cbm_c_build_cross_registry / cbm_run_c_lsp_cross_with_registry */
-#include "lsp/cs_lsp.h" /* cbm_cs_build_cross_registry / cbm_run_cs_lsp_cross_with_registry */
-#include "lsp/ts_lsp.h" /* cbm_ts_build_cross_registry / cbm_run_ts_lsp_cross_with_registry */
+#include "lsp/py_lsp.h"   /* cbm_py_build_cross_registry / cbm_run_py_lsp_cross_with_registry */
+#include "lsp/c_lsp.h"    /* cbm_c_build_cross_registry / cbm_run_c_lsp_cross_with_registry */
+#include "lsp/cs_lsp.h"   /* cbm_cs_build_cross_registry / cbm_run_cs_lsp_cross_with_registry */
+#include "lsp/ts_lsp.h"   /* cbm_ts_build_cross_registry / cbm_run_ts_lsp_cross_with_registry */
 #include "lsp/rust_lsp.h" /* cbm_rust_build_cross_registry / cbm_run_rust_lsp_cross_with_registry */
 #include "pipeline/pipeline_internal.h"
 #include <stdbool.h>

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -2852,7 +2852,8 @@ static void resolve_worker(int worker_id, void *ctx_ptr) {
                                 /*result=*/NULL);
                         } else {
                             cbm_pxc_run_one(lang, result, lsp_source, lsp_source_len, def_module,
-                                            file_defs, file_def_count, imp_keys, imp_vals, imp_count);
+                                            file_defs, file_def_count, imp_keys, imp_vals,
+                                            imp_count);
                         }
                     } else if (lang == CBM_LANG_JAVASCRIPT || lang == CBM_LANG_TYPESCRIPT ||
                                lang == CBM_LANG_TSX) {

--- a/src/pipeline/pass_semantic_edges.c
+++ b/src/pipeline/pass_semantic_edges.c
@@ -1053,8 +1053,8 @@ static int cmp_deferred_edge_canonical(const void *pa, const void *pb) {
  * and apply the per-node max_edges budget HERE — single-threaded — so the
  * admitted edge set is a pure function of the (canonically sorted) inputs,
  * independent of worker count and scheduling. */
-static int phase6b_merge_edges(cbm_gbuf_t *gbuf, deferred_edge_buf_t *worker_bufs,
-                               int worker_count, int *edge_counts, int max_edges) {
+static int phase6b_merge_edges(cbm_gbuf_t *gbuf, deferred_edge_buf_t *worker_bufs, int worker_count,
+                               int *edge_counts, int max_edges) {
     int total_pairs = 0;
     for (int w = 0; w < worker_count; w++) {
         total_pairs += worker_bufs[w].count;
@@ -1335,8 +1335,7 @@ static void free_token_pool_entry(const char *key, void *value, void *ud) {
 /* all_tokens slots BORROW their strings from the per-worker intern pools;
  * the pools own exactly one copy per unique token per worker. */
 static void free_funcs_and_tokens(cbm_sem_func_t *funcs, int func_count, char **all_tokens,
-                                  const int *token_counts, CBMHashTable **pools,
-                                  int worker_count) {
+                                  const int *token_counts, CBMHashTable **pools, int worker_count) {
     (void)token_counts;
     for (int f = 0; f < func_count; f++) {
         free(funcs[f].tfidf_indices);
@@ -1410,7 +1409,6 @@ int cbm_pipeline_pass_semantic_edges(cbm_pipeline_ctx_t *ctx) {
                                    worker_count);
     CBM_PROF_END_N("semantic_edges", "4_build_and_store_vec", t_phase4, func_count);
 
-
     cbm_log_info("pass.semantic.vectors_stored", "count", itoa_log(func_count));
 
     /* Phase 5: LSH hyperplanes → signatures → buckets. */
@@ -1432,8 +1430,7 @@ int cbm_pipeline_pass_semantic_edges(cbm_pipeline_ctx_t *ctx) {
     free_lsh_buckets(band_buckets);
     free(signatures);
     cbm_log_info("pass.done", "pass", "semantic_edges", "edges", itoa_log(total_edges));
-    free_funcs_and_tokens(funcs, func_count, all_tokens, token_counts, token_pools,
-                          worker_count);
+    free_funcs_and_tokens(funcs, func_count, all_tokens, token_counts, token_pools, worker_count);
     free(token_counts);
     cbm_sem_corpus_free(corpus);
     CBM_PROF_END("semantic_edges", "7_cleanup", t_phase7);

--- a/src/pipeline/pass_similarity.c
+++ b/src/pipeline/pass_similarity.c
@@ -230,8 +230,7 @@ static void sim_query_worker(int worker_id, void *ctx_ptr) {
              * assigned in parallel-merge order and vary run to run, which
              * flipped which side owned a pair and (with the per-source edge
              * cap) flickered the emitted set (determinism). */
-            if (!src->qn || !cand->qualified_name ||
-                strcmp(src->qn, cand->qualified_name) >= 0) {
+            if (!src->qn || !cand->qualified_name || strcmp(src->qn, cand->qualified_name) >= 0) {
                 continue;
             }
 

--- a/src/semantic/rotsq.h
+++ b/src/semantic/rotsq.h
@@ -3,7 +3,9 @@
  *
  * Implements the core of Extended RaBitQ (Gao et al., SIGMOD 2024/2025;
  * arXiv:2405.12497, arXiv:2409.09913) without the reference library (which is
- * C++ and bundles Eigen/MPL-2.0). Named rotsq, not rabitq: this is the
+ * C++ and bundles the Eigen linear-algebra dependency; nothing here is vendored
+ * or derived from it — this file is written from the papers). Named rotsq, not
+ * rabitq: this is the
  * FAMILY core (randomized rotation + per-vector scalar quantization + exact
  * code-expansion estimator), not the papers' exact codebook construction —
  * the name should not overclaim fidelity. Rotate each vector with a deterministic
@@ -34,10 +36,10 @@
 #include <stdint.h>
 
 enum {
-    CBM_RSQ_IN_DIM = 768,   /* input dimension (CBM_SEM_DIM) */
-    CBM_RSQ_DIM = 1024,     /* padded pow2 rotation dimension */
-    CBM_RSQ_BITS = 4,       /* bits per coordinate */
-    CBM_RSQ_LEVELS = 15,    /* (1 << CBM_RSQ_BITS) - 1 */
+    CBM_RSQ_IN_DIM = 768,                 /* input dimension (CBM_SEM_DIM) */
+    CBM_RSQ_DIM = 1024,                   /* padded pow2 rotation dimension */
+    CBM_RSQ_BITS = 4,                     /* bits per coordinate */
+    CBM_RSQ_LEVELS = 15,                  /* (1 << CBM_RSQ_BITS) - 1 */
     CBM_RSQ_CODE_BYTES = CBM_RSQ_DIM / 2, /* two 4-bit codes per byte */
 };
 


### PR DESCRIPTION
Two follow-ups to #921 caught by the dry run:

- clang-format pass over six files touched by the perf campaign (formatter was not run before merge; cppcheck clean).
- The rotsq.h header comment mentioned the license identifier of a third-party library's bundled dependency while explaining we deliberately avoid that library; ScanCode matches the bare identifier string and blocks. Reworded to state provenance directly (written from the published papers, nothing vendored or derived). Verified: a normalized shared-line sweep of rotsq.{h,c} against both public reference implementations finds zero overlap beyond include-statement boilerplate.

Whitespace + comment changes only; local `make lint-ci` green.