### PR TITLE
docs: add project to CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Removes all agent configs, skills, hooks, and instructions. Does not remove the 
 - **Single static binary, zero infrastructure**: SQLite-backed, persists to `~/.cache/codebase-memory-mcp/`
 - **Auto-sync**: Background watcher detects file changes and re-indexes automatically
 - **Route nodes**: REST endpoints are first-class graph entities
-- **CLI mode**: `codebase-memory-mcp cli search_graph '{"name_pattern": ".*Handler.*"}'`
+- **CLI mode**: `codebase-memory-mcp cli search_graph '{"project": "my-project", "name_pattern": ".*Handler.*"}'`
 - **Available on**: npm, PyPI, Homebrew, Scoop, Winget, Chocolatey, AUR, `go install`
 
 ## Team-Shared Graph Artifact
@@ -397,11 +397,13 @@ Every MCP tool can be invoked from the command line:
 
 ```bash
 codebase-memory-mcp cli index_repository '{"repo_path": "/path/to/repo"}'
-codebase-memory-mcp cli search_graph '{"name_pattern": ".*Handler.*", "label": "Function"}'
-codebase-memory-mcp cli trace_path '{"function_name": "Search", "direction": "both"}'
-codebase-memory-mcp cli query_graph '{"query": "MATCH (f:Function) RETURN f.name LIMIT 5"}'
 codebase-memory-mcp cli list_projects
-codebase-memory-mcp cli --raw search_graph '{"label": "Function"}' | jq '.results[].name'
+
+# Use the "name" returned by list_projects as the project value.
+codebase-memory-mcp cli search_graph '{"project": "my-project", "name_pattern": ".*Handler.*", "label": "Function"}'
+codebase-memory-mcp cli trace_path '{"project": "my-project", "function_name": "Search", "direction": "both"}'
+codebase-memory-mcp cli query_graph '{"project": "my-project", "query": "MATCH (f:Function) RETURN f.name LIMIT 5"}'
+codebase-memory-mcp cli --raw search_graph '{"project": "my-project", "label": "Function"}' | jq '.results[].name'
 ```
 
 ## MCP Tools


### PR DESCRIPTION
## What does this PR do?

Updates the README CLI examples to include the required `project` field for project-scoped tool calls.

The previous examples showed commands such as `search_graph`, `trace_path`, `query_graph`, and `--raw search_graph` without a `project` value, which can lead to `project not found or not indexed` errors when users copy the examples directly.

This PR also adds a short note telling users to run `list_projects` first and use the returned project `name` as the `project` value.

Closes #945.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects unsigned commits ([DCO](./DCO), see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [ ] Tests pass locally (`make -f Makefile.cbm test`) — not run; docs-only change
- [ ] Lint passes locally (`make -f Makefile.cbm lint-ci`) — not run; docs-only change
- [x] New behavior is covered by a test — not applicable; README-only documentation fix