### PR TITLE
fix(cli): reject unknown tool flags with a nearest-flag suggestion

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -4520,6 +4520,62 @@ static char *cli_heap_msgf(const char *fmt, const char *arg) {
     return cbm_strdup(buf);
 }
 
+/* Levenshtein distance for near-miss flag suggestions (two-row DP; inputs
+ * are schema property names, well under the buffer sizes used here). */
+static int cli_edit_distance(const char *a, const char *b) {
+    enum { CLI_ED_MAX = 128 };
+    size_t la = strlen(a);
+    size_t lb = strlen(b);
+    if (la >= CLI_ED_MAX || lb >= CLI_ED_MAX) {
+        return CLI_ED_MAX;
+    }
+    int prev[CLI_ED_MAX + 1];
+    int cur[CLI_ED_MAX + 1];
+    for (size_t j = 0; j <= lb; j++) {
+        prev[j] = (int)j;
+    }
+    for (size_t i = 1; i <= la; i++) {
+        cur[0] = (int)i;
+        for (size_t j = 1; j <= lb; j++) {
+            int cost = (a[i - 1] == b[j - 1]) ? 0 : 1;
+            int del = prev[j] + 1;
+            int ins = cur[j - 1] + 1;
+            int sub = prev[j - 1] + cost;
+            int m = del < ins ? del : ins;
+            cur[j] = m < sub ? m : sub;
+        }
+        memcpy(prev, cur, (lb + 1) * sizeof(int));
+    }
+    return prev[lb];
+}
+
+/* Closest schema property to `key` for a "did you mean" suggestion, or NULL
+ * when nothing is plausibly near (distance > half the key length, min 2). */
+static const char *cli_closest_prop(yyjson_val *props, const char *key) {
+    const char *best = NULL;
+    int best_d = 0;
+    size_t idx;
+    size_t max;
+    yyjson_val *k;
+    yyjson_val *v;
+    yyjson_obj_foreach(props, idx, max, k, v) {
+        const char *name = yyjson_get_str(k);
+        if (!name) {
+            continue;
+        }
+        int d = cli_edit_distance(key, name);
+        if (!best || d < best_d) {
+            best = name;
+            best_d = d;
+        }
+    }
+    int limit = (int)(strlen(key) / 2);
+    if (limit < 2) {
+        limit = 2;
+    }
+    return (best && best_d <= limit) ? best : NULL;
+}
+
 /* True if the schema's required[] array contains `key`. */
 static bool cli_schema_required_has(yyjson_val *required, const char *key) {
     if (!required || !yyjson_is_arr(required)) {
@@ -4660,6 +4716,34 @@ char *cbm_cli_build_args_json(const char *tool_name, int argc, char **argv, char
 
         cli_kebab_to_snake(key);
         const char *type = cli_schema_type(props, key);
+
+        /* Unknown flag for a known tool: reject loudly (#997). Silently
+         * typing it as a string ships it as an ignored JSON arg — the
+         * server applies its default and the caller gets silently-wrong
+         * output (e.g. `trace_path --max-depth 1` traced at depth 3). */
+        if (props && !type) {
+            char kebab_key[CLI_BUF_256];
+            snprintf(kebab_key, sizeof(kebab_key), "%s", key);
+            cli_snake_to_kebab(kebab_key);
+            const char *close = cli_closest_prop(props, key);
+            char suggestion[CLI_BUF_256] = "";
+            if (close) {
+                char close_kebab[CLI_BUF_256];
+                snprintf(close_kebab, sizeof(close_kebab), "%s", close);
+                cli_snake_to_kebab(close_kebab);
+                snprintf(suggestion, sizeof(suggestion), " (did you mean --%s?)", close_kebab);
+            }
+            if (err_out) {
+                char buf[CLI_BUF_512];
+                snprintf(buf, sizeof(buf),
+                         "unknown flag --%s for this tool%s — run 'cli %s --help' for the "
+                         "supported flags",
+                         kebab_key, suggestion, tool_name);
+                *err_out = cbm_strdup(buf);
+            }
+            ok = false;
+            break;
+        }
 
         if (type && strcmp(type, "array") == 0 && !have_value) {
             if (err_out) {

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -2957,6 +2957,24 @@ TEST(cli_build_args_json_bare_boolean_issue680) {
     PASS();
 }
 
+/* An unknown flag for a KNOWN tool must be rejected loudly, not silently
+ * typed as a string and dropped server-side (#997). GF1 eval: `trace_path
+ * --max-depth 1` was accepted, the real --depth stayed at default 3, and
+ * the trace silently returned hop-2/3 results — silent-wrong output. The
+ * error names the closest valid flag as a suggestion. */
+TEST(cli_build_args_json_unknown_flag_rejected) {
+    char *err = NULL;
+    char *argv[] = {"--max-depth", "1"};
+    char *json = cbm_cli_build_args_json("trace_path", 2, argv, &err);
+    ASSERT_NULL(json);
+    ASSERT_NOT_NULL(err);
+    ASSERT(strstr(err, "unknown flag") != NULL);
+    ASSERT(strstr(err, "max-depth") != NULL);
+    ASSERT(strstr(err, "--depth") != NULL); /* nearest-flag suggestion */
+    free(err);
+    PASS();
+}
+
 /* A repeated array-typed flag accumulates into a JSON array. */
 TEST(cli_build_args_json_repeated_array_issue680) {
     char *err = NULL;
@@ -3226,6 +3244,7 @@ SUITE(cli) {
     RUN_TEST(cli_build_args_json_string_flag_issue680);
     RUN_TEST(cli_build_args_json_integer_flag_issue680);
     RUN_TEST(cli_build_args_json_bare_boolean_issue680);
+    RUN_TEST(cli_build_args_json_unknown_flag_rejected);
     RUN_TEST(cli_build_args_json_repeated_array_issue680);
     RUN_TEST(cli_build_args_json_kebab_to_snake_issue680);
     RUN_TEST(cli_build_args_json_key_equals_value_issue680);


### PR DESCRIPTION
Closes #997.

Unknown flags were typed as strings and shipped as JSON args the server ignores — `trace_path --max-depth 1` succeeded but traced at the default depth 3, returning hop-2/3 rows the caller never asked for (found by an agent evaluation that burned ~5.4K output tokens on it and mis-read the graph). Silent-wrong is the worst CLI failure mode.

**Change:** unknown flag for a known tool → loud error with a Levenshtein nearest-flag suggestion:
```
error: unknown flag --max-depth for this tool (did you mean --depth?) — run 'cli trace_path --help' for the supported flags
```

**Blast-radius check:** raw-JSON, `--args-file`, stdin, unknown-tool (schema-less), and the supervisor's worker argv all bypass the flag converter — verified untouched. Global flags (`--json`) are parsed before tool dispatch.

**Reproduce-first:** `cli_build_args_json_unknown_flag_rejected` — RED on the permissive code, GREEN with the fix; CLI suite 119/119; lint-ci clean.