### PR TITLE
fix(ci): issue labeler no-oped on every issue — (?i) is invalid in JS RegExp

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,17 +1,21 @@
-# Config for github/issue-labeler (.github/workflows/issue-labeler.yml).
-# Non-versioned format: one regex per label, matched against title + body.
+# Config for the Issue area labeler (.github/workflows/issue-labeler.yml).
+# FORMAT (parsed line-wise by the workflow): one rule per line, exactly
+#   "label": 'regex'
+# Patterns are compiled as JavaScript RegExp with the `i` flag applied by
+# the workflow — do NOT use PCRE-only syntax like inline `(?i)` groups
+# (that broke every run, #764). Matched against issue title + body.
 # Additive only — these never remove a maintainer's manual label.
 
-"windows": '(?i)\b(windows|win\s?1[01]|powershell|\.ps1|mapped drive|smb share|unc path)\b'
+"windows": '\b(windows|win\s?1[01]|powershell|\.ps1|mapped drive|smb share|unc path)\b'
 
-"stability/performance": '(?i)(out of memory|\boom\b|memory leak|segfault|sigsegv|sigbus|crash(es|ed|ing)?|core dumped|\bhang(s|ing)?\b|deadlock|freezes?|time(s)?\s?out|timeout|never finishes|cgroup)'
+"stability/performance": '(out of memory|\boom\b|memory leak|segfault|sigsegv|sigbus|crash(es|ed|ing)?|core dumped|\bhang(s|ing)?\b|deadlock|freezes?|time(s)?\s?out|timeout|never finishes|cgroup)'
 
-"parsing/quality": '(?i)(trace_path|query_graph|search_graph|calls? edge|missing (edges|nodes)|false positive|zero edges|0 edges|module node|not indexed|extraction|wrong (node|label))'
+"parsing/quality": '(trace_path|query_graph|search_graph|calls? edge|missing (edges|nodes)|false positive|zero edges|0 edges|module node|not indexed|extraction|wrong (node|label))'
 
-"editor/integration": '(?i)(cursor|vscode|vs code|opencode|codex|claude code|gemini cli|antigravity|mcp client|\.mcp\.json|installer)'
+"editor/integration": '(cursor|vscode|vs code|opencode|codex|claude code|gemini cli|antigravity|mcp client|\.mcp\.json|installer)'
 
-"ux/behavior": '(?i)(web ui|\bui\b|dashboard|3d graph|visuali[sz]ation|watcher|project name|frontend)'
+"ux/behavior": '(web ui|\bui\b|dashboard|3d graph|visuali[sz]ation|watcher|project name|frontend)'
 
-"cypher": '(?i)\bcypher\b'
+"cypher": '\bcypher\b'
 
-"language-request": '(?i)(language support|hybrid lsp|new language support|support for \w+ language)'
+"language-request": '(language support|hybrid lsp|new language support|support for \w+ language)'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,9 +1,15 @@
 name: Issue area labeler
 
 # Adds area labels to new/edited issues based on keyword regexes in
-# .github/issue-labeler.yml. Additive only (sync-labels off): it never
-# removes a label a maintainer set by hand. Base bug/enhancement labels
-# already come from the issue forms.
+# .github/issue-labeler.yml. Additive only (addLabels never removes): it
+# never touches a label a maintainer set by hand. Base bug/enhancement
+# labels already come from the issue forms.
+#
+# Implemented with first-party actions/github-script (not a third-party
+# labeler action) so every pattern is compiled as a JavaScript RegExp with
+# the `i` flag applied centrally — inline `(?i)` groups are PCRE-only and
+# threw `SyntaxError: Invalid group` on every issue (#764). A pattern that
+# fails to compile now fails the run loudly instead of silently no-oping.
 
 on:
   issues:
@@ -16,13 +22,38 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     steps:
-      - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          configuration-path: .github/issue-labeler.yml
-          enable-versioned-regex: 0
-          include-title: 1
-          include-body: 1
-          sync-labels: 0
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const text = [context.payload.issue.title, context.payload.issue.body]
+              .filter(Boolean).join('\n');
+            const rules = [];
+            const bad = [];
+            // Config format: one rule per line — "label": 'regex' (see the
+            // header comment in .github/issue-labeler.yml).
+            for (const line of fs.readFileSync('.github/issue-labeler.yml', 'utf8').split('\n')) {
+              const m = line.match(/^"([^"]+)":\s*'(.*)'\s*$/);
+              if (!m) continue;
+              try { rules.push({ label: m[1], re: new RegExp(m[2], 'i') }); }
+              catch (e) { bad.push(`${m[1]}: ${e.message}`); }
+            }
+            if (rules.length === 0 && bad.length === 0) {
+              core.setFailed('no labeling rules parsed from .github/issue-labeler.yml');
+              return;
+            }
+            const labels = rules.filter(r => r.re.test(text)).map(r => r.label);
+            if (labels.length) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels,
+              });
+            }
+            core.info(`matched: ${labels.join(', ') || '(none)'}`);
+            if (bad.length) core.setFailed(`invalid label regex(es): ${bad.join('; ')}`);


### PR DESCRIPTION
Closes #764.

The `Issue area labeler` workflow has been a silent no-op since it landed: `github/issue-labeler` compiles each config pattern with JavaScript `RegExp`, which rejects the PCRE-only inline `(?i)` group (`SyntaxError: Invalid group`) on the first rule — every run failed before evaluating anything, so no issue ever received an area label.

**Fix**: replace the third-party action with first-party `actions/github-script` (pinned v9.0.0). The workflow parses the same `.github/issue-labeler.yml` rules and compiles each with the `i` flag applied centrally, preserving the intended case-insensitivity without PCRE syntax. All 7 patterns have `(?i)` stripped; the config header documents the line format. Labels remain additive-only (`addLabels` never removes a manual label).

**Failure-mode upgrade**: a rule that fails to compile (or an empty config) now `setFailed`s the run loudly — the silent-no-op class is gone.

**CI-change scope (full disclosure):**
- **Trigger scope**: unchanged (`issues: [opened, edited]`).
- **Permissions**: unchanged in effect — job keeps `issues: write`; `contents: read` now explicit at job level (needed for checkout of the config).
- **Cost**: negligible — one checkout + one node step per issue event; not gating for PRs; no runner-slot polling.
- **Third-party surface**: *reduced* — drops the `github/issue-labeler` dependency; both remaining actions are GitHub-first-party, SHA-pinned (checkout v7.0.0 = existing repo pin; github-script v9.0.0 = tag SHA resolved via API).
- **Flake surface**: none expected; script is deterministic over local config + event payload.

**Verification** (reproduce-first):
- RED: `new RegExp('(?i)\\b(windows|...)\\b')` throws `Invalid group` under Node — the exact failure from [run 28579100257](https://github.com/DeusData/codebase-memory-mcp/actions/runs/28579100257).
- GREEN: all 7 updated rules parse + compile; sample issue texts (Windows/OOM, zero-edges, VSCode-hang, dashboard, Cypher, language-request, unrelated) each yield exactly the expected label set, case-insensitively.
- Post-merge, the next `issues` event is the live proof — I'll check the first run.