### PR TITLE
Fix tools/list default pagination for non-paginating clients

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -621,7 +621,10 @@ const char *cbm_mcp_tool_input_schema(const char *tool_name) {
     return NULL;
 }
 
-static int mcp_tools_cursor_offset(const char *params_json) {
+static int mcp_tools_cursor_offset(const char *params_json, bool *has_cursor_out) {
+    if (has_cursor_out) {
+        *has_cursor_out = false;
+    }
     if (!params_json) {
         return 0;
     }
@@ -635,6 +638,9 @@ static int mcp_tools_cursor_offset(const char *params_json) {
     yyjson_val *root = yyjson_doc_get_root(doc);
     yyjson_val *cursor = root ? yyjson_obj_get(root, "cursor") : NULL;
     if (cursor) {
+        if (has_cursor_out) {
+            *has_cursor_out = true;
+        }
         offset = TOOL_COUNT;
         if (yyjson_is_str(cursor)) {
             const char *cursor_str = yyjson_get_str(cursor);
@@ -654,8 +660,12 @@ static int mcp_tools_cursor_offset(const char *params_json) {
 }
 
 static char *cbm_mcp_tools_list_page(const char *params_json) {
-    return cbm_mcp_tools_list_range(mcp_tools_cursor_offset(params_json), MCP_TOOLS_PAGE_SIZE,
-                                    true);
+    bool has_cursor = false;
+    int offset = mcp_tools_cursor_offset(params_json, &has_cursor);
+    if (!has_cursor) {
+        return cbm_mcp_tools_list();
+    }
+    return cbm_mcp_tools_list_range(offset, MCP_TOOLS_PAGE_SIZE, true);
 }
 
 /* Supported protocol versions, newest first. The server picks the newest

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -586,16 +586,26 @@ TEST(server_handle_tools_list) {
     PASS();
 }
 
-TEST(server_handle_tools_list_paginates) {
+TEST(server_handle_tools_list_defaults_to_all_tools_and_accepts_cursor) {
     cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
 
     char *resp =
         cbm_mcp_server_handle(srv, "{\"jsonrpc\":\"2.0\",\"id\":200,\"method\":\"tools/list\"}");
     ASSERT_NOT_NULL(resp);
     ASSERT_NOT_NULL(strstr(resp, "\"id\":200"));
-    ASSERT_NOT_NULL(strstr(resp, "\"nextCursor\":\"8\""));
+    ASSERT_NULL(strstr(resp, "\"nextCursor\""));
     ASSERT_NOT_NULL(strstr(resp, "index_repository"));
-    ASSERT_NULL(strstr(resp, "manage_adr"));
+    ASSERT_NOT_NULL(strstr(resp, "manage_adr"));
+    ASSERT_NOT_NULL(strstr(resp, "ingest_traces"));
+    free(resp);
+
+    resp = cbm_mcp_server_handle(
+        srv, "{\"jsonrpc\":\"2.0\",\"id\":202,\"method\":\"tools/list\",\"params\":{}}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "\"id\":202"));
+    ASSERT_NULL(strstr(resp, "\"nextCursor\""));
+    ASSERT_NOT_NULL(strstr(resp, "manage_adr"));
+    ASSERT_NOT_NULL(strstr(resp, "ingest_traces"));
     free(resp);
 
     resp = cbm_mcp_server_handle(
@@ -5026,7 +5036,7 @@ SUITE(mcp) {
     RUN_TEST(server_handle_initialize);
     RUN_TEST(server_handle_initialized_notification);
     RUN_TEST(server_handle_tools_list);
-    RUN_TEST(server_handle_tools_list_paginates);
+    RUN_TEST(server_handle_tools_list_defaults_to_all_tools_and_accepts_cursor);
     RUN_TEST(server_handle_logs_request_without_params);
     RUN_TEST(server_handle_unknown_method);
 


### PR DESCRIPTION
## What does this PR do?

Fixes #971.

`tools/list` now returns all currently registered tools when a client does not provide a cursor, including the `params:{}` request shape used by some JSON-RPC clients. Explicit cursor requests still use the existing paged response path, so compliant paginating clients can continue to request suffix pages.

This keeps the MCP pagination machinery in place while avoiding the v0.9.0 compatibility regression where non-paginating clients only exposed the first 8 of 14 tools.

Local proof:

- `build/c/test-runner mcp` passed with `144 passed`.
- `scripts/build.sh` passed and built `build/c/codebase-memory-mcp`.
- JSON-RPC stdio probe against `build/c/codebase-memory-mcp --ui=false` returned 14 tools and no `nextCursor` for default `tools/list`, and still returned the 6 suffix tools for explicit cursor `8`.
- `make -f Makefile.cbm lint-ci` passed.

Caveat: full `make -f Makefile.cbm test` is not green in this checkout; it reported `4927 passed, 859 failed, 1 skipped` from broad grammar/matrix probe failures plus a network-offline clone setup that do not involve the touched MCP handler path. The focused MCP suite and issue-level binary proof above pass.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Tests pass locally (`make -f Makefile.cbm test`)
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)
