### PR TITLE
fix(incremental): name File nodes by basename, matching the full pipeline

### DIFF
--- a/src/pipeline/pipeline_incremental.c
+++ b/src/pipeline/pipeline_incremental.c
@@ -848,8 +848,17 @@ int cbm_pipeline_run_incremental(cbm_pipeline_t *p, const char *db_path, cbm_fil
     for (int i = 0; i < ci; i++) {
         char *file_qn = cbm_pipeline_fqn_compute(project, changed_files[i].rel_path, "__file__");
         if (file_qn) {
-            cbm_gbuf_upsert_node(existing, "File", changed_files[i].rel_path, file_qn,
-                                 changed_files[i].rel_path, 0, 0, "{}");
+            /* #994: the name must be the BASENAME with extension props,
+             * mirroring the full build's File node (pipeline.c) — upserts
+             * match by QN, so any other name here renames the node in place
+             * and the incremental graph diverges from a full build. */
+            const char *rel = changed_files[i].rel_path;
+            const char *slash = strrchr(rel, '/');
+            const char *basename = slash ? slash + SKIP_ONE : rel;
+            char props[CBM_SZ_256];
+            const char *ext = strrchr(basename, '.');
+            snprintf(props, sizeof(props), "{\"extension\":\"%s\"}", ext ? ext : "");
+            cbm_gbuf_upsert_node(existing, "File", basename, file_qn, rel, 0, 0, props);
             free(file_qn);
         }
     }

--- a/tests/test_incremental.c
+++ b/tests/test_incremental.c
@@ -964,6 +964,36 @@ static int resp_lacks_key(const char *resp, const char *key) {
 
 /* ── list_projects ─────────────────────────────────────────────── */
 
+TEST(incr_file_node_name_stays_basename) {
+    /* #994: File nodes must keep their basename NAME through an incremental
+     * re-index (the bug renamed touched files' nodes to rel_path, diverging
+     * from a full build). Modify a file, re-index, assert no File node name
+     * contains a path separator. */
+    char path[512];
+    snprintf(path, sizeof(path), "%s/fastapi/applications.py", g_repodir);
+    FILE *f = fopen(path, "a");
+    ASSERT(f != NULL);
+    fprintf(f, "\n# incr_file_node_name_stays_basename touch\n");
+    fclose(f);
+
+    char *resp = index_repo();
+    ASSERT(resp != NULL);
+    free(resp);
+
+    double ms;
+    char *r = call_tool_timed("query_graph", &ms,
+                              "{\"project\":\"%s\",\"format\":\"json\","
+                              "\"query\":\"MATCH (n:File) WHERE n.name CONTAINS '/'"
+                              " RETURN n.name LIMIT 5\"}",
+                              g_project);
+    TOOL_OK(r, ms);
+    /* No File node may carry a path separator in its name; the query engine
+     * returns an empty rows array when nothing matches. */
+    ASSERT(strstr(r, "\"rows\":[]") != NULL || strstr(r, "\\\"rows\\\":[]") != NULL);
+    free(r);
+    PASS();
+}
+
 TEST(tool_list_projects_basic) {
     double ms;
     char *r = call_tool_timed("list_projects", &ms, "{}");
@@ -2970,6 +3000,7 @@ SUITE(incremental) {
 
     /* Phase 3: Incremental deltas */
     RUN_TEST(incr_modify_file);
+    RUN_TEST(incr_file_node_name_stays_basename);
     RUN_TEST(incr_formatter_run);
     RUN_TEST(incr_add_file);
     RUN_TEST(incr_delete_file);


### PR DESCRIPTION
Fixes #994.

The incremental path passed `changed_files[i].rel_path` as the File node **name** (the full pipeline uses the **basename**). Upserts match by QN, so an incremental re-index renamed a touched file's File node in place — the same tree produced different graphs fresh vs incrementally, diverging further with every edited file, and name-based inbound-USAGE traversal dead-ended at touched files' nodes (details + minimal repro in #994).

**Change:** mirror the full pipeline's node shape at the incremental call site — basename as the name and the same `{"extension": ...}` props (previously `"{}"`).

**Test:** adds `incr_file_node_name_stays_basename` to the incremental suite: modify a file, incremental re-index, assert no File node name contains `/`. Red without the fix, green with it; full incremental suite 162/162 (macOS arm64, ASan/UBSan runner).

Commit is DCO signed-off.
