### PR TITLE
mcp: make cbm_path_within_root parseable without the preprocessor

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -4103,20 +4103,34 @@ static yyjson_doc *enrich_node_properties(yyjson_mut_doc *doc, yyjson_mut_val *o
  * the search path (attach_result_source) route through it, so a result whose
  * indexed path escapes the project root — via a `..` segment, or a symlink /
  * Windows junction picked up during discovery — is never read back out. */
+/* Canonicalize `path` (resolve symlinks/junctions and `..`) into `out`
+ * (>= CBM_SZ_4K bytes); returns true on success. Isolating the per-OS resolver
+ * keeps cbm_path_within_root's control flow unconditional: the previous `#ifdef`
+ * opened the `if (...) {` brace in one branch and a different one in the other,
+ * sharing a single close brace — legal C, but it splits the function's braces
+ * across preprocessor branches, which defeats source-level tooling that parses
+ * without the preprocessor (and left this function unindexed in the graph). */
+static bool resolve_canonical_path(const char *path, char *out, size_t out_sz) {
+#ifdef _WIN32
+    if (!_fullpath(out, path, out_sz)) {
+        return false;
+    }
+    cbm_normalize_path_sep(out);
+    return true;
+#else
+    (void)out_sz;
+    return realpath(path, out) != NULL;
+#endif
+}
+
 bool cbm_path_within_root(const char *root_path, const char *abs_path) {
     if (!root_path || !abs_path) {
         return false;
     }
     char real_root[CBM_SZ_4K];
     char real_file[CBM_SZ_4K];
-#ifdef _WIN32
-    if (_fullpath(real_root, root_path, sizeof(real_root)) &&
-        _fullpath(real_file, abs_path, sizeof(real_file))) {
-        cbm_normalize_path_sep(real_root);
-        cbm_normalize_path_sep(real_file);
-#else
-    if (realpath(root_path, real_root) && realpath(abs_path, real_file)) {
-#endif
+    if (resolve_canonical_path(root_path, real_root, sizeof(real_root)) &&
+        resolve_canonical_path(abs_path, real_file, sizeof(real_file))) {
         size_t root_len = strlen(real_root);
         if (strncmp(real_file, real_root, root_len) == 0 &&
             (real_file[root_len] == '/' || real_file[root_len] == '\0')) {


### PR DESCRIPTION
## Problem

`cbm_path_within_root` (the containment guard every MCP file-read sink passes through) was **missing from the code knowledge graph** — despite its callers being present. Root cause: its definition used

```c
#ifdef _WIN32
    if (_fullpath(...) && _fullpath(...)) {   // opening brace in the WIN32 branch
        ...
#else
    if (realpath(...) && realpath(...)) {     // a different opening brace in the POSIX branch
#endif
        ...shared body...
    }                                         // single shared close brace
```

That's legal C, but the `#ifdef` **splits the function body's braces across preprocessor branches**. A source-level parser that runs *without* the preprocessor (the tree-sitter-based indexer) sees two `if {` opens and one `}` close → unbalanced → error node → no `Function` node emitted.

## Change

Extract a tiny per-OS `resolve_canonical_path()` helper (each `#ifdef` branch is now a complete statement), leaving `cbm_path_within_root` with **one unconditional `if`**. Purely structural — behavior is identical.

## Verification
- `mcp_path_within_root_rejects_escape` and `path_within_root_allowed` still pass; full C build + lint clean.
- Re-indexed the tree: `cbm_path_within_root` now appears as a `Function` node with `in_degree=6` (all callers resolve to it), and the new `resolve_canonical_path` helper is linked. Before this change it was absent from the graph entirely.

The *general* extractor limitation (functions whose braces are split by `#ifdef`) is tracked separately as an issue; this PR fixes the one security-relevant function and removes a genuine code smell.
