### PR TITLE
fix(win): wide-path canonicalization — drop ANSI _access/_fullpath

### DIFF
--- a/src/foundation/compat_fs.c
+++ b/src/foundation/compat_fs.c
@@ -714,6 +714,51 @@ int cbm_exec_no_shell(const char *const *argv) {
 
 #endif /* _WIN32 */
 
+/* Canonicalize an EXISTING path (collapse `..`, resolve per-OS): realpath on
+ * POSIX; on Windows a wide-path GetFileAttributesW existence check +
+ * GetFullPathNameW. The previous callers used the ANSI CRT (_access/
+ * _fullpath) on UTF-8 input — locale-dependent by construction: on a CJK
+ * system codepage (e.g. Big5) the UTF-8 bytes of a CJK path re-decode into
+ * different characters and canonicalization corrupts the path (#973).
+ * Returns 0 when the path does not exist or cannot be resolved. */
+int cbm_canonical_path(const char *path, char *out, size_t out_sz) {
+    if (!path || !out || out_sz == 0) {
+        return 0;
+    }
+#ifdef _WIN32
+    wchar_t *wpath = cbm_utf8_to_wide(path);
+    if (!wpath) {
+        return 0;
+    }
+    if (GetFileAttributesW(wpath) == INVALID_FILE_ATTRIBUTES) {
+        free(wpath);
+        return 0;
+    }
+    enum { CANON_WIDE_MAX = 4096 };
+    wchar_t wfull[CANON_WIDE_MAX];
+    DWORD n = GetFullPathNameW(wpath, CANON_WIDE_MAX, wfull, NULL);
+    free(wpath);
+    if (n == 0 || n >= CANON_WIDE_MAX) {
+        return 0;
+    }
+    char *utf8 = cbm_wide_to_utf8(wfull);
+    if (!utf8) {
+        return 0;
+    }
+    size_t len = strlen(utf8);
+    if (len >= out_sz) {
+        free(utf8);
+        return 0;
+    }
+    memcpy(out, utf8, len + 1);
+    free(utf8);
+    return 1;
+#else
+    /* Callers pass >= 4K buffers (>= PATH_MAX on our platforms). */
+    return realpath(path, out) != NULL;
+#endif
+}
+
 /* rename() with overwrite semantics on every platform: POSIX rename already
  * replaces atomically; Windows rename fails with EEXIST when the target
  * exists, so use MoveFileExW(MOVEFILE_REPLACE_EXISTING) there (wide paths —

--- a/src/foundation/compat_fs.h
+++ b/src/foundation/compat_fs.h
@@ -53,6 +53,10 @@ void cbm_remove_db_sidecars(const char *db_path);
 /* rename() that replaces an existing destination on every platform
  * (Windows rename fails with EEXIST; this uses MoveFileExW there). */
 int cbm_rename_replace(const char *src, const char *dst);
+/* Canonicalize an EXISTING path (realpath / wide GetFullPathNameW). Locale-
+ * independent on Windows — never routes UTF-8 through the ANSI CRT (#973).
+ * out must be >= 4096 bytes. Returns 1 on success, 0 otherwise. */
+int cbm_canonical_path(const char *path, char *out, size_t out_sz);
 
 /* Delete an empty directory. Returns 0 on success. */
 int cbm_rmdir(const char *path);

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -811,8 +811,10 @@ static char *canonicalize_repo_path_if_exists(char *repo_path) {
     }
 
     char real[CBM_SZ_4K];
-#ifdef _WIN32
-    if (_access(repo_path, 0) == 0 && _fullpath(real, repo_path, sizeof(real))) {
+    /* Wide-path canonicalization: the old _access/_fullpath pair decoded the
+     * UTF-8 repo_path through the ANSI codepage and corrupted CJK paths on
+     * CJK-locale systems (#973). */
+    if (cbm_canonical_path(repo_path, real, sizeof(real))) {
         cbm_normalize_path_sep(real);
         char *canonical = heap_strdup(real);
         if (canonical) {
@@ -820,16 +822,6 @@ static char *canonicalize_repo_path_if_exists(char *repo_path) {
             return canonical;
         }
     }
-#else
-    if (realpath(repo_path, real)) {
-        cbm_normalize_path_sep(real);
-        char *canonical = heap_strdup(real);
-        if (canonical) {
-            free(repo_path);
-            return canonical;
-        }
-    }
-#endif
 
     return repo_path;
 }
@@ -5056,16 +5048,17 @@ static yyjson_doc *enrich_node_properties(yyjson_mut_doc *doc, yyjson_mut_val *o
  * across preprocessor branches, which defeats source-level tooling that parses
  * without the preprocessor (and left this function unindexed in the graph). */
 static bool resolve_canonical_path(const char *path, char *out, size_t out_sz) {
-#ifdef _WIN32
-    if (!_fullpath(out, path, out_sz)) {
+    /* cbm_canonical_path: realpath on POSIX; wide existence check +
+     * GetFullPathNameW on Windows (the old bare _fullpath was ANSI —
+     * CJK-locale corruption, #973 — and, unlike POSIX realpath, resolved
+     * nonexistent paths too; requiring existence aligns the platforms). */
+    if (!cbm_canonical_path(path, out, out_sz)) {
         return false;
     }
+#ifdef _WIN32
     cbm_normalize_path_sep(out);
-    return true;
-#else
-    (void)out_sz;
-    return realpath(path, out) != NULL;
 #endif
+    return true;
 }
 
 bool cbm_path_within_root(const char *root_path, const char *abs_path) {

--- a/src/pipeline/fqn.c
+++ b/src/pipeline/fqn.c
@@ -5,6 +5,7 @@
  * Handles Python __init__.py, JS/TS index.{js,ts}, path separators.
  */
 #include "pipeline/pipeline.h"
+#include "foundation/compat_fs.h"
 #include "foundation/constants.h"
 #include "foundation/platform.h"
 
@@ -410,17 +411,12 @@ char *cbm_project_name_from_path(const char *abs_path) {
 
     char real[CBM_SZ_4K];
     const char *name_path = abs_path;
-#ifdef _WIN32
-    if (_access(abs_path, 0) == 0 && _fullpath(real, abs_path, sizeof(real))) {
+    /* Wide-path canonicalization — the ANSI _access/_fullpath pair corrupted
+     * CJK paths on CJK-locale Windows (#973). */
+    if (cbm_canonical_path(abs_path, real, sizeof(real))) {
         cbm_normalize_path_sep(real);
         name_path = real;
     }
-#else
-    if (realpath(abs_path, real)) {
-        cbm_normalize_path_sep(real);
-        name_path = real;
-    }
-#endif
 
     /* Work on mutable copy */
     char *path = strdup(name_path);

--- a/tests/windows/test_cli_non_ascii_arg.py
+++ b/tests/windows/test_cli_non_ascii_arg.py
@@ -98,6 +98,28 @@ def main():
         print("non-ASCII argv (supervised): rc=%d" % p.returncode)
         print("  stdout: %s" % out[:200].replace("\n", " "))
         print("  stderr: %s" % err[-200:].replace("\n", " "))
+        # #973 variant: the reporter's exact shape — Traditional-Chinese dir,
+        # FLAG-form --repo-path + --mode fast, supervised. This adds coverage
+        # of the flag->JSON converter and the repo-path canonicalization,
+        # which used ANSI _access/_fullpath (locale-dependent — corrupted CJK
+        # paths on CJK-codepage systems) before the cbm_canonical_path fix.
+        cjk_repo = os.path.join(work, "\u96f7\u9054\u6e2c\u8a66")
+        make_fixture(cjk_repo)
+        env3 = dict(os.environ)
+        env3["CBM_CACHE_DIR"] = os.path.join(work, "cache_cjk")
+        env3.pop("CBM_INDEX_SUPERVISOR", None)
+        p2 = subprocess.run([binary, "cli", "index_repository",
+                             "--repo-path", cjk_repo, "--mode", "fast"],
+                            capture_output=True, timeout=120, env=env3)
+        out2 = (p2.stdout or b"").decode("utf-8", "replace")
+        cjk_ok = '"nodes"' in out2 and '"nodes":0' not in out2.replace(" ", "")
+        print("CJK flag-form (--repo-path, supervised, fast): rc=%d" % p2.returncode)
+        print("  stdout: %s" % out2[:200].replace("\n", " "))
+        if not cjk_ok:
+            print("\nRED: CJK flag-form repo_path was not indexed (#973 — "
+                  "canonicalization or spawn boundary mangled the path).")
+            return 1
+
         if honored:
             print("\nGREEN: CLI honored the non-ASCII repo_path (argv + worker spawn).")
             return 0


### PR DESCRIPTION
Closes #973.

**Root cause (by construction, not by CI repro):** three canonicalization sites ran UTF-8 paths through the ANSI CRT (`_access`/`_fullpath`) — repo_path canonicalization, fqn project-name derivation, and `resolve_canonical_path`. On a CJK system codepage (the reporter is on Big5), the UTF-8 bytes of `雷達測試` re-decode as different characters and canonicalization corrupts the path. Our CI runners use the en-US codepage, which is why every existing non-ASCII guard stayed green while v0.9.0 crashed in the reporter's environment — the earlier session audit already flagged these exact sites as the lead suspect.

**Fix:** `cbm_canonical_path` — POSIX `realpath` unchanged; Windows goes fully wide (`GetFileAttributesW` + `GetFullPathNameW` via the UTF-8↔wide helpers). No ANSI path decoding remains on these sites. `resolve_canonical_path` now requires existence on Windows too, aligning with the POSIX semantics it mirrors.

**Guard:** the Windows CLI guard gains the reporter's exact invocation — Traditional-Chinese directory, flag-form `--repo-path` + `--mode fast`, real supervised spawn. Honest scope note: CI cannot switch its system codepage, so the guard validates the mechanics under en-US; the locale-dependence itself is eliminated structurally.

Full suite 5,994/0 locally, lint-ci clean. Windows legs will exercise the new wide code paths.