### PR TITLE
feat(codex): install codebase-memory skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,8 +374,8 @@ Restart your agent. Verify with `/mcp` — you should see `codebase-memory-mcp` 
 
 | Agent | MCP Config | Instructions | Hooks |
 |-------|-----------|-------------|-------|
-| Claude Code | `.claude/.mcp.json` | 4 Skills | PreToolUse (Grep/Glob graph augment, non-blocking) |
-| Codex CLI | `.codex/config.toml` | `.codex/AGENTS.md` | SessionStart reminder |
+| Claude Code | `.claude/.mcp.json` | 1 Skill (`codebase-memory`) | PreToolUse (Grep/Glob graph augment, non-blocking) + SessionStart + SubagentStart |
+| Codex CLI | `.codex/config.toml` | `.codex/AGENTS.md` + 1 Skill (`codebase-memory`) | SessionStart reminder |
 | Gemini CLI | `.gemini/settings.json` | `.gemini/GEMINI.md` | BeforeTool (grep reminder) + SessionStart reminder |
 | Zed | `settings.json` (JSONC) | — | — |
 | OpenCode | `opencode.json` | `AGENTS.md` | — |

--- a/scripts/security-install.sh
+++ b/scripts/security-install.sh
@@ -49,6 +49,7 @@ find "$HOME" -type f > "$TMPDIR/created_files.txt" 2>/dev/null || true
 # Expected path patterns (relative to HOME):
 #   .config/*/mcp.json (or .mcp.json variants)
 #   .claude/skills/*
+#   .agents/skills/*
 #   .claude/settings.json
 #   .continue/config.yaml
 #   .codeium/config.json
@@ -56,6 +57,7 @@ find "$HOME" -type f > "$TMPDIR/created_files.txt" 2>/dev/null || true
 #   Various agent config dirs
 
 EXPECTED_PATTERNS=(
+    ".agents/"
     ".claude/"
     ".cursor/"
     ".config/"
@@ -121,10 +123,18 @@ fi
 echo ""
 echo "--- Auditing skill file content ---"
 
-SKILLS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills"
-if [[ -d "$SKILLS_DIR" ]]; then
-    SKILL_ISSUES=0
+SKILL_DIRS=(
+    "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills"
+    "$HOME/.agents/skills"
+)
+SKILL_ISSUES=0
+SKILL_DIRS_FOUND=0
 
+for SKILLS_DIR in "${SKILL_DIRS[@]}"; do
+    if [[ ! -d "$SKILLS_DIR" ]]; then
+        continue
+    fi
+    SKILL_DIRS_FOUND=1
     while IFS= read -r skill_file; do
         basename=$(basename "$skill_file")
 
@@ -138,11 +148,11 @@ if [[ -d "$SKILLS_DIR" ]]; then
         done
 
         # Check for unexpected URLs
-        if grep -oE 'https?://[^\s"'"'"']+' "$skill_file" 2>/dev/null | grep -v 'github.com/DeusData' | grep -v 'localhost' | grep -v '127.0.0.1' > /tmp/sec_skill_urls 2>/dev/null; then
+        if grep -oE 'https?://[^\s"'"'"']+' "$skill_file" 2>/dev/null | grep -v 'github.com/DeusData' | grep -v 'localhost' | grep -v '127.0.0.1' > "$TMPDIR/sec_skill_urls" 2>/dev/null; then
             while IFS= read -r url; do
                 echo "REVIEW: Skill '$basename' contains URL: $url"
-            done < /tmp/sec_skill_urls
-            rm -f /tmp/sec_skill_urls
+            done < "$TMPDIR/sec_skill_urls"
+            rm -f "$TMPDIR/sec_skill_urls"
         fi
 
         # Check for encoded strings (base64-like blocks > 50 chars)
@@ -150,12 +160,14 @@ if [[ -d "$SKILLS_DIR" ]]; then
             echo "REVIEW: Skill '$basename' contains potential encoded content"
         fi
     done < <(find "$SKILLS_DIR" -type f -name '*.md')
+done
 
+if [[ $SKILL_DIRS_FOUND -eq 0 ]]; then
+    echo "SKIP: No skills directory created."
+else
     if [[ $SKILL_ISSUES -eq 0 ]]; then
         echo "OK: Skill files contain no dangerous patterns."
     fi
-else
-    echo "SKIP: No skills directory created."
 fi
 
 # ── Summary ──────────────────────────────────────────────────────

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -981,6 +981,14 @@ if [ ! -f "$FAKE_HOME/.codex/AGENTS.md" ] || ! grep -q 'codebase-memory-mcp' "$F
 fi
 echo "OK 8i: Codex instructions"
 
+# 8i2: Codex user skill
+CODEX_SKILL_FILE="$FAKE_HOME/.agents/skills/codebase-memory/SKILL.md"
+if [ ! -s "$CODEX_SKILL_FILE" ] || ! grep -q 'Quick Decision Matrix' "$CODEX_SKILL_FILE"; then
+  echo "FAIL 8i2: Codex codebase-memory skill missing or incomplete"
+  exit 1
+fi
+echo "OK 8i2: Codex skill installed"
+
 # 8j-l: Gemini MCP + hooks + merge
 CMD=$(json_get "$FAKE_HOME/.gemini/settings.json" "d['mcpServers']['codebase-memory-mcp']['command']")
 if ! path_match "$CMD" "$SELF_PATH"; then
@@ -1200,6 +1208,11 @@ if ! grep -q 'existing_section' "$FAKE_HOME/.codex/config.toml" 2>/dev/null; the
   exit 1
 fi
 echo "OK 9e-f: Codex TOML cleaned, existing preserved"
+if [ -d "$FAKE_HOME/.agents/skills/codebase-memory" ]; then
+  echo "FAIL 9f2: Codex skill not removed"
+  exit 1
+fi
+echo "OK 9f2: Codex skill removed"
 
 # 9g-i: Gemini MCP removed, existing preserved, hooks removed
 if cat "$FAKE_HOME/.gemini/settings.json" 2>/dev/null | python3 -c "

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -698,6 +698,35 @@ int cbm_remove_skills(const char *skills_dir, bool dry_run) {
     return count;
 }
 
+static void cbm_codex_skills_dir(const char *home_dir, char *out, size_t out_sz) {
+    if (out_sz == 0) {
+        return;
+    }
+    out[0] = '\0';
+    if (!home_dir || !home_dir[0]) {
+        return;
+    }
+    snprintf(out, out_sz, "%s/.agents/skills", home_dir);
+}
+
+int cbm_install_codex_skills(const char *home_dir, bool force, bool dry_run) {
+    char skills_dir[CLI_BUF_1K];
+    cbm_codex_skills_dir(home_dir, skills_dir, sizeof(skills_dir));
+    if (!skills_dir[0]) {
+        return 0;
+    }
+    return cbm_install_skills(skills_dir, force, dry_run);
+}
+
+int cbm_remove_codex_skills(const char *home_dir, bool dry_run) {
+    char skills_dir[CLI_BUF_1K];
+    cbm_codex_skills_dir(home_dir, skills_dir, sizeof(skills_dir));
+    if (!skills_dir[0]) {
+        return 0;
+    }
+    return cbm_remove_skills(skills_dir, dry_run);
+}
+
 bool cbm_remove_old_monolithic_skill(const char *skills_dir, bool dry_run) {
     if (!skills_dir) {
         return false;
@@ -3352,14 +3381,22 @@ static void install_gemini_config(const char *home, const char *binary_path, boo
 }
 
 static void install_cli_agent_configs(const cbm_detected_agents_t *agents, const char *home,
-                                      const char *binary_path, bool dry_run) {
+                                      const char *binary_path, bool force, bool dry_run) {
     if (agents->codex) {
         char cp[CLI_BUF_1K];
         char ip[CLI_BUF_1K];
+        char sp[CLI_BUF_1K];
         snprintf(cp, sizeof(cp), "%s/.codex/config.toml", home);
         snprintf(ip, sizeof(ip), "%s/.codex/AGENTS.md", home);
+        cbm_codex_skills_dir(home, sp, sizeof(sp));
         install_generic_agent_config("Codex CLI", binary_path, cp, ip, dry_run,
                                      cbm_upsert_codex_mcp);
+        if (g_install_plan) {
+            plan_record("Codex CLI", "skills", sp);
+        } else {
+            int skill_count = cbm_install_codex_skills(home, force, dry_run);
+            printf("  skills: %d installed\n", skill_count);
+        }
         /* Choose the hook target: if ~/.codex/hooks.json already exists, the
          * user manages Codex hooks via the JSON representation — write the
          * SessionStart reminder there instead of config.toml. Writing both
@@ -3559,7 +3596,7 @@ static void cbm_install_agent_configs(const char *home, const char *binary_path,
     if (agents.claude_code) {
         install_claude_code_config(home, binary_path, force, dry_run);
     }
-    install_cli_agent_configs(&agents, home, binary_path, dry_run);
+    install_cli_agent_configs(&agents, home, binary_path, force, dry_run);
     install_editor_agent_configs(&agents, home, binary_path, dry_run);
 }
 
@@ -3978,6 +4015,8 @@ static void uninstall_cli_agents(const cbm_detected_agents_t *agents, const char
         if (!dry_run) {
             cbm_remove_codex_hooks(cp);
         }
+        int removed = cbm_remove_codex_skills(home, dry_run);
+        printf("  removed skills: %d\n", removed);
     }
     if (agents->gemini) {
         uninstall_gemini_config(home, dry_run);

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -95,6 +95,11 @@ int cbm_install_skills(const char *skills_dir, bool force, bool dry_run);
  * Returns count of skills removed. */
 int cbm_remove_skills(const char *skills_dir, bool dry_run);
 
+/* Install/remove Codex user skills in ~/.agents/skills.
+ * Returns count of skills written/removed. */
+int cbm_install_codex_skills(const char *home_dir, bool force, bool dry_run);
+int cbm_remove_codex_skills(const char *home_dir, bool dry_run);
+
 /* Remove old monolithic skill dir if it exists.
  * Returns true if it was removed. */
 bool cbm_remove_old_monolithic_skill(const char *skills_dir, bool dry_run);

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -519,6 +519,73 @@ TEST(cli_uninstall_removes_skills) {
     PASS();
 }
 
+TEST(cli_codex_skill_install_uses_agents_dir) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-codex-skill-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    int written = cbm_install_codex_skills(tmpdir, false, false);
+    ASSERT_EQ(written, CBM_SKILL_COUNT);
+
+    char path[1024];
+    snprintf(path, sizeof(path), "%s/.agents/skills/codebase-memory/SKILL.md", tmpdir);
+    const char *data = read_test_file(path);
+    ASSERT_NOT_NULL(data);
+    ASSERT(strstr(data, "name: codebase-memory") != NULL);
+    ASSERT(strstr(data, "Quick Decision Matrix") != NULL);
+
+    int second = cbm_install_codex_skills(tmpdir, false, false);
+    ASSERT_EQ(second, 0);
+
+    test_rmdir_r(tmpdir);
+    PASS();
+}
+
+TEST(cli_codex_skill_force_overwrite) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-codex-skill-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    ASSERT_EQ(cbm_install_codex_skills(tmpdir, false, false), CBM_SKILL_COUNT);
+
+    char path[1024];
+    snprintf(path, sizeof(path), "%s/.agents/skills/codebase-memory/SKILL.md", tmpdir);
+    write_test_file(path, "stale skill content\n");
+
+    ASSERT_EQ(cbm_install_codex_skills(tmpdir, false, false), 0);
+    const char *data = read_test_file(path);
+    ASSERT_NOT_NULL(data);
+    ASSERT(strstr(data, "stale skill content") != NULL);
+
+    ASSERT_EQ(cbm_install_codex_skills(tmpdir, true, false), CBM_SKILL_COUNT);
+    data = read_test_file(path);
+    ASSERT_NOT_NULL(data);
+    ASSERT(strstr(data, "Quick Decision Matrix") != NULL);
+
+    test_rmdir_r(tmpdir);
+    PASS();
+}
+
+TEST(cli_codex_skill_uninstall_removes_agents_dir_skill) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-codex-skill-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    ASSERT_EQ(cbm_install_codex_skills(tmpdir, false, false), CBM_SKILL_COUNT);
+    ASSERT_EQ(cbm_remove_codex_skills(tmpdir, false), CBM_SKILL_COUNT);
+
+    char path[1024];
+    snprintf(path, sizeof(path), "%s/.agents/skills/codebase-memory", tmpdir);
+    struct stat st;
+    ASSERT(stat(path, &st) != 0);
+
+    test_rmdir_r(tmpdir);
+    PASS();
+}
+
 TEST(cli_remove_old_monolithic_skill) {
     /* Port of TestRemoveOldMonolithicSkill */
     char tmpdir[256];
@@ -1761,6 +1828,7 @@ TEST(cli_install_plan_receipt_no_mutation_issue388) {
     ASSERT(strstr(json, "cursor") != NULL);
     ASSERT(strstr(json, ".cursor/mcp.json") != NULL);
     ASSERT(strstr(json, ".codex/config.toml") != NULL);
+    ASSERT(strstr(json, ".agents/skills") != NULL);
     free(json);
 
     /* Critical: building the plan must NOT have created any config file. */
@@ -1769,6 +1837,8 @@ TEST(cli_install_plan_receipt_no_mutation_issue388) {
     snprintf(cfg, sizeof(cfg), "%s/.cursor/mcp.json", tmpdir);
     ASSERT(stat(cfg, &st) != 0); /* must not exist */
     snprintf(cfg, sizeof(cfg), "%s/.codex/config.toml", tmpdir);
+    ASSERT(stat(cfg, &st) != 0); /* must not exist */
+    snprintf(cfg, sizeof(cfg), "%s/.agents/skills/codebase-memory/SKILL.md", tmpdir);
     ASSERT(stat(cfg, &st) != 0); /* must not exist */
 
     test_rmdir_r(tmpdir);
@@ -3085,6 +3155,9 @@ SUITE(cli) {
     RUN_TEST(cli_skill_idempotent);
     RUN_TEST(cli_skill_force_overwrite);
     RUN_TEST(cli_uninstall_removes_skills);
+    RUN_TEST(cli_codex_skill_install_uses_agents_dir);
+    RUN_TEST(cli_codex_skill_force_overwrite);
+    RUN_TEST(cli_codex_skill_uninstall_removes_agents_dir_skill);
     RUN_TEST(cli_remove_old_monolithic_skill);
     RUN_TEST(cli_skill_files_content);
     RUN_TEST(cli_codex_instructions);


### PR DESCRIPTION
## Summary

- install the existing consolidated codebase-memory Skill for Codex users under HOME/.agents/skills/codebase-memory/SKILL.md
- preserve .codex/AGENTS.md as the lightweight always-loaded guidance while using the Skill for progressive-disclosure workflows
- include the Codex skill path in install --plan and remove the managed skill during uninstall
- update smoke/security install checks and the README multi-agent table

Closes #976

## Testing

- ./build/c/test-runner cli
- make -f Makefile.cbm cbm
- bash -n scripts/security-install.sh
- bash -n scripts/smoke-test.sh
- fake HOME install --plan check for .agents/skills without mutation
- fake HOME install/uninstall cycle verifying Codex skill write/remove and existing config preservation
- bash scripts/security-install.sh build/c/codebase-memory-mcp

Note: make -f Makefile.cbm test currently exits nonzero in existing graph/edge regression suites with no graph DB; the touched CLI suite passes.