### PR TITLE
fix: resolve C/C++ includes to header file targets by matching stems

### DIFF
--- a/internal/cbm/extract_defs.c
+++ b/internal/cbm/extract_defs.c
@@ -5540,8 +5540,8 @@ static void extract_class_fields(CBMExtractCtx *ctx, TSNode class_node, const ch
          * For the nested case, the child has no "type" field directly. Detect by
          * walking named children for a variable_declaration. */
         TSNode type_node = ts_node_child_by_field_name(child, TS_FIELD("type"));
-        TSNode name_node =
-            ts_node_is_null(type_node) ? (TSNode){0} : resolve_field_name_node(child);
+        TSNode empty_node = {0};
+        TSNode name_node = ts_node_is_null(type_node) ? empty_node : resolve_field_name_node(child);
 
         if (ts_node_is_null(type_node)) {
             uint32_t cnc = ts_node_named_child_count(child);

--- a/src/pipeline/pass_pkgmap.c
+++ b/src/pipeline/pass_pkgmap.c
@@ -426,8 +426,12 @@ static void parse_pyproject_toml(const char *source, int source_len, const char 
     pkg_entries_push(entries, name, entry);
 
     /* Also register <name>/__init__ as alternative (no src/ prefix) */
-    snprintf(suffix, sizeof(suffix), "%s/__init__", name_copy);
-    char *alt_entry = build_entry_path(rel_path, suffix);
+    char *alt_entry = NULL;
+    if (name_copy) {
+        snprintf(suffix, sizeof(suffix), "%s/__init__", name_copy);
+        alt_entry = build_entry_path(rel_path, suffix);
+    }
+
     if (name_copy && alt_entry) {
         pkg_entries_push(entries, name_copy, alt_entry);
     } else {
@@ -1265,6 +1269,151 @@ static bool import_targetable_label(const char *label) {
     return false;
 }
 
+static const char *path_leaf(const char *path) {
+    const char *leaf = path;
+    for (const char *p = path; p && *p; p++) {
+        if (*p == '/' || *p == '\\') {
+            leaf = p + 1;
+        }
+    }
+    return leaf;
+}
+
+static bool is_header_include(const char *path) {
+    if (!path || !path[0]) {
+        return false;
+    }
+    static const char *header_exts[] = {".h", ".hh", ".hpp", ".hxx", ".inc", ".inl", ".ipp", NULL};
+    for (const char **ext = header_exts; *ext; ext++) {
+        size_t path_len = strlen(path);
+        size_t ext_len = strlen(*ext);
+        if (path_len > ext_len && strcmp(path + path_len - ext_len, *ext) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool is_c_family_source(const char *source_rel) {
+    if (!source_rel || !source_rel[0]) {
+        return false;
+    }
+    static const char *exts[] = {".c", ".cc", ".cpp", ".cxx", ".c++",
+                                 ".h", ".hh", ".hpp", ".hxx", NULL};
+    for (const char **ext = exts; *ext; ext++) {
+        size_t path_len = strlen(source_rel);
+        size_t ext_len = strlen(*ext);
+        if (path_len > ext_len && strcmp(source_rel + path_len - ext_len, *ext) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static const cbm_gbuf_node_t *resolve_exact_file_node(const cbm_pipeline_ctx_t *ctx,
+                                                      const char *file_path,
+                                                      const char *source_file_qn) {
+    if (!ctx || !file_path || !file_path[0]) {
+        return NULL;
+    }
+
+    const char *leaf = path_leaf(file_path);
+    if (!leaf || !leaf[0]) {
+        return NULL;
+    }
+
+    char stem[PKGMAP_PATH_BUF];
+    snprintf(stem, sizeof(stem), "%s", leaf);
+    char *last_dot = strrchr(stem, '.');
+    if (last_dot && last_dot != stem) {
+        *last_dot = '\0';
+    }
+
+    const char *names[2] = {stem[0] ? stem : NULL, leaf};
+    const cbm_gbuf_node_t *best = NULL;
+    for (int ni = 0; ni < 2; ni++) {
+        const char *name = names[ni];
+        if (!name || !name[0]) {
+            continue;
+        }
+
+        const cbm_gbuf_node_t **hits = NULL;
+        int hit_count = 0;
+        if (cbm_gbuf_find_by_name(ctx->gbuf, name, &hits, &hit_count) != 0 || !hits) {
+            continue;
+        }
+
+        for (int i = 0; i < hit_count; i++) {
+            const cbm_gbuf_node_t *cand = hits[i];
+            if (!cand || !cand->file_path) {
+                continue;
+            }
+
+            /* Tie-breaker: Ensure the candidate's actual file_path ends with the
+             * specific include path requested (e.g., 'a/util.h' instead of just 'util.h'). */
+            if (!ends_with(cand->file_path, file_path)) {
+                continue;
+            }
+
+            if (!cand->label || !import_targetable_label(cand->label)) {
+                continue;
+            }
+            if (source_file_qn && cand->qualified_name &&
+                strcmp(cand->qualified_name, source_file_qn) == 0) {
+                continue;
+            }
+            if (strcmp(cand->label, "File") == 0) {
+                return cand;
+            }
+            if (!best) {
+                best = cand;
+            }
+        }
+        if (best) {
+            return best;
+        }
+    }
+    return NULL;
+}
+
+static const cbm_gbuf_node_t *resolve_header_include(const cbm_pipeline_ctx_t *ctx,
+                                                     const char *source_rel,
+                                                     const char *source_file_qn,
+                                                     const char *module_path) {
+    if (!is_c_family_source(source_rel) || !is_header_include(module_path)) {
+        return NULL;
+    }
+
+    const char *base = module_path;
+    if (base[0] == '.' && base[1] == '/') {
+        base += 2;
+    }
+
+    const cbm_gbuf_node_t *exact = resolve_exact_file_node(ctx, base, source_file_qn);
+    if (exact) {
+        return exact;
+    }
+
+    if (source_rel && source_rel[0]) {
+        char *dir = path_dirname(source_rel);
+        if (dir) {
+            char candidate[PKGMAP_PATH_BUF];
+            if (dir[0]) {
+                snprintf(candidate, sizeof(candidate), "%s/%s", dir, base);
+            } else {
+                snprintf(candidate, sizeof(candidate), "%s", base);
+            }
+            free(dir);
+            exact = resolve_exact_file_node(ctx, candidate, source_file_qn);
+            if (exact) {
+                return exact;
+            }
+        }
+    }
+
+    return NULL;
+}
+
 /* Resolve a sibling-file import: a bare path/name (no leading "./") that names
  * a file relative to the importer's directory.  This covers build/markup
  * grammars whose import string is a sibling filename or directory rather than a
@@ -1350,6 +1499,14 @@ const cbm_gbuf_node_t *cbm_pipeline_resolve_import_node(const cbm_pipeline_ctx_t
                                                         CBMHashTable *namespace_map) {
     if (!ctx || !imp || !imp->module_path) {
         return NULL;
+    }
+
+    /* Prefer exact header-file nodes for C/C++ includes so same-stem source or
+     * module nodes do not steal the edge target. */
+    const cbm_gbuf_node_t *header_target =
+        resolve_header_include(ctx, source_rel, source_file_qn, imp->module_path);
+    if (header_target) {
+        return header_target;
     }
 
     /* Strategy 1: module-path resolution → existing node (Python/TS/Go).

--- a/tests/fixtures/cpp_include/NodeController.cpp
+++ b/tests/fixtures/cpp_include/NodeController.cpp
@@ -1,0 +1,5 @@
+#include "NodeController.h"
+
+int node_controller_value() {
+    return 1;
+}

--- a/tests/fixtures/cpp_include/NodeController.h
+++ b/tests/fixtures/cpp_include/NodeController.h
@@ -1,0 +1,5 @@
+#pragma once
+
+struct NodeController {
+    int value;
+};

--- a/tests/fixtures/cpp_include/SystemController.cpp
+++ b/tests/fixtures/cpp_include/SystemController.cpp
@@ -1,0 +1,5 @@
+#include "SystemController.h"
+
+int system_controller_value() {
+    return 2;
+}

--- a/tests/fixtures/cpp_include/SystemController.h
+++ b/tests/fixtures/cpp_include/SystemController.h
@@ -1,0 +1,5 @@
+#pragma once
+
+struct SystemController {
+    int value;
+};

--- a/tests/fixtures/cpp_include/main.cpp
+++ b/tests/fixtures/cpp_include/main.cpp
@@ -1,0 +1,6 @@
+#include "NodeController.h"
+#include <SystemController.h>
+
+int main() {
+    return 0;
+}

--- a/tests/test_edge_imports.c
+++ b/tests/test_edge_imports.c
@@ -72,6 +72,10 @@ typedef struct {
     const char *content;
 } EILangFile;
 
+typedef struct {
+    const char *name; /* fixture filename relative to a checked-in fixture root */
+} EILangFixtureFile;
+
 static void ei_to_fwd_slashes(char *p) {
     for (; *p; p++) {
         if (*p == '\\') *p = '/';
@@ -121,6 +125,89 @@ static cbm_store_t *ei_index_files(EILangProj *lp, const EILangFile *files, int 
     if (resp) free(resp);
 
     return cbm_store_open_path(lp->dbpath);
+}
+
+static char *ei_slurp_file(const char *path) {
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return NULL;
+    }
+    long size = ftell(f);
+    if (size < 0) {
+        fclose(f);
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_SET) != 0) {
+        fclose(f);
+        return NULL;
+    }
+    char *buf = (char *)calloc((size_t)size + 1, 1);
+    if (!buf) {
+        fclose(f);
+        return NULL;
+    }
+    size_t nread = fread(buf, 1, (size_t)size, f);
+    fclose(f);
+    buf[nread] = '\0';
+    return buf;
+}
+
+static cbm_store_t *ei_index_fixture_files(EILangProj *lp, const char *fixture_root,
+                                           const EILangFixtureFile *files, int nfiles) {
+    EILangFile *loaded = (EILangFile *)calloc((size_t)nfiles, sizeof(EILangFile));
+    char **contents = (char **)calloc((size_t)nfiles, sizeof(char *));
+    if (!loaded || !contents) {
+        free(loaded);
+        free(contents);
+        return NULL;
+    }
+
+    cbm_store_t *store = NULL;
+    for (int i = 0; i < nfiles; i++) {
+        char path[512];
+        snprintf(path, sizeof(path), "%s/%s", fixture_root, files[i].name);
+        contents[i] = ei_slurp_file(path);
+        if (!contents[i]) {
+            goto done;
+        }
+        loaded[i].name = files[i].name;
+        loaded[i].content = contents[i];
+    }
+
+    store = ei_index_files(lp, loaded, nfiles);
+
+done:
+    for (int i = 0; i < nfiles; i++) {
+        free(contents[i]);
+    }
+    free(contents);
+    free(loaded);
+    return store;
+}
+
+static int64_t ei_node_id_for_file_label(cbm_store_t *store, const char *project,
+                                         const char *file_path, const char *label) {
+    cbm_node_t *nodes = NULL;
+    int count = 0;
+    if (cbm_store_find_nodes_by_file(store, project, file_path, &nodes, &count) != CBM_STORE_OK) {
+        return 0;
+    }
+    int64_t id = 0;
+    for (int i = 0; i < count; i++) {
+        if (nodes[i].label && strcmp(nodes[i].label, label) == 0) {
+            id = nodes[i].id;
+            break;
+        }
+    }
+    if (id == 0 && count > 0) {
+        id = nodes[0].id;
+    }
+    cbm_store_free_nodes(nodes, count);
+    return id;
 }
 
 static void ei_cleanup(EILangProj *lp, cbm_store_t *store) {
@@ -406,6 +493,68 @@ TEST(ei_go_two_consumers_same_package) {
         {"b/b.go",       "package b\n\nimport \"example.com/two/util\"\n\n"
                          "func Run() int { return util.Helper(2) }\n"}};
     ASSERT_TRUE(ei_edge_present(f, 4, "IMPORTS", 2));
+    PASS();
+}
+
+/* C++: header include should resolve to the header file node, not the same-stem
+ * source node. Also exercises angle-bracket include resolution. */
+TEST(ei_cpp_header_include_targets_header_file) {
+    static const EILangFixtureFile fixture_files[] = {
+        {"main.cpp"},
+        {"NodeController.h"},
+        {"NodeController.cpp"},
+        {"SystemController.h"},
+        {"SystemController.cpp"},
+    };
+
+    EILangProj lp;
+    cbm_store_t *store = ei_index_fixture_files(&lp, "tests/fixtures/cpp_include",
+                                                fixture_files,
+                                                (int)(sizeof(fixture_files) / sizeof(fixture_files[0])));
+    ASSERT_NOT_NULL(store);
+
+    int64_t main_id = ei_node_id_for_file_label(store, lp.project, "main.cpp", "File");
+    int64_t node_source_id = ei_node_id_for_file_label(store, lp.project, "NodeController.cpp", "File");
+    int64_t system_source_id = ei_node_id_for_file_label(store, lp.project, "SystemController.cpp", "File");
+
+    ASSERT_GT(main_id, 0);
+    ASSERT_GT(node_source_id, 0);
+    ASSERT_GT(system_source_id, 0);
+
+    cbm_edge_t *edges = NULL;
+    int edge_count = 0;
+    int rc = cbm_store_find_edges_by_source_type(store, main_id, "IMPORTS", &edges, &edge_count);
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_TRUE(edge_count >= 2);
+
+    bool saw_node_header = false;
+    bool saw_system_header = false;
+    for (int i = 0; i < edge_count; i++) {
+        cbm_node_t *target = (cbm_node_t *)calloc(1, sizeof(cbm_node_t));
+        
+        /* Pass target directly (no &) because it is already a pointer */
+        ASSERT_EQ(cbm_store_find_node_by_id(store, edges[i].target_id, target), CBM_STORE_OK);
+        ASSERT_EQ(edges[i].source_id, main_id);
+        ASSERT_NEQ(edges[i].target_id, node_source_id);
+        ASSERT_NEQ(edges[i].target_id, system_source_id);
+        
+        /* Use -> instead of . to access fields on a pointer */
+        if (target->file_path && strcmp(target->file_path, "NodeController.h") == 0) {
+            saw_node_header = true;
+        }
+        if (target->file_path && strcmp(target->file_path, "SystemController.h") == 0) {
+            saw_system_header = true;
+        }
+        
+        /* Free the node inside the loop */
+        cbm_store_free_nodes(target, 1);
+    }
+    cbm_store_free_edges(edges, edge_count);
+
+    ASSERT_TRUE(saw_node_header);
+    ASSERT_TRUE(saw_system_header);
+
+    ei_cleanup(&lp, store);
     PASS();
 }
 
@@ -868,6 +1017,7 @@ SUITE(edge_imports) {
     RUN_TEST(ei_go_subpackage_import);
     RUN_TEST(ei_go_blank_import);
     RUN_TEST(ei_go_two_consumers_same_package);
+    RUN_TEST(ei_cpp_header_include_targets_header_file);
 
     /* ── RED REPRODUCTIONS — Rust (expected to FAIL until pipeline fixed) ── */
     RUN_TEST(ei_rust_mod_plus_use);


### PR DESCRIPTION
Closes #964

## What does this PR do?

Resolves an FQN (Fully Qualified Name) matching collision in the import resolver where C/C++ `#include` directives were incorrectly mapping `IMPORTS` edges to same-stem `.cpp` module nodes instead of the target `.h` header nodes.

**Technical Details & Root Cause:**
* **The Bug:** By dumping and analyzing the temporary SQLite graph database during extraction, it became clear that the graph indexes header content nodes under their FQN stem (e.g., `NodeController`) rather than their full leaf path (`NodeController.h`). 
* **The Collision:** Because the exact-match helper in `pass_pkgmap.c` was strictly querying the full leaf path, the lookup for the header node failed. The resolver then fell back to the FQN module heuristic, which blindly grabbed the `.cpp` source node since it shared the exact same `NodeController` stem.
* **The Fix:** Patched the FQN exact-match logic in `src/pipeline/pass_pkgmap.c` to implement a **stem-first search strategy**. The resolver now strips the extension to match the graph's internal indexing behavior for headers, only falling back to the full leaf if the stem match fails.
* **Validation:** Added a dedicated C++ test fixture (`tests/fixtures/cpp_include/`) and a strict graph-level regression test (`ei_cpp_header_include_targets_header_file`) in `tests/test_edge_imports.c`. The test asserts that the `IMPORTS` edge resolves successfully to the header node's `file_path`.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test`)
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)