### PR TITLE
ci(smoke): fail soft when the Windows Defender scan engine can't run

### DIFF
--- a/.github/workflows/_smoke.yml
+++ b/.github/workflows/_smoke.yml
@@ -248,9 +248,20 @@ jobs:
         run: |
           & "C:\Program Files\Windows Defender\MpCmdRun.exe" -SignatureUpdate 2>$null
           $result = & "C:\Program Files\Windows Defender\MpCmdRun.exe" -Scan -ScanType 3 -File "$PWD\codebase-memory-mcp.exe" -DisableRemediation
+          $code = $LASTEXITCODE
           Write-Host $result
-          if ($LASTEXITCODE -ne 0) { Write-Host "BLOCKED: Windows Defender flagged binary!"; exit 1 }
-          Write-Host "=== Windows Defender: clean ==="
+          # MpCmdRun -Scan exit codes: 0 = clean, 2 = threat found. Any OTHER non-zero
+          # means the scan engine could not run at all (e.g. hr=0x800106ba: the Defender
+          # antimalware service is unavailable on the runner) — that is NOT a detection.
+          # Fail soft on an engine failure so a transient runner-side AV outage can't
+          # false-fail a release; only a real detection (exit 2) hard-blocks.
+          if ($code -eq 2) {
+            Write-Host "BLOCKED: Windows Defender flagged binary!"; exit 1
+          } elseif ($code -ne 0) {
+            Write-Host "::warning::Windows Defender scan could not run (exit $code) - skipping AV gate on this runner"
+          } else {
+            Write-Host "=== Windows Defender: clean ==="
+          }
 
   smoke-linux-portable:
     needs: setup-matrix


### PR DESCRIPTION
## Problem

The `Windows Defender scan` step in `_smoke.yml` treated **any** non-zero `MpCmdRun` exit as a malware detection (`"BLOCKED: flagged binary!"; exit 1`). But `MpCmdRun -Scan` returns **2** for a real detection and **0** for clean; any *other* non-zero means the scan **engine could not run at all** — e.g. `hr=0x800106ba`, the Defender antimalware service being unavailable on the runner, a chronic transient flake on GitHub's windows-arm64 runners.

This **false-failed the v0.9.0 release on its first attempt** (a re-run on a fresh runner passed). Worse, the "flagged binary!" wording mislabels a runner outage as malware.

## Change

Distinguish the two: only exit **2** (an actual detection) hard-blocks; an engine failure emits `::warning::` and continues.

## CI-change scope (per repo policy)
- **Gating:** *reduces* false-fails from a runner-side AV outage; a real detection (exit 2) still hard-blocks. Net: fewer flake-driven release failures, same real protection.
- **Cost / trigger scope / matrix:** unchanged — same scan runs on the same jobs.
- **Flake surface:** strictly reduced (this is the fix for that flake).
