### PR TITLE
fix(graph-ui): clear ADR content on delete

### DIFF
--- a/graph-ui/src/components/StatsTab.test.tsx
+++ b/graph-ui/src/components/StatsTab.test.tsx
@@ -207,6 +207,53 @@ describe("StatsTab index modal", () => {
     await new Promise((r) => setTimeout(r, 400));
     expect(browseCalls()).toBe(before);
   });
+
+  it("posts empty ADR content when deleting an existing ADR", async () => {
+    let saved: unknown = null;
+    mockProjectsFetch((url, init) => {
+      if (url === "/rpc") {
+        const body = JSON.parse(String(init?.body));
+        const tool = body.params?.name;
+        const result = tool === "list_projects"
+          ? {
+              projects: [{
+                name: "demo",
+                root_path: "/repo",
+                indexed_at: "2026-01-01T00:00:00Z",
+              }],
+            }
+          : { node_labels: [], edge_types: [], total_nodes: 0, total_edges: 0 };
+        return new Response(JSON.stringify({
+          result: { content: [{ text: JSON.stringify(result) }] },
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      if (url.startsWith("/api/adr")) {
+        if (init?.method === "POST") {
+          saved = JSON.parse(String(init.body));
+          return new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({
+          has_adr: true,
+          content: "old decision text",
+          updated_at: "2026-01-01",
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return undefined;
+    });
+
+    render(<StatsTab onSelectProject={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "ADR" }));
+    expect(await screen.findByDisplayValue("old decision text")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(saved).toEqual({ project: "demo", content: "" });
+    });
+  });
 });
 
 describe("IndexProgress", () => {

--- a/graph-ui/src/components/StatsTab.tsx
+++ b/graph-ui/src/components/StatsTab.tsx
@@ -85,13 +85,13 @@ function AdrButton({ project }: { project: string }) {
 
   useEffect(() => { fetchAdr(); }, [fetchAdr]);
 
-  const save = async () => {
+  const save = async (nextContent = content) => {
     setSaving(true);
     try {
       await fetch("/api/adr", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ project, content }),
+        body: JSON.stringify({ project, content: nextContent }),
       });
       await fetchAdr();
       setOpen(false);
@@ -138,7 +138,7 @@ function AdrButton({ project }: { project: string }) {
               {hasAdr && (
                 <button
                   onClick={async () => {
-                    setContent(""); await save();
+                    setContent(""); await save("");
                   }}
                   className="px-3 py-2 rounded-lg text-[12px] text-destructive/60 hover:text-destructive hover:bg-destructive/10 font-medium transition-all"
                 >
@@ -146,7 +146,7 @@ function AdrButton({ project }: { project: string }) {
                 </button>
               )}
               <button onClick={() => setOpen(false)} className="px-4 py-2 rounded-lg text-[12px] text-foreground/40 hover:bg-white/[0.04] font-medium transition-all">{t.common.cancel}</button>
-              <button onClick={save} disabled={saving} className="px-4 py-2 rounded-lg bg-primary/20 hover:bg-primary/30 text-primary text-[12px] font-medium transition-all disabled:opacity-30">
+              <button onClick={() => save()} disabled={saving} className="px-4 py-2 rounded-lg bg-primary/20 hover:bg-primary/30 text-primary text-[12px] font-medium transition-all disabled:opacity-30">
                 {saving ? t.common.saving : t.common.save}
               </button>
             </div>


### PR DESCRIPTION
﻿## Summary

Fixes ADR deletion in the graph UI. The delete action cleared React state and then saved through the stale state value, so the old ADR content could be posted back instead of an empty body.

## Changes

- Allows the ADR save helper to receive the content that should be posted.
- Sends an explicit empty ADR body from the delete action.
- Wraps the normal save click handler so React mouse events are not treated as content.
- Adds a regression test for deleting an existing ADR.

## Validation

- npm test -- --run src/components/StatsTab.test.tsx
- npm test
- npm run build
- git diff --check