### PR TITLE
fix(pipeline): preserve ADRs during incremental reindex

### DIFF
--- a/src/pipeline/pipeline_incremental.c
+++ b/src/pipeline/pipeline_incremental.c
@@ -645,25 +645,47 @@ static int dump_and_persist(cbm_gbuf_t *gbuf, const char *db_path, const char *p
     struct timespec t;
     cbm_clock_gettime(CLOCK_MONOTONIC, &t);
 
+    /* Preserve ADR content stored in project_summaries before replacing the DB. */
+    char *saved_adr = NULL;
+    cbm_store_t *adr_store = cbm_store_open_path(db_path);
+    if (adr_store) {
+        cbm_adr_t existing = {0};
+        if (cbm_store_adr_get(adr_store, project, &existing) == CBM_STORE_OK) {
+            if (existing.content) {
+                saved_adr = strdup(existing.content);
+            }
+            cbm_store_adr_free(&existing);
+        }
+        cbm_store_close(adr_store);
+    }
+
+    int rc = CBM_STORE_ERR;
+
     if ((cbm_unlink(db_path) != 0 && errno != ENOENT) || cbm_remove_db_sidecars(db_path) != 0) {
         cbm_log_error("incremental.err", "msg", "clear_staging_failed", "path", db_path);
-        return CBM_STORE_ERR;
+        goto cleanup;
     }
 
     int dump_rc = cbm_gbuf_dump_to_sqlite(gbuf, db_path);
     cbm_log_info("incremental.dump", "rc", itoa_buf(dump_rc), "elapsed_ms",
                  itoa_buf((int)elapsed_ms(t)));
     if (dump_rc != 0) {
-        return dump_rc;
+        rc = dump_rc;
+        goto cleanup;
     }
 
     cbm_store_t *hash_store = cbm_store_open_path(db_path);
     if (!hash_store) {
         cbm_log_error("incremental.err", "msg", "open_staging_after_dump", "path", db_path);
-        return CBM_STORE_ERR;
+        goto cleanup;
     }
-    int rc =
-        persist_hashes(hash_store, project, files, file_count, mode_skipped, mode_skipped_count);
+    /* #992: restore the captured ADR before persisting hashes, mirroring the
+     * full-reindex path (#516) -- the DB replacement above dropped it. */
+    if (saved_adr && cbm_store_adr_store(hash_store, project, saved_adr) != CBM_STORE_OK) {
+        cbm_log_error("incremental.err", "msg", "adr_restore", "project", project);
+    }
+
+    rc = persist_hashes(hash_store, project, files, file_count, mode_skipped, mode_skipped_count);
 
     /* Coverage rows (#963): re-write the merged set into the rebuilt DB
      * (AFTER hashes, so the deleted-file prune sees the live file set). */
@@ -701,6 +723,9 @@ static int dump_and_persist(cbm_gbuf_t *gbuf, const char *db_path, const char *p
         }
     }
     cbm_store_close(hash_store);
+
+cleanup:
+    free(saved_adr);
     return rc;
 }
 

--- a/src/pipeline/pipeline_incremental.c
+++ b/src/pipeline/pipeline_incremental.c
@@ -679,10 +679,12 @@ static int dump_and_persist(cbm_gbuf_t *gbuf, const char *db_path, const char *p
         cbm_log_error("incremental.err", "msg", "open_staging_after_dump", "path", db_path);
         goto cleanup;
     }
+    bool adr_restore_failed = false;
     /* #992: restore the captured ADR before persisting hashes, mirroring the
      * full-reindex path (#516) -- the DB replacement above dropped it. */
     if (saved_adr && cbm_store_adr_store(hash_store, project, saved_adr) != CBM_STORE_OK) {
         cbm_log_error("incremental.err", "msg", "adr_restore", "project", project);
+        adr_restore_failed = true;
     }
 
     rc = persist_hashes(hash_store, project, files, file_count, mode_skipped, mode_skipped_count);
@@ -723,6 +725,9 @@ static int dump_and_persist(cbm_gbuf_t *gbuf, const char *db_path, const char *p
         }
     }
     cbm_store_close(hash_store);
+    if (adr_restore_failed) {
+        rc = CBM_PIPELINE_ABORT_PRESERVE_DB;
+    }
 
 cleanup:
     free(saved_adr);

--- a/tests/test_pipeline.c
+++ b/tests/test_pipeline.c
@@ -9,6 +9,7 @@
 #include "test_framework.h"
 #include "test_helpers.h"
 #include "foundation/mem.h" // cbm_mem_init/budget (back-pressure futile-nap test)
+#include "foundation/log.h"
 #include "pipeline/pipeline.h"
 #include "pipeline/pipeline_internal.h"
 #include "store/store.h"
@@ -29,6 +30,13 @@
 /* ── Helper: create temp test repo with known layout ───────────── */
 
 static char g_tmpdir[256];
+static bool g_incremental_route_seen;
+
+static void capture_incremental_route(const char *line) {
+    if (strstr(line, "pipeline.route") && strstr(line, "incremental")) {
+        g_incremental_route_seen = true;
+    }
+}
 
 /* Create:
  *   /tmp/cbm_test_XXXXXX/
@@ -330,6 +338,68 @@ TEST(pipeline_adr_survives_full_reindex) {
     cbm_pipeline_free(p2);
 
     /* The ADR must still be present and unchanged. */
+    cbm_store_t *s2 = cbm_store_open_path(db_path);
+    ASSERT_NOT_NULL(s2);
+    cbm_adr_t adr = {0};
+    int rc = cbm_store_adr_get(s2, project_copy, &adr);
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_NOT_NULL(adr.content);
+    ASSERT_STR_EQ(adr.content, adr_text);
+    cbm_store_adr_free(&adr);
+    cbm_store_close(s2);
+
+    rm_rf(tmp);
+    PASS();
+}
+
+TEST(pipeline_adr_survives_incremental_reindex) {
+    char tmp[256];
+    snprintf(tmp, sizeof(tmp), "/tmp/cbm_adr_incr_XXXXXX");
+    if (!cbm_mkdtemp(tmp)) {
+        FAIL("failed to create temp dir");
+    }
+
+    char db_path[512];
+    snprintf(db_path, sizeof(db_path), "%s/test.db", tmp);
+
+    char path[512];
+    snprintf(path, sizeof(path), "%s/main.py", tmp);
+    FILE *f = fopen(path, "w");
+    ASSERT_NOT_NULL(f);
+    fprintf(f, "def foo():\n    return 1\n");
+    fclose(f);
+
+    cbm_pipeline_t *p1 = cbm_pipeline_new(tmp, db_path, CBM_MODE_FULL);
+    ASSERT_NOT_NULL(p1);
+    ASSERT_EQ(cbm_pipeline_run(p1), 0);
+    const char *project = cbm_pipeline_project_name(p1);
+    char project_copy[256];
+    snprintf(project_copy, sizeof(project_copy), "%s", project);
+    cbm_pipeline_free(p1);
+
+    const char *adr_text = "# Decision\nIncremental reindex keeps ADR content.";
+    cbm_store_t *s1 = cbm_store_open_path(db_path);
+    ASSERT_NOT_NULL(s1);
+    ASSERT_EQ(cbm_store_adr_store(s1, project_copy, adr_text), CBM_STORE_OK);
+    cbm_store_close(s1);
+
+    /* Change one existing file so cbm_pipeline_run routes through incremental
+     * reindex instead of the full delete/rebuild path. */
+    f = fopen(path, "a");
+    ASSERT_NOT_NULL(f);
+    fprintf(f, "\ndef bar():\n    return 2\n");
+    fclose(f);
+
+    g_incremental_route_seen = false;
+    cbm_log_set_sink_ex(capture_incremental_route, CBM_LOG_SINK_REPLACE);
+    cbm_pipeline_t *p2 = cbm_pipeline_new(tmp, db_path, CBM_MODE_FULL);
+    ASSERT_NOT_NULL(p2);
+    int pipeline_rc = cbm_pipeline_run(p2);
+    cbm_log_set_sink(NULL);
+    ASSERT_EQ(pipeline_rc, 0);
+    ASSERT_TRUE(g_incremental_route_seen);
+    cbm_pipeline_free(p2);
+
     cbm_store_t *s2 = cbm_store_open_path(db_path);
     ASSERT_NOT_NULL(s2);
     cbm_adr_t adr = {0};
@@ -7772,6 +7842,7 @@ SUITE(pipeline) {
     RUN_TEST(pipeline_structure_nodes);
     RUN_TEST(pipeline_committed_counts_match_persisted);
     RUN_TEST(pipeline_adr_survives_full_reindex);
+    RUN_TEST(pipeline_adr_survives_incremental_reindex);
     RUN_TEST(pipeline_structure_edges);
     RUN_TEST(pipeline_branch_root_structure);
     RUN_TEST(pipeline_project_name_derived);


### PR DESCRIPTION
## What does this PR do?

Preserves `manage_adr` content when `index_repository` takes the incremental reindex path.

This is a follow-up to #516. The full reindex path already captures ADR content from `project_summaries.summary` before replacing the SQLite DB and restores it afterward. The incremental path also replaces the DB in `dump_and_persist()`, but it only repersisted graph data, file hashes, coverage rows, and FTS state. Any ADR stored through `manage_adr` was therefore silently dropped on the next incremental rebuild.

The failure shape is:

1. Index a project.
2. Store ADR content with `manage_adr` mode `update`.
3. Read it back with mode `get`; content is present.
4. Change an existing source file so the next `index_repository` routes through incremental reindex.
5. Read the ADR again; before this fix it could return successfully with empty content because `project_summaries` was recreated without the previous `summary`.

This PR mirrors the full-reindex preservation behavior in `src/pipeline/pipeline_incremental.c`:

- before unlinking/rebuilding the DB, read any existing ADR content for the project;
- after `cbm_gbuf_dump_to_sqlite()` recreates the DB and it is reopened, write that ADR content back with `cbm_store_adr_store()`;
- log a restore failure instead of silently losing the ADR.

It also adds `pipeline_adr_survives_incremental_reindex`, which indexes a tiny repo, stores an ADR, changes one existing file to force the incremental route, and asserts that the ADR content is still present afterward.

This PR is intentionally scoped to ADR loss during incremental reindex. It does not attempt to address any separate stale-WAL/listed-but-unqueryable project lookup behavior.

## Verification

- `git fetch origin main` and rebase onto current `origin/main` (`6b57db2`) succeeded without conflicts.
- `make -j2 -f Makefile.cbm cbm` succeeded.
- Direct MCP repro against the rebuilt binary passed:
  - `manage_adr update` stored content;
  - immediate `manage_adr get` returned the content;
  - a second `index_repository` after changing one file reported `"adr_present":true`;
  - post-incremental `manage_adr get` returned the original content.
- `make -j2 -f Makefile.cbm build/c/test-runner` succeeded.
- `ASAN_OPTIONS=detect_leaks=0 build/c/test-runner pipeline` reached and passed the new `pipeline_adr_survives_incremental_reindex` test, including the `pipeline.route path=incremental` branch.
- The selected `pipeline` suite still exits non-zero with an unrelated existing failure: `pipeline_backpressure_futile_nap_disengages` at `tests/test_pipeline.c:6801` (`220 passed, 1 failed`).

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Tests pass locally (`make -f Makefile.cbm test`)
- [ ] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)
