### PR TITLE
fix(test): harness index worker must _Exit like the production worker

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -75,10 +75,18 @@ static int tf_maybe_run_index_worker(int argc, char **argv) {
                 (void)fclose(rf);
             }
         }
-        free(result);
     }
-    cbm_mcp_server_free(srv);
-    return 0;
+    /* Faithful worker exit: mirror run_cli's supervised-worker fast path.
+     * The worker-role pipeline deliberately skips its teardown (the OS
+     * reclaims everything wholesale on process death), so a normal return
+     * through main() lets LeakSanitizer run at exit, report the
+     * intentionally-unfreed pipeline, and force exit code 1 — the
+     * supervisor then reads a HEALTHY index as worker_failed (the
+     * Linux-only IDX832 red: LSan is active in Linux gcc ASan builds,
+     * absent on macOS/Windows). _Exit skips atexit/LSan by design,
+     * exactly like the production worker in run_cli. */
+    fflush(NULL);
+    _Exit(result ? 0 : 1);
 }
 
 /* #798 follow-up: socket-isolation probe. The parent test


### PR DESCRIPTION
Fifth and last dry-run blocker: the supervised-worker teardown skip pairs with _Exit (which bypasses LeakSanitizer) in production run_cli, but the test binary's worker emulation returned normally through main — LSan reported the intentionally-unfreed pipeline and forced exit 1, so the supervisor read a healthy index as worker_failed (IDX832 red on the four Linux legs only; macOS/Windows ASan run no leak pass).

Verified in an ubuntu:22.04 arm64 container (the failing condition): reap outcome=clean exit_code=0, mcp suite 140 passed / 0 failed. Local macOS suite and lint-ci green.