### PR TITLE
feat(index): by-design coverage class — deliberately-ignored files reported as purposely not indexed

### DIFF
--- a/src/discover/discover.c
+++ b/src/discover/discover.c
@@ -417,6 +417,15 @@ typedef struct {
     char **excluded;
     int excluded_count;
     int excluded_cap;
+    /* Individual files dropped by ignore rules (#963 "purposely not
+     * indexed"). Collected only when requested (collect_ignored); stored
+     * entries are capped at CBM_DISCOVER_IGNORED_CAP while ignored_total
+     * keeps counting so truncation is explicit. */
+    bool collect_ignored;
+    cbm_ignored_file_t *ignored;
+    int ignored_count;
+    int ignored_cap;
+    int ignored_total;
 } file_list_t;
 
 static void file_list_add_excluded(file_list_t *fl, const char *rel_path) {
@@ -437,6 +446,35 @@ static void file_list_add_excluded(file_list_t *fl, const char *rel_path) {
         return;
     }
     fl->excluded[fl->excluded_count++] = copy;
+}
+
+static void file_list_add_ignored(file_list_t *fl, const char *rel_path, const char *reason) {
+    if (!fl->collect_ignored || !rel_path || rel_path[0] == '\0') {
+        return;
+    }
+    fl->ignored_total++;
+    if (fl->ignored_count >= CBM_DISCOVER_IGNORED_CAP) {
+        return; /* counted above — truncation stays visible via the total */
+    }
+    if (fl->ignored_count >= fl->ignored_cap) {
+        int new_cap = fl->ignored_cap ? fl->ignored_cap * PAIR_LEN : CBM_SZ_64;
+        cbm_ignored_file_t *grown = realloc(fl->ignored, new_cap * sizeof(cbm_ignored_file_t));
+        if (!grown) {
+            return;
+        }
+        fl->ignored = grown;
+        fl->ignored_cap = new_cap;
+    }
+    char *path_copy = strdup(rel_path);
+    char *reason_copy = strdup(reason ? reason : "");
+    if (!path_copy || !reason_copy) {
+        free(path_copy);
+        free(reason_copy);
+        return;
+    }
+    fl->ignored[fl->ignored_count].rel_path = path_copy;
+    fl->ignored[fl->ignored_count].reason = reason_copy;
+    fl->ignored_count++;
 }
 
 static void fl_add(file_list_t *fl, const char *abs_path, const char *rel_path, CBMLanguage lang,
@@ -526,44 +564,50 @@ static bool should_skip_directory(const char *entry_name, const char *rel_path,
 }
 
 /* Check if a regular file should be skipped (filters + gitignore + size). */
-static bool should_skip_file(const char *entry_name, const char *rel_path,
-                             const cbm_discover_opts_t *opts, const cbm_gitignore_t *gitignore,
-                             const cbm_gitignore_t *global_gi, const cbm_gitignore_t *cbmignore,
-                             const cbm_gitignore_t *local_gi, const char *local_gi_prefix,
-                             off_t file_size) {
+/* Classify why a file is skipped. Returns a static reason string (the #963
+ * "purposely not indexed" class) or NULL to keep the file. Check order and
+ * semantics — including the .cbmignore negation un-ignoring a global-gitignore
+ * match — are IDENTICAL to the original boolean predicate. */
+static const char *file_skip_reason(const char *entry_name, const char *rel_path,
+                                    const cbm_discover_opts_t *opts,
+                                    const cbm_gitignore_t *gitignore,
+                                    const cbm_gitignore_t *global_gi,
+                                    const cbm_gitignore_t *cbmignore,
+                                    const cbm_gitignore_t *local_gi, const char *local_gi_prefix,
+                                    off_t file_size) {
     cbm_index_mode_t mode = opts ? opts->mode : CBM_MODE_FULL;
     if (cbm_has_ignored_suffix(entry_name, mode)) {
-        return true;
+        return "ignored-suffix";
     }
     if (cbm_should_skip_filename(entry_name, mode)) {
-        return true;
+        return "skip-list";
     }
     if (cbm_matches_fast_pattern(entry_name, mode)) {
-        return true;
+        return "fast-pattern";
     }
     if (gitignore && cbm_gitignore_matches(gitignore, rel_path, false)) {
-        return true;
+        return "gitignore";
     }
     bool global_ignored = global_gi && cbm_gitignore_matches(global_gi, rel_path, false);
     if (local_gi) {
         const char *lrel = local_rel_path(rel_path, local_gi_prefix);
         if (cbm_gitignore_matches(local_gi, lrel, false)) {
-            return true;
+            return "gitignore";
         }
     }
     if (cbmignore) {
         int cbm_result = cbm_gitignore_match_result(cbmignore, rel_path, false);
         if (cbm_result > 0) {
-            return true;
+            return "cbmignore";
         }
         if (cbm_result < 0 && global_ignored) {
             global_ignored = false;
         }
     }
     if (opts && opts->max_file_size > 0 && file_size > opts->max_file_size) {
-        return true;
+        return "size-cap";
     }
-    return global_ignored;
+    return global_ignored ? "gitignore" : NULL;
 }
 
 /* Detect language for a file, handling .m disambiguation and JSON filtering. */
@@ -638,8 +682,14 @@ static void walk_dir_process_file(const char *abs_path, const char *rel_path, co
                                   const cbm_gitignore_t *global_gi,
                                   const cbm_gitignore_t *cbmignore, const cbm_gitignore_t *local_gi,
                                   const char *local_gi_prefix, off_t size, file_list_t *out) {
-    if (should_skip_file(name, rel_path, opts, gitignore, global_gi, cbmignore, local_gi,
-                         local_gi_prefix, size)) {
+    const char *skip_reason = file_skip_reason(name, rel_path, opts, gitignore, global_gi,
+                                               cbmignore, local_gi, local_gi_prefix, size);
+    if (skip_reason) {
+        /* Deliberately not indexed (#963) — record so callers can surface it.
+         * Unsupported-language files below are NOT recorded: "no grammar for
+         * this extension" is not an ignore decision, and listing every
+         * README/asset would drown the signal. */
+        file_list_add_ignored(out, rel_path, skip_reason);
         return;
     }
     CBMLanguage lang = detect_file_language(name, abs_path);
@@ -878,11 +928,28 @@ int cbm_discover(const char *repo_path, const cbm_discover_opts_t *opts, cbm_fil
 
 int cbm_discover_ex(const char *repo_path, const cbm_discover_opts_t *opts, cbm_file_info_t **out,
                     int *count, char ***excluded_out, int *excluded_count_out) {
+    return cbm_discover_ex2(repo_path, opts, out, count, excluded_out, excluded_count_out, NULL,
+                            NULL, NULL);
+}
+
+int cbm_discover_ex2(const char *repo_path, const cbm_discover_opts_t *opts, cbm_file_info_t **out,
+                     int *count, char ***excluded_out, int *excluded_count_out,
+                     cbm_ignored_file_t **ignored_out, int *ignored_count_out,
+                     int *ignored_total_out) {
     if (excluded_out) {
         *excluded_out = NULL;
     }
     if (excluded_count_out) {
         *excluded_count_out = 0;
+    }
+    if (ignored_out) {
+        *ignored_out = NULL;
+    }
+    if (ignored_count_out) {
+        *ignored_count_out = 0;
+    }
+    if (ignored_total_out) {
+        *ignored_total_out = 0;
     }
     if (!repo_path || !out || !count) {
         return CBM_NOT_FOUND;
@@ -956,6 +1023,7 @@ int cbm_discover_ex(const char *repo_path, const cbm_discover_opts_t *opts, cbm_
 
     /* Walk */
     file_list_t fl = {0};
+    fl.collect_ignored = ignored_out != NULL;
     walk_dir(repo_path, "", opts, gitignore, global_gi, cbmignore, &fl);
 
     /* Cleanup */
@@ -974,6 +1042,19 @@ int cbm_discover_ex(const char *repo_path, const cbm_discover_opts_t *opts, cbm_
         }
     } else {
         cbm_discover_free_excluded(fl.excluded, fl.excluded_count);
+    }
+
+    /* Same handoff for the ignored-file list (#963). */
+    if (ignored_out) {
+        *ignored_out = fl.ignored;
+        if (ignored_count_out) {
+            *ignored_count_out = fl.ignored_count;
+        }
+        if (ignored_total_out) {
+            *ignored_total_out = fl.ignored_total;
+        }
+    } else {
+        cbm_discover_free_ignored(fl.ignored, fl.ignored_count);
     }
     return 0;
 }
@@ -997,4 +1078,15 @@ void cbm_discover_free_excluded(char **excluded, int count) {
         free(excluded[i]);
     }
     free(excluded);
+}
+
+void cbm_discover_free_ignored(cbm_ignored_file_t *ignored, int count) {
+    if (!ignored) {
+        return;
+    }
+    for (int i = 0; i < count; i++) {
+        free(ignored[i].rel_path);
+        free(ignored[i].reason);
+    }
+    free(ignored);
 }

--- a/src/discover/discover.h
+++ b/src/discover/discover.h
@@ -130,10 +130,40 @@ int cbm_discover(const char *repo_path, const cbm_discover_opts_t *opts, cbm_fil
 int cbm_discover_ex(const char *repo_path, const cbm_discover_opts_t *opts, cbm_file_info_t **out,
                     int *count, char ***excluded_out, int *excluded_count_out);
 
+/* One deliberately-not-indexed file (#963): an individual file dropped by an
+ * ignore mechanism during the walk (its parent directory was NOT excluded —
+ * whole subtrees are reported separately as excluded dirs). BY DESIGN, not a
+ * failure. */
+typedef struct {
+    char *rel_path; /* heap-allocated, relative to repo root */
+    char *reason;   /* heap-allocated: "gitignore" | "cbmignore" |
+                     * "skip-list" | "ignored-suffix" | "fast-pattern" |
+                     * "size-cap" */
+} cbm_ignored_file_t;
+
+/* Stored per-file ignore entries are capped (the walk still counts ALL of
+ * them in *ignored_total_out, so truncation is always explicit, never
+ * silent). Whole excluded subtrees stay exhaustive via excluded_out. */
+enum { CBM_DISCOVER_IGNORED_CAP = 2000 };
+
+/* Like cbm_discover_ex(), but additionally reports the individual files that
+ * ignore rules dropped (#963 "purposely not indexed"). *ignored_out receives
+ * a heap array (caller frees via cbm_discover_free_ignored),
+ * *ignored_count_out its stored length (<= CBM_DISCOVER_IGNORED_CAP), and
+ * *ignored_total_out the TOTAL number of ignored files seen. Pass NULL to
+ * skip the collection entirely. */
+int cbm_discover_ex2(const char *repo_path, const cbm_discover_opts_t *opts, cbm_file_info_t **out,
+                     int *count, char ***excluded_out, int *excluded_count_out,
+                     cbm_ignored_file_t **ignored_out, int *ignored_count_out,
+                     int *ignored_total_out);
+
 /* Free an array of file info results. NULL-safe. */
 void cbm_discover_free(cbm_file_info_t *files, int count);
 
 /* Free the excluded-directory list returned by cbm_discover_ex(). NULL-safe. */
 void cbm_discover_free_excluded(char **excluded, int count);
+
+/* Free the ignored-file list returned by cbm_discover_ex2(). NULL-safe. */
+void cbm_discover_free_ignored(cbm_ignored_file_t *ignored, int count);
 
 #endif /* CBM_DISCOVER_H */

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -322,7 +322,9 @@ static const tool_def_t TOOLS[] = {
      "constructs inside the listed line ranges could not be parsed and MAY be missing from "
      "the graph). Query the persisted signal any time via index_status or "
      "structurally via query_graph(graph=\"missed\"). Both signals are best-effort: absence "
-     "of a flag is NOT a completeness guarantee; prefer grep inside flagged ranges.",
+     "of a flag is NOT a completeness guarantee; prefer grep inside flagged ranges. "
+     "Separately, 'excluded' + 'not_indexed_files' list what was deliberately NOT indexed "
+     "(gitignore/.cbmignore/skip-lists) — by design, not failures.",
      "{\"type\":\"object\",\"properties\":{\"repo_path\":{\"type\":\"string\",\"description\":"
      "\"Path to the repository\"},"
      "\"mode\":{\"type\":\"string\","
@@ -507,7 +509,9 @@ static const tool_def_t TOOLS[] = {
      "trusting graph completeness on a file: if a file is listed, ALSO grep it (especially the "
      "flagged ranges). IMPORTANT: absence from these lists is NOT a completeness guarantee — the "
      "signal only marks what the indexer can detect. For structural queries over the misses use "
-     "query_graph(graph=\"missed\").",
+     "query_graph(graph=\"missed\"). The report also carries 'not_indexed' — files/dirs excluded "
+     "BY DESIGN (gitignore/.cbmignore/skip-lists): deliberate and deterministic, not failures; "
+     "change the ignore rules and re-index to include them.",
      "{\"type\":\"object\",\"properties\":{\"project\":{\"type\":\"string\"}},\"required\":["
      "\"project\"]}"},
 
@@ -2191,11 +2195,15 @@ static void add_coverage_report(yyjson_mut_doc *doc, yyjson_mut_val *root, cbm_s
 
     yyjson_mut_val *pp_files = yyjson_mut_arr(doc);
     yyjson_mut_val *sk_files = yyjson_mut_arr(doc);
+    yyjson_mut_val *ni_dirs = yyjson_mut_arr(doc);
+    yyjson_mut_val *ni_files = yyjson_mut_arr(doc);
     int pp_n = 0;
     int sk_n = 0;
+    int ni_dir_n = 0;
+    int ni_file_n = 0;
     for (int i = 0; i < count; i++) {
-        bool partial = rows[i].kind && strcmp(rows[i].kind, "parse_partial") == 0;
-        if (partial) {
+        const char *kind = rows[i].kind ? rows[i].kind : "";
+        if (strcmp(kind, "parse_partial") == 0) {
             if (pp_n < COVERAGE_FILE_CAP) {
                 yyjson_mut_val *fe = yyjson_mut_obj(doc);
                 yyjson_mut_obj_add_strcpy(doc, fe, "path", rows[i].rel_path);
@@ -2204,6 +2212,19 @@ static void add_coverage_report(yyjson_mut_doc *doc, yyjson_mut_val *root, cbm_s
                 yyjson_mut_arr_add_val(pp_files, fe);
             }
             pp_n++;
+        } else if (strcmp(kind, "not_indexed_dir") == 0) {
+            if (ni_dir_n < COVERAGE_FILE_CAP) {
+                yyjson_mut_arr_add_strcpy(doc, ni_dirs, rows[i].rel_path);
+            }
+            ni_dir_n++;
+        } else if (strcmp(kind, "not_indexed_file") == 0) {
+            if (ni_file_n < COVERAGE_FILE_CAP) {
+                yyjson_mut_val *fe = yyjson_mut_obj(doc);
+                yyjson_mut_obj_add_strcpy(doc, fe, "path", rows[i].rel_path);
+                yyjson_mut_obj_add_strcpy(doc, fe, "reason", rows[i].detail ? rows[i].detail : "");
+                yyjson_mut_arr_add_val(ni_files, fe);
+            }
+            ni_file_n++;
         } else {
             if (sk_n < COVERAGE_FILE_CAP) {
                 yyjson_mut_val *fe = yyjson_mut_obj(doc);
@@ -2229,6 +2250,25 @@ static void add_coverage_report(yyjson_mut_doc *doc, yyjson_mut_val *root, cbm_s
     yyjson_mut_obj_add_bool(doc, sk, "truncated", sk_n > COVERAGE_FILE_CAP);
     yyjson_mut_obj_add_val(doc, root, "skipped", sk);
 
+    /* By-design exclusions (#963 "purposely not indexed"): a deliberate,
+     * deterministic class — NOT a failure and NOT best-effort. Dirs are
+     * exhaustive; per-file entries are capped in discovery (2000) with the
+     * truncation explicit. */
+    yyjson_mut_val *ni = yyjson_mut_obj(doc);
+    yyjson_mut_obj_add_val(doc, ni, "dirs", ni_dirs);
+    yyjson_mut_obj_add_int(doc, ni, "dirs_count", ni_dir_n);
+    yyjson_mut_obj_add_val(doc, ni, "files", ni_files);
+    yyjson_mut_obj_add_int(doc, ni, "files_count", ni_file_n);
+    yyjson_mut_obj_add_bool(doc, ni, "truncated",
+                            ni_dir_n > COVERAGE_FILE_CAP || ni_file_n > COVERAGE_FILE_CAP);
+    if (ni_dir_n > 0 || ni_file_n > 0) {
+        yyjson_mut_obj_add_str(doc, ni, "note",
+                               "Purposely not indexed — excluded BY DESIGN via "
+                               "gitignore/.cbmignore/skip-lists (see each file's reason). Not an "
+                               "error: change the ignore rules and re-index to include them.");
+    }
+    yyjson_mut_obj_add_val(doc, root, "not_indexed", ni);
+
     if (pp_n > 0 || sk_n > 0) {
         yyjson_mut_obj_add_str(
             doc, root, "coverage_note",
@@ -2236,7 +2276,8 @@ static void add_coverage_report(yyjson_mut_doc *doc, yyjson_mut_val *root, cbm_s
             "but constructs inside the listed line ranges (1-based) MAY be missing from the graph "
             "(tree-sitter error recovery still salvages some). skipped files were not indexed at "
             "all. Prefer text search (grep) for flagged files/ranges. Files absent from this list "
-            "are NOT guaranteed to be fully indexed.");
+            "are NOT guaranteed to be fully indexed. (not_indexed entries are a separate, "
+            "BY-DESIGN class — deliberate ignore rules, not failures.)");
     }
 }
 
@@ -3409,6 +3450,41 @@ static void add_excluded_summary(yyjson_mut_doc *doc, yyjson_mut_val *root, char
  * the JSON carries "count" + "truncated" so nothing is silently hidden. */
 enum { INDEX_SKIPPED_FILE_CAP = 50 };
 
+/* Attach the by-design ignored-FILES summary (#963 "purposely not indexed").
+ * Individual files dropped by ignore rules — deliberate, not failures; whole
+ * excluded subtrees are reported separately via "excluded". Always emits
+ * "not_indexed_files_count" (the uncapped total); the list itself is capped
+ * like skipped[] and marked truncated when discovery hit its storage cap. */
+static void add_not_indexed_files_summary(yyjson_mut_doc *doc, yyjson_mut_val *root,
+                                          cbm_pipeline_t *p) {
+    cbm_ignored_file_t *ignored = NULL;
+    int stored = 0;
+    int total = 0;
+    cbm_pipeline_get_ignored(p, &ignored, &stored, &total);
+    yyjson_mut_obj_add_int(doc, root, "not_indexed_files_count", total);
+    if (!ignored || stored <= 0) {
+        return;
+    }
+    yyjson_mut_val *ni = yyjson_mut_obj(doc);
+    yyjson_mut_val *files = yyjson_mut_arr(doc);
+    int shown = stored < INDEX_SKIPPED_FILE_CAP ? stored : INDEX_SKIPPED_FILE_CAP;
+    for (int i = 0; i < shown; i++) {
+        yyjson_mut_val *fe = yyjson_mut_obj(doc);
+        yyjson_mut_obj_add_strcpy(doc, fe, "path", ignored[i].rel_path ? ignored[i].rel_path : "");
+        yyjson_mut_obj_add_strcpy(doc, fe, "reason", ignored[i].reason ? ignored[i].reason : "");
+        yyjson_mut_arr_add_val(files, fe);
+    }
+    yyjson_mut_obj_add_val(doc, ni, "files", files);
+    yyjson_mut_obj_add_int(doc, ni, "count", total);
+    yyjson_mut_obj_add_bool(doc, ni, "truncated", total > shown);
+    yyjson_mut_obj_add_str(doc, ni, "note",
+                           "Purposely not indexed — excluded BY DESIGN via "
+                           "gitignore/.cbmignore/skip-lists (see each file's reason). Not an "
+                           "error: change the ignore rules and re-index to include them. Whole "
+                           "excluded subtrees are listed separately under \"excluded\".");
+    yyjson_mut_obj_add_val(doc, root, "not_indexed_files", ni);
+}
+
 /* True when a recorded per-file entry is the parse-partial coverage signal
  * (#963) rather than a genuine skip. Kept out of skipped[]/skipped_count so
  * the "skipped" contract (file NOT indexed) stays exact. */
@@ -3567,6 +3643,7 @@ static bool build_index_success_response(cbm_mcp_server_t *srv, yyjson_mut_doc *
     add_excluded_summary(doc, root, excluded_dirs, excluded_count);
     add_skipped_summary(doc, root, file_errors, file_error_count, logfile);
     add_parse_partial_summary(doc, root, file_errors, file_error_count);
+    add_not_indexed_files_summary(doc, root, p);
 
     int exp_nodes = -1;
     int exp_edges = -1;

--- a/src/pipeline/pipeline.c
+++ b/src/pipeline/pipeline.c
@@ -92,6 +92,14 @@ struct cbm_pipeline {
     char **excluded_dirs;
     int excluded_count;
 
+    /* Individual files dropped by ignore rules during discovery (#963
+     * "purposely not indexed" — by design, not failures). Stored entries are
+     * capped in discovery; ignored_total keeps the uncapped count so
+     * truncation stays explicit. Owned by the pipeline. */
+    cbm_ignored_file_t *ignored_files;
+    int ignored_count;
+    int ignored_total;
+
     /* Per-file indexing failures (skipped files) surfaced via MCP/CLI/logfile
      * (Stage 2 / Track B). A skip is the expected handled outcome of a bad or
      * oversized file — the run still succeeds ("indexed"). Owned by the
@@ -215,6 +223,10 @@ void cbm_pipeline_free(cbm_pipeline_t *p) {
     cbm_discover_free_excluded(p->excluded_dirs, p->excluded_count);
     p->excluded_dirs = NULL;
     p->excluded_count = 0;
+    cbm_discover_free_ignored(p->ignored_files, p->ignored_count);
+    p->ignored_files = NULL;
+    p->ignored_count = 0;
+    p->ignored_total = 0;
     for (int i = 0; i < p->file_errors_count; i++) {
         free(p->file_errors[i].path);
         free(p->file_errors[i].reason);
@@ -312,6 +324,19 @@ void cbm_pipeline_get_file_errors(const cbm_pipeline_t *p, cbm_file_error_t **ou
     }
     if (count) {
         *count = p ? p->file_errors_count : 0;
+    }
+}
+
+void cbm_pipeline_get_ignored(const cbm_pipeline_t *p, cbm_ignored_file_t **out, int *count,
+                              int *total) {
+    if (out) {
+        *out = p ? p->ignored_files : NULL;
+    }
+    if (count) {
+        *count = p ? p->ignored_count : 0;
+    }
+    if (total) {
+        *total = p ? p->ignored_total : 0;
     }
 }
 
@@ -1114,27 +1139,48 @@ static int dump_and_persist_hashes(cbm_pipeline_t *p, const cbm_file_info_t *fil
         }
         CBM_PROF_END_N("persist", "4_file_hashes", t_fh, file_count);
 
-        /* Coverage rows (#963): a full run's file_errors is the complete
-         * coverage truth for the project. The dump recreated the DB file, so
-         * the separate index_coverage table starts empty — write only when
-         * there is something to record (AFTER hashes, so the deleted-file
-         * prune inside replace sees the live file set). */
-        if (p->file_errors_count > 0) {
+        /* Coverage rows (#963): a full run's file_errors plus the by-design
+         * discovery exclusions are the complete coverage truth for the
+         * project. The dump recreated the DB file, so the separate
+         * index_coverage table starts empty — write only when there is
+         * something to record (AFTER hashes, so the deleted-file prune inside
+         * replace sees the live file set; not_indexed_* kinds are exempt from
+         * that prune — deliberately-unindexed paths have no hash rows). */
+        int cov_total = p->file_errors_count + p->excluded_count + p->ignored_count;
+        if (cov_total > 0) {
             cbm_coverage_row_t *cov =
-                (cbm_coverage_row_t *)malloc((size_t)p->file_errors_count * sizeof(*cov));
+                (cbm_coverage_row_t *)malloc((size_t)cov_total * sizeof(*cov));
             if (cov) {
+                int cn = 0;
                 for (int i = 0; i < p->file_errors_count; i++) {
-                    cov[i].rel_path = p->file_errors[i].path;
-                    cov[i].kind = p->file_errors[i].phase;
-                    cov[i].detail = p->file_errors[i].reason;
+                    cov[cn].rel_path = p->file_errors[i].path;
+                    cov[cn].kind = p->file_errors[i].phase;
+                    cov[cn].detail = p->file_errors[i].reason;
+                    cn++;
                 }
-                if (cbm_store_coverage_replace(hash_store, p->project_name, cov,
-                                               p->file_errors_count) != CBM_STORE_OK) {
+                for (int i = 0; i < p->excluded_count; i++) {
+                    cov[cn].rel_path = p->excluded_dirs[i];
+                    cov[cn].kind = "not_indexed_dir";
+                    cov[cn].detail = "excluded subtree";
+                    cn++;
+                }
+                for (int i = 0; i < p->ignored_count; i++) {
+                    cov[cn].rel_path = p->ignored_files[i].rel_path;
+                    cov[cn].kind = "not_indexed_file";
+                    cov[cn].detail = p->ignored_files[i].reason;
+                    cn++;
+                }
+                if (cbm_store_coverage_replace(hash_store, p->project_name, cov, cn) !=
+                    CBM_STORE_OK) {
                     cbm_log_error("pipeline.err", "phase", "persist_coverage", "project",
                                   p->project_name);
                 }
                 free(cov);
             }
+        }
+        if (p->ignored_total > p->ignored_count) {
+            cbm_log_warn("index.ignored_capped", "stored", itoa_buf(p->ignored_count), "total",
+                         itoa_buf(p->ignored_total));
         }
 
         /* FTS5 backfill: populate nodes_fts with camelCase-split names.
@@ -1319,13 +1365,19 @@ int cbm_pipeline_run(cbm_pipeline_t *p) {
     cbm_file_info_t *files = NULL;
     int file_count = 0;
     /* Capture skipped subtrees on the pipeline so the MCP layer can report
-     * which directories were excluded (#411). Replace any prior list (e.g. a
-     * re-run on the same pipeline) to avoid leaking the previous one. */
+     * which directories were excluded (#411), plus the individually-ignored
+     * files (#963 "purposely not indexed"). Replace any prior lists (e.g. a
+     * re-run on the same pipeline) to avoid leaking the previous ones. */
     cbm_discover_free_excluded(p->excluded_dirs, p->excluded_count);
     p->excluded_dirs = NULL;
     p->excluded_count = 0;
-    int rc = cbm_discover_ex(p->repo_path, &opts, &files, &file_count, &p->excluded_dirs,
-                             &p->excluded_count);
+    cbm_discover_free_ignored(p->ignored_files, p->ignored_count);
+    p->ignored_files = NULL;
+    p->ignored_count = 0;
+    p->ignored_total = 0;
+    int rc = cbm_discover_ex2(p->repo_path, &opts, &files, &file_count, &p->excluded_dirs,
+                              &p->excluded_count, &p->ignored_files, &p->ignored_count,
+                              &p->ignored_total);
     if (rc != 0) {
         cbm_log_error("pipeline.err", "phase", "discover", "rc", itoa_buf(rc));
     }

--- a/src/pipeline/pipeline.h
+++ b/src/pipeline/pipeline.h
@@ -18,6 +18,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "discover/discover.h" /* cbm_ignored_file_t (#963) */
+
 /* Forward declarations */
 typedef struct cbm_store cbm_store_t;
 typedef struct cbm_gbuf cbm_gbuf_t;
@@ -116,6 +118,13 @@ void cbm_pipeline_add_file_error(cbm_pipeline_t *p, const char *path, const char
  * cbm_pipeline_free()). out and count are set to NULL and 0 when p is NULL or
  * nothing was skipped. Do not free. */
 void cbm_pipeline_get_file_errors(const cbm_pipeline_t *p, cbm_file_error_t **out, int *count);
+
+/* Borrowed accessor for the individually-ignored files captured during
+ * discovery (#963 "purposely not indexed" — by design, not failures). count
+ * is the stored (capped) length, total the uncapped number seen. Do not
+ * free. */
+void cbm_pipeline_get_ignored(const cbm_pipeline_t *p, cbm_ignored_file_t **out, int *count,
+                              int *total);
 
 /* ── Index lock (prevents concurrent pipeline runs on same DB) ──── */
 

--- a/src/pipeline/pipeline_incremental.c
+++ b/src/pipeline/pipeline_incremental.c
@@ -858,19 +858,29 @@ int cbm_pipeline_run_incremental(cbm_pipeline_t *p, const char *db_path, cbm_fil
     cbm_pipeline_pass_k8s(&ctx, changed_files, ci);
     run_postpasses(&ctx, changed_files, ci, project);
 
-    /* Coverage rows (#963): merge = previous rows for files NOT re-extracted
-     * this run + this run's fresh entries (changed files replace their old
-     * rows — a file that parses cleanly now simply contributes nothing, so
-     * its stale flag dies here). Rows for deleted files are pruned against
-     * file_hashes inside the replace. Borrowed strings: old_cov and the
-     * pipeline own them past the dump_and_persist call below. */
+    /* Coverage rows (#963): merge = previous FAILURE rows for files NOT
+     * re-extracted this run + this run's fresh entries (changed files replace
+     * their old rows — a file that parses cleanly now simply contributes
+     * nothing, so its stale flag dies here). By-design not_indexed_* rows are
+     * NOT carried over: discovery runs completely on every route, so this
+     * run's excluded dirs + ignored files are the fresh, authoritative set.
+     * Rows for deleted files are pruned against file_hashes inside the
+     * replace. Borrowed strings: old_cov and the pipeline own them past the
+     * dump_and_persist call below. */
     cbm_file_error_t *run_errs = NULL;
     int run_err_count = 0;
     cbm_pipeline_get_file_errors(p, &run_errs, &run_err_count);
+    char **run_excluded = NULL;
+    int run_excluded_count = 0;
+    cbm_pipeline_get_excluded(p, &run_excluded, &run_excluded_count);
+    cbm_ignored_file_t *run_ignored = NULL;
+    int run_ignored_count = 0;
+    cbm_pipeline_get_ignored(p, &run_ignored, &run_ignored_count, NULL);
     cbm_coverage_row_t *cov = NULL;
     int cov_n = 0;
-    if (old_cov_count + run_err_count > 0) {
-        cov = (cbm_coverage_row_t *)malloc((size_t)(old_cov_count + run_err_count) * sizeof(*cov));
+    int cov_cap = old_cov_count + run_err_count + run_excluded_count + run_ignored_count;
+    if (cov_cap > 0) {
+        cov = (cbm_coverage_row_t *)malloc((size_t)cov_cap * sizeof(*cov));
     }
     if (cov) {
         CBMHashTable *changed_set = cbm_ht_create(ci > 0 ? (size_t)ci * PAIR_LEN : CBM_SZ_64);
@@ -878,7 +888,9 @@ int cbm_pipeline_run_incremental(cbm_pipeline_t *p, const char *db_path, cbm_fil
             cbm_ht_set(changed_set, changed_files[i].rel_path, &changed_files[i]);
         }
         for (int i = 0; i < old_cov_count; i++) {
-            if (old_cov[i].rel_path && !cbm_ht_get(changed_set, old_cov[i].rel_path)) {
+            bool by_design = old_cov[i].kind && strncmp(old_cov[i].kind, "not_indexed", 11) == 0;
+            if (!by_design && old_cov[i].rel_path &&
+                !cbm_ht_get(changed_set, old_cov[i].rel_path)) {
                 cov[cov_n++] = old_cov[i];
             }
         }
@@ -887,6 +899,18 @@ int cbm_pipeline_run_incremental(cbm_pipeline_t *p, const char *db_path, cbm_fil
             cov[cov_n].rel_path = run_errs[i].path;
             cov[cov_n].kind = run_errs[i].phase;
             cov[cov_n].detail = run_errs[i].reason;
+            cov_n++;
+        }
+        for (int i = 0; i < run_excluded_count; i++) {
+            cov[cov_n].rel_path = run_excluded[i];
+            cov[cov_n].kind = "not_indexed_dir";
+            cov[cov_n].detail = "excluded subtree";
+            cov_n++;
+        }
+        for (int i = 0; i < run_ignored_count; i++) {
+            cov[cov_n].rel_path = run_ignored[i].rel_path;
+            cov[cov_n].kind = "not_indexed_file";
+            cov[cov_n].detail = run_ignored[i].reason;
             cov_n++;
         }
     }

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -1897,6 +1897,19 @@ static void cov_rebuild_shadow_graph(cbm_store_t *s, const char *project) {
         cbm_store_free_coverage(rows, count);
         return;
     }
+    /* Only FAILURE rows materialize in the miss graph; a project whose only
+     * coverage rows are by-design not_indexed_* entries gets NO graph (not
+     * even a bare root node). */
+    int failure_count = 0;
+    for (int i = 0; i < count; i++) {
+        if (!rows[i].kind || strncmp(rows[i].kind, "not_indexed", 11) != 0) {
+            failure_count++;
+        }
+    }
+    if (failure_count == 0) {
+        cbm_store_free_coverage(rows, count);
+        return;
+    }
 
     /* nodes.project has an FK to projects(name) (enforced: foreign_keys=ON),
      * so the shadow project needs its row. Invisible to list_projects, which
@@ -1916,6 +1929,12 @@ static void cov_rebuild_shadow_graph(cbm_store_t *s, const char *project) {
     for (int i = 0; i < count; i++) {
         const char *rel = rows[i].rel_path;
         if (!rel || !rel[0] || root_id <= 0) {
+            continue;
+        }
+        /* The missed graph shows FAILURES ("we did not manage") only —
+         * by-design not_indexed_* rows stay out of it, so the UI's
+         * report-an-edge-case callout never fires for gitignored paths. */
+        if (rows[i].kind && strncmp(rows[i].kind, "not_indexed", 11) == 0) {
             continue;
         }
         char pathbuf[CBM_SZ_1K];
@@ -2024,11 +2043,15 @@ int cbm_store_coverage_replace(cbm_store_t *s, const char *project, const cbm_co
         sqlite3_reset(ins);
     }
     sqlite3_finalize(ins);
-    /* Prune rows for files no longer known to the index (deleted from the
-     * repo): file_hashes is the authoritative live-file set after persist. */
+    /* Prune FAILURE rows for files no longer known to the index (deleted from
+     * the repo): file_hashes is the authoritative live-file set after
+     * persist. By-design not_indexed_* rows are exempt — deliberately
+     * unindexed paths never have hash rows (discovery rewrites them fresh
+     * every run instead). */
     sqlite3_stmt *prune = NULL;
     if (sqlite3_prepare_v2(s->db,
-                           "DELETE FROM index_coverage WHERE project = ?1 AND rel_path NOT IN "
+                           "DELETE FROM index_coverage WHERE project = ?1 "
+                           "AND kind NOT LIKE 'not_indexed%' AND rel_path NOT IN "
                            "(SELECT rel_path FROM file_hashes WHERE project = ?1);",
                            CBM_NOT_FOUND, &prune, NULL) == SQLITE_OK) {
         bind_text(prune, SKIP_ONE, project);

--- a/tests/test_index_resilience.c
+++ b/tests/test_index_resilience.c
@@ -514,9 +514,147 @@ TEST(index_parse_partial_clears_on_fix) {
     PASS();
 }
 
+/* INV(not-indexed-by-design, #963): files/dirs dropped by ignore rules are a
+ * deliberate, deterministic class — reported as such and NEVER mixed into the
+ * failure surfaces:
+ *   - response: "not_indexed_files" lists the gitignored file with its reason
+ *     and the by-design note; "excluded" lists the ignored dir; the failure
+ *     surfaces stay clean (skipped_count == 0, parse_partial_count == 0),
+ *   - index_status: "not_indexed" carries dirs + files with the note,
+ *   - the missed graph (failures only) does NOT contain them — the UI's
+ *     report-an-edge-case callout must never fire for gitignored paths,
+ *   - the persisted rows survive a re-index (the deleted-file prune must not
+ *     eat them — deliberately-unindexed paths have no file_hashes rows). */
+TEST(index_not_indexed_by_design_reported) {
+    RProj lp;
+    memset(&lp, 0, sizeof(lp));
+    snprintf(lp.tmpdir, sizeof(lp.tmpdir), "/tmp/cbm_resil_XXXXXX");
+    if (!cbm_mkdtemp(lp.tmpdir)) {
+        FAIL("mkdtemp failed");
+    }
+    rh_to_fwd_slashes(lp.tmpdir);
+
+    ri_write_text(lp.tmpdir, ".gitignore", "secret.py\ngenerated/\n");
+    ri_write_text(lp.tmpdir, "good.py", "def alpha():\n    return 1\n");
+    ri_write_text(lp.tmpdir, "secret.py", "def hidden():\n    return 42\n");
+    char gen_dir[700];
+    snprintf(gen_dir, sizeof(gen_dir), "%s/generated", lp.tmpdir);
+    cbm_mkdir(gen_dir);
+    ri_write_text(gen_dir, "gen.py", "def generated():\n    return 3\n");
+
+    char *resp = NULL;
+    cbm_store_t *store = ri_index_capture(&lp, &resp);
+    if (!resp) {
+        FAIL("no MCP response");
+    }
+    if (!store) {
+        free(resp);
+        FAIL("store did not open");
+    }
+
+    yyjson_doc *d = yyjson_read(resp, strlen(resp), 0);
+    ASSERT_NOT_NULL(d);
+    yyjson_val *sc = yyjson_obj_get(yyjson_doc_get_root(d), "structuredContent");
+    ASSERT_NOT_NULL(sc);
+
+    /* By design ≠ failure: both failure surfaces stay clean. */
+    ASSERT_STR_EQ("indexed", yyjson_get_str(yyjson_obj_get(sc, "status")));
+    ASSERT_EQ(yyjson_get_int(yyjson_obj_get(sc, "skipped_count")), 0);
+    ASSERT_EQ(yyjson_get_int(yyjson_obj_get(sc, "parse_partial_count")), 0);
+
+    /* The gitignored FILE is listed with its reason + the by-design note. */
+    ASSERT_GTE(yyjson_get_int(yyjson_obj_get(sc, "not_indexed_files_count")), 1);
+    yyjson_val *ni = yyjson_obj_get(sc, "not_indexed_files");
+    ASSERT_NOT_NULL(ni);
+    yyjson_val *files = yyjson_obj_get(ni, "files");
+    ASSERT_NOT_NULL(files);
+    int found_secret = 0;
+    size_t idx = 0;
+    size_t fmax = 0;
+    yyjson_val *fe = NULL;
+    yyjson_arr_foreach(files, idx, fmax, fe) {
+        const char *fp = yyjson_get_str(yyjson_obj_get(fe, "path"));
+        const char *reason = yyjson_get_str(yyjson_obj_get(fe, "reason"));
+        if (fp && strcmp(fp, "secret.py") == 0) {
+            found_secret = 1;
+            ASSERT_NOT_NULL(reason);
+            ASSERT_STR_EQ("gitignore", reason);
+        }
+    }
+    ASSERT_TRUE(found_secret);
+    const char *note = yyjson_get_str(yyjson_obj_get(ni, "note"));
+    ASSERT_NOT_NULL(note);
+    ASSERT_NOT_NULL(strstr(note, "BY DESIGN"));
+
+    /* The gitignored DIR is in the excluded subtrees list. */
+    yyjson_val *excluded = yyjson_obj_get(sc, "excluded");
+    ASSERT_NOT_NULL(excluded);
+    char *excl_json = yyjson_val_write(excluded, 0, NULL);
+    ASSERT_NOT_NULL(excl_json);
+    ASSERT_NOT_NULL(strstr(excl_json, "generated"));
+    free(excl_json);
+
+    /* index_status carries the persisted by-design section. */
+    char qargs[900];
+    snprintf(qargs, sizeof(qargs), "{\"project\":\"%s\"}", lp.project);
+    char *sresp = cbm_mcp_handle_tool(lp.srv, "index_status", qargs);
+    ASSERT_NOT_NULL(sresp);
+    ASSERT_NOT_NULL(strstr(sresp, "not_indexed"));
+    ASSERT_NOT_NULL(strstr(sresp, "secret.py"));
+    ASSERT_NOT_NULL(strstr(sresp, "generated"));
+    ASSERT_NOT_NULL(strstr(sresp, "BY DESIGN"));
+    free(sresp);
+
+    /* The missed graph shows FAILURES only — no by-design paths, so the UI
+     * callout can never fire for them. */
+    snprintf(qargs, sizeof(qargs),
+             "{\"project\":\"%s\",\"graph\":\"missed\",\"query\":\"MATCH (f) RETURN "
+             "f.file_path\"}",
+             lp.project);
+    char *gresp = cbm_mcp_handle_tool(lp.srv, "query_graph", qargs);
+    ASSERT_NOT_NULL(gresp);
+    ASSERT_NULL(strstr(gresp, "secret.py"));
+    ASSERT_NULL(strstr(gresp, "generated"));
+    free(gresp);
+
+    /* Re-index (DB exists → incremental route): the by-design rows survive
+     * the rebuild + deleted-file prune and stay fresh. */
+    char iargs[700];
+    snprintf(iargs, sizeof(iargs), "{\"repo_path\":\"%s\"}", lp.tmpdir);
+    char *resp2 = cbm_mcp_handle_tool(lp.srv, "index_repository", iargs);
+    ASSERT_NOT_NULL(resp2);
+    free(resp2);
+    char *sresp2 = cbm_mcp_handle_tool(lp.srv, "index_status", qargs);
+    ASSERT_NOT_NULL(sresp2);
+    ASSERT_NOT_NULL(strstr(sresp2, "secret.py"));
+    ASSERT_NOT_NULL(strstr(sresp2, "generated"));
+    free(sresp2);
+
+    /* The ignored constructs are genuinely absent from the graph (label
+     * counts include <python-builtins> stubs, so assert by name). */
+    cbm_node_t *hits = NULL;
+    int hit_count = 0;
+    ASSERT_EQ(cbm_store_find_nodes_by_name(store, lp.project, "hidden", &hits, &hit_count),
+              CBM_STORE_OK);
+    ASSERT_EQ(hit_count, 0);
+    cbm_store_free_nodes(hits, hit_count);
+    hits = NULL;
+    hit_count = 0;
+    ASSERT_EQ(cbm_store_find_nodes_by_name(store, lp.project, "alpha", &hits, &hit_count),
+              CBM_STORE_OK);
+    ASSERT_GTE(hit_count, 1); /* the non-ignored neighbor IS indexed */
+    cbm_store_free_nodes(hits, hit_count);
+
+    yyjson_doc_free(d);
+    free(resp);
+    rh_cleanup(&lp, store);
+    PASS();
+}
+
 SUITE(index_resilience) {
     RUN_TEST(index_oversized_file_reported);
     RUN_TEST(index_clean_run_no_logfile);
     RUN_TEST(index_parse_partial_reported);
     RUN_TEST(index_parse_partial_clears_on_fix);
+    RUN_TEST(index_not_indexed_by_design_reported);
 }

--- a/tests/test_store_nodes.c
+++ b/tests/test_store_nodes.c
@@ -1606,20 +1606,35 @@ TEST(store_coverage_roundtrip_prune_shadow) {
     cbm_coverage_row_t rows[] = {
         {.rel_path = "src/a.py", .kind = "parse_partial", .detail = "4-7"},
         {.rel_path = "gone.py", .kind = "oversized", .detail = "too big"},
+        /* By-design rows (#963): neither has a file_hashes row, yet both must
+         * SURVIVE the deleted-file prune (deliberately-unindexed paths never
+         * have hashes) — and must stay OUT of the shadow miss graph. */
+        {.rel_path = "secret.py", .kind = "not_indexed_file", .detail = "gitignore"},
+        {.rel_path = "generated", .kind = "not_indexed_dir", .detail = "excluded subtree"},
     };
-    ASSERT_EQ(cbm_store_coverage_replace(s, "test", rows, 2), CBM_STORE_OK);
+    ASSERT_EQ(cbm_store_coverage_replace(s, "test", rows, 4), CBM_STORE_OK);
 
     cbm_coverage_row_t *got = NULL;
     int n = 0;
     ASSERT_EQ(cbm_store_coverage_get(s, "test", &got, &n), CBM_STORE_OK);
-    ASSERT_EQ(n, 1); /* gone.py pruned — no file_hashes row */
-    ASSERT_STR_EQ(got[0].rel_path, "src/a.py");
-    ASSERT_STR_EQ(got[0].kind, "parse_partial");
-    ASSERT_STR_EQ(got[0].detail, "4-7");
+    ASSERT_EQ(n, 3); /* gone.py pruned — no file_hashes row; by-design rows kept */
+    int saw_partial = 0;
+    int saw_by_design = 0;
+    for (int i = 0; i < n; i++) {
+        if (strcmp(got[i].kind, "parse_partial") == 0) {
+            saw_partial++;
+        }
+        if (strncmp(got[i].kind, "not_indexed", 11) == 0) {
+            saw_by_design++;
+        }
+    }
+    ASSERT_EQ(saw_partial, 1);
+    ASSERT_EQ(saw_by_design, 2);
     cbm_store_free_coverage(got, n);
 
-    /* Shadow miss-graph materialized under "test::missed":
-     * Project → Folder(src) → File(a.py){kind,detail}. */
+    /* Shadow miss-graph materialized under "test::missed": FAILURES only —
+     * Project → Folder(src) → File(a.py){kind,detail}; the by-design rows do
+     * not appear. */
     cbm_node_t *nodes = NULL;
     int nc = 0;
     ASSERT_EQ(cbm_store_find_nodes_by_label(s, "test::missed", "File", &nodes, &nc), CBM_STORE_OK);


### PR DESCRIPTION
## Summary

Completes the #963 coverage taxonomy. The coverage report now distinguishes three classes:

| class | meaning | nature |
|---|---|---|
| `parse_partial` | indexed, but constructs in flagged ranges MAY be missing | best-effort |
| `skipped` | not indexed at all (oversized/read/parse failure) | best-effort |
| **`not_indexed`** (new) | **deliberately excluded — gitignore/.cbmignore/skip-lists** | **deterministic, by design** |

## What it does

- **Discovery** classifies every per-file skip by reason (`gitignore`, `cbmignore`, `skip-list`, `ignored-suffix`, `fast-pattern`, `size-cap`) via the new `cbm_discover_ex2`. Per-file entries are capped at 2000 with the uncapped total always reported — truncation is explicit, never silent. Excluded subtrees stay exhaustive. Unsupported-extension files are deliberately NOT listed (not an ignore decision; would drown the signal).
- **Persistence**: `not_indexed_file` / `not_indexed_dir` rows in the same `index_coverage` table, rewritten fresh from discovery on every run (full and incremental); exempt from the deleted-file prune (deliberately-unindexed paths have no hash rows).
- **Reporting**: `index_repository` gains `not_indexed_files` (+ always-present `not_indexed_files_count`); `index_status`'s coverage report gains a `not_indexed` section (dirs + files + note). The note frames the class as deliberate: *not an error — change the ignore rules and re-index to include them.*
- **Strict separation from failures**: by-design rows never appear in `skipped`/`parse_partial`, never enter the missed shadow graph, and can never trigger the UI's report-an-edge-case callout.

## Tests

- e2e (`test_index_resilience.c`): gitignored file + dir reported with reasons on both surfaces; failure surfaces stay clean; missed graph excludes them; rows survive an incremental re-index; the ignored constructs are genuinely absent from the graph while neighbors are indexed.
- store unit test: prune exemption + shadow-graph exclusion.
- Live CLI check: `{path: secret.py, reason: gitignore}` + `excluded dirs: [vendor]` with `skipped: 0, parse_partial: 0`.

Local: 814 tests across affected suites green (ASan/UBSan), lint-format + lint-cppcheck clean.

Refs #963 — closes out the issue's remaining scope once merged.