### PR TITLE
fix(semantic): sort deferred edges by (score desc, j) for deterministic admission (#998)

### DIFF
--- a/src/pipeline/pass_semantic_edges.c
+++ b/src/pipeline/pass_semantic_edges.c
@@ -1034,16 +1034,23 @@ static void phase5c_build_lsh_buckets(const uint64_t *signatures, int func_count
 /* Phase 6b: serialize deferred edges from all worker buffers into the graph
  * buffer (sequential because gbuf isn't thread-safe). */
 /* Canonical order for candidate pairs: ascending discovering-func index,
- * then ascending candidate rank — the order a sequential scoring loop over
- * canonically-sorted funcs would have produced. */
+ * then DESCENDING score so the per-node budget admits the strongest edges
+ * first, then ascending partner func index as a stable tie-break (func
+ * indices are sorted by qualified_name in phase 1a, so this is equivalent
+ * to a qn tie-break).  The previous (i, c) key used the candidate's LSH
+ * arrival rank which could vary with scheduling, producing ~50% edge-set
+ * churn across identical runs (#998). */
 static int cmp_deferred_edge_canonical(const void *pa, const void *pb) {
     const deferred_edge_t *a = pa;
     const deferred_edge_t *b = pb;
     if (a->i != b->i) {
         return a->i < b->i ? -1 : 1;
     }
-    if (a->c != b->c) {
-        return a->c < b->c ? -1 : 1;
+    if (a->score != b->score) {
+        return a->score > b->score ? -1 : 1; /* descending */
+    }
+    if (a->j != b->j) {
+        return a->j < b->j ? -1 : 1;
     }
     return 0;
 }


### PR DESCRIPTION
## What does this PR do?
Fixes the ~50% SEMANTICALLY_RELATED edge churn across identical runs reported in #998. The root cause is `cmp_deferred_edge_canonical` sorting deferred edges by `(i, c)` where `c` is the candidate's LSH arrival rank, which varies with worker scheduling. This PR replaces the sort key with `(i, score desc, j)` so the per-node `max_edges` budget always admits the highest-scored edges first, with the partner func index (sorted by qualified_name in phase 1a) as a deterministic tie-break.
## Checklist
- [x] Every commit is signed off (`git commit -s`) -- required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test`)
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)
      `tests/repro/repro_parallel_determinism.c` already guards this class of fix
