### PR TITLE
fix(java-enum): resolve enum methods from enum_body_declarations

### DIFF
--- a/internal/cbm/extract_defs.c
+++ b/internal/cbm/extract_defs.c
@@ -3554,8 +3554,9 @@ static void extract_class_def(CBMExtractCtx *ctx, TSNode node, const CBMLangSpec
     }
 
     TSNode name_node = ts_node_child_by_field_name(node, TS_FIELD("name"));
-    // ObjC: class name is first identifier child
-    if (ts_node_is_null(name_node) && ctx->language == CBM_LANG_OBJC) {
+    // ObjC/Java: class name is first identifier child (Java fallback for enum_declaration)
+    if (ts_node_is_null(name_node) &&
+        (ctx->language == CBM_LANG_OBJC || ctx->language == CBM_LANG_JAVA)) {
         name_node = cbm_find_child_by_kind(node, "identifier");
     }
     // ObjectScript UDL: class name is a `class_name` child (no "name" field).
@@ -3974,6 +3975,12 @@ static TSNode find_class_body(TSNode class_node, CBMLanguage lang) {
     for (const char **f = body_fields; *f; f++) {
         TSNode body = ts_node_child_by_field_name(class_node, *f, (uint32_t)strlen(*f));
         if (!ts_node_is_null(body)) {
+            if (strcmp(ts_node_type(body), "enum_body") == 0) {
+                TSNode decls = cbm_find_child_by_kind(body, "enum_body_declarations");
+                if (!ts_node_is_null(decls)) {
+                    return decls;
+                }
+            }
             return body;
         }
     }
@@ -4029,17 +4036,31 @@ static TSNode find_class_body(TSNode class_node, CBMLanguage lang) {
                                        "implementation_definition",
                                        NULL};
     uint32_t count = ts_node_child_count(class_node);
+    TSNode result = {0};
     for (uint32_t i = 0; i < count; i++) {
         TSNode child = ts_node_child(class_node, i);
         const char *ck = ts_node_type(child);
         for (const char **t = body_types; *t; t++) {
             if (strcmp(ck, *t) == 0) {
-                return child;
+                result = child;
+                break;
             }
         }
+        if (!ts_node_is_null(result)) {
+            break;
+        }
     }
-    TSNode null_node = {0};
-    return null_node;
+    if (!ts_node_is_null(result) && strcmp(ts_node_type(result), "enum_body") == 0) {
+        TSNode decls = cbm_find_child_by_kind(result, "enum_body_declarations");
+        if (!ts_node_is_null(decls)) {
+            return decls;
+        }
+    }
+    if (ts_node_is_null(result)) {
+        TSNode null_node = {0};
+        return null_node;
+    }
+    return result;
 }
 
 // Dart: resolve method name from method_signature/function_signature.
@@ -6200,7 +6221,8 @@ static void push_class_body_children(TSNode node, const CBMLangSpec *spec, wd_st
         const char *ck = ts_node_type(child);
         if (strcmp(ck, "field_declaration_list") == 0 || strcmp(ck, "class_body") == 0 ||
             strcmp(ck, "declaration_list") == 0 || strcmp(ck, "body") == 0 ||
-            strcmp(ck, "block") == 0 || strcmp(ck, "suite") == 0 ||
+            strcmp(ck, "block") == 0 || strcmp(ck, "suite") == 0 || strcmp(ck, "enum_body") == 0 ||
+            strcmp(ck, "enum_body_declarations") == 0 ||
             // Groovy class bodies are a `closure` node; routing through the
             // nested-class path keeps methods from being re-walked (and thus
             // double-extracted) as top-level functions. Gated to Groovy so other

--- a/tests/test_extraction.c
+++ b/tests/test_extraction.c
@@ -418,6 +418,23 @@ TEST(java_class_extends_and_implements) {
     PASS();
 }
 
+TEST(java_enum_method) {
+    CBMFileResult *r = extract(
+        "enum Day {\n"
+        "    MON, TUE, WED, THU, FRI, SAT, SUN;\n\n"
+        "    public boolean isWeekend() { return this == SAT || this == SUN; }\n"
+        "    public String label() { return name().toLowerCase(); }\n"
+        "}\n",
+        CBM_LANG_JAVA, "t", "Day.java");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+    ASSERT(has_def(r, "Enum", "Day"));
+    ASSERT(has_def(r, "Method", "isWeekend"));
+    ASSERT(has_def(r, "Method", "label"));
+    cbm_free_result(r);
+    PASS();
+}
+
 /* REPRODUCTION (RED until fixed) — Python `class Animal(Base):` must extract the
  * BARE base name "Base", but extract_base_classes captures the whole
  * `superclasses` argument_list text "(Base)" instead: collect_bases_from_field
@@ -4429,6 +4446,7 @@ SUITE(extraction) {
     RUN_TEST(java_method);
     RUN_TEST(java_interface);
     RUN_TEST(java_class_extends_and_implements);
+    RUN_TEST(java_enum_method);
     RUN_TEST(python_class_base_extracted_bare);
     RUN_TEST(php_class);
     RUN_TEST(php_function);


### PR DESCRIPTION
## What does this PR do?

Resolves extraction and calling-edge issues for Java enums that define methods (e.g., `isWeekend` or `label` in `cp_enum_method_java`).

In tree-sitter-java, an enum's methods are declared within an `enum_body_declarations` block, which is a nested child of `enum_body` rather than a direct child of the enum declaration itself. Previously:
- `find_class_body` resolved only the raw `enum_body` node.
- `extract_class_methods` iterated over this body, encountering constants and separator tokens, but missing the nested `enum_body_declarations` block. As a result, method definitions were ignored and calling edges failed to resolve.

This change:
1. Updates `find_class_body` to correctly scan and inspect the `enum_body` for nested `enum_body_declarations` nodes and return them.
2. Adds `enum_body` and `enum_body_declarations` to the list of recognized body containers in `push_class_body_children` so the AST traverser pushes all method declarations under the correct enum QN namespace.
3. Complies with the 100-character column format limit in `extract_defs.c`.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test`)
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)
