### PR TITLE
feat(ui): add configurable host binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,18 @@ The UI ships as a separate `ui` build (it embeds the frontend). The default inst
 Then run it:
 
 ```bash
-codebase-memory-mcp --ui=true --port=9749
+codebase-memory-mcp --ui=true --host=127.0.0.1 --port=9749
 ```
 
 Open `http://localhost:9749` in your browser. The UI runs as a background thread alongside the MCP server — it's available whenever your agent is connected.
+
+The default host is `127.0.0.1` and is persisted with the UI port. To share the UI on a trusted LAN, bind a specific local address:
+
+```bash
+codebase-memory-mcp --ui=true --host=192.168.88.26 --port=9749
+```
+
+Use `--host=0.0.0.0` only when you need all interfaces. The UI has no authentication; a non-loopback bind is reachable over the network and may expose codebase graph data and UI actions. Protect it with a firewall or trusted network, and prefer a specific LAN IP over `0.0.0.0`.
 
 ### Auto-Index
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -9,7 +9,7 @@ This page documents the configuration files that `codebase-memory-mcp` reads or 
 | Global custom extension mapping | `$XDG_CONFIG_HOME/codebase-memory-mcp/config.json` | JSON | Falls back to `~/.config/codebase-memory-mcp/config.json` when `XDG_CONFIG_HOME` is unset. |
 | Per-project custom extension mapping | `{repo_root}/.codebase-memory.json` | JSON | Overrides conflicting global `extra_extensions` entries. |
 | CLI-managed runtime settings | `${CBM_CACHE_DIR:-~/.cache/codebase-memory-mcp}/_config.db` | SQLite | Written by `codebase-memory-mcp config set/reset`. |
-| UI settings | `${CBM_CACHE_DIR:-~/.cache/codebase-memory-mcp}/config.json` | JSON | Stores `ui_enabled` and `ui_port`. |
+| UI settings | `${CBM_CACHE_DIR:-~/.cache/codebase-memory-mcp}/config.json` | JSON | Stores `ui_enabled`, `ui_port`, and numeric IPv4 `ui_host`. |
 
 ## 1. Custom File Extension Mapping
 
@@ -95,13 +95,35 @@ Current format:
 ```json
 {
   "ui_enabled": false,
-  "ui_port": 9749
+  "ui_port": 9749,
+  "ui_host": "127.0.0.1"
 }
 ```
 
 Notes:
 
 - If the UI-enabled binary has embedded assets and no UI config file exists yet, the UI auto-enables on first run.
+- `ui_host` defaults to `127.0.0.1`; config files written before this field existed remain localhost-only.
+- `--host=<IPv4>` accepts numeric IPv4 addresses only and persists the setting, just like `--port`.
+- Localhost-only UI:
+
+  ```bash
+  codebase-memory-mcp --ui=true --host=127.0.0.1 --port=9749
+  ```
+
+- Specific LAN interface (recommended when sharing on a trusted network):
+
+  ```bash
+  codebase-memory-mcp --ui=true --host=192.168.88.26 --port=9749
+  ```
+
+- All interfaces:
+
+  ```bash
+  codebase-memory-mcp --ui=true --host=0.0.0.0 --port=9749
+  ```
+
+  Binding to a non-loopback address prints a warning because the UI has no authentication, is reachable over the network, and may expose codebase graph data and UI actions. Protect it with a firewall or trusted network; prefer a specific LAN IP over `0.0.0.0`.
 - `CBM_CACHE_DIR` changes both the UI config location and the runtime settings database location.
 
 ## 4. Environment Variables

--- a/scripts/security-allowlist.txt
+++ b/scripts/security-allowlist.txt
@@ -54,6 +54,7 @@ URL:https://api.github.com/repos/DeusData/codebase-memory-mcp/releases/latest:up
 URL:https://github.com/DeusData/codebase-memory-mcp/releases/latest/download:binary download + checksums
 URL:https://github.com/DeusData/codebase-memory-mcp/releases/latest:version check via redirect header
 URL:http://127.0.0.1:UI server binding (localhost only)
+URL:http://%s:%d:UI serving URL assembled from the validated bind host and bound port for logging (not a network call)
 URL:https://www.sqlite.org/c3ref/c_checkpoint_full.html:sqlite WAL checkpoint API doc reference (comment only, not a network call)
 URL:https://github.com/DeusData/codebase-memory-mcp:project repository self-reference in update/star notice (src/mcp/mcp.c)
 URL:https://%s:GitHub blob-URL construction in src/ui/http_server.c cbm_ui_git_web_base — https-forces the repo web base for frontend deep-links (not a network call)

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -61,9 +61,10 @@ done < <(find "$ROOT/src" -name '*.c' -type f | sort)
 # ── 1b. Raw network calls (must not exist) ──────────────────────
 #
 # The graph-UI HTTP server (src/ui/httpd.c) is the one component that owns a
-# listening socket. It is first-party, binds 127.0.0.1 only, and is audited
-# separately by scripts/security-ui.sh (binding + CORS checks), so it is
-# exempt from this scan. No other source file may make raw network calls.
+# listening socket. It binds 127.0.0.1 by default; non-loopback binding requires
+# an explicit validated numeric IPv4 configuration and is audited separately by
+# scripts/security-ui.sh (binding + warning + CORS checks). No other source file
+# may make raw network calls.
 
 echo ""
 echo "--- Scanning for raw network calls (must not exist) ---"

--- a/scripts/security-ui.sh
+++ b/scripts/security-ui.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Audits:
 #   A. Frontend asset scan (embedded JS/CSS/HTML or graph-ui/dist/)
-#   B. HTTP server binding (must be 127.0.0.1 only)
+#   B. HTTP server binding (localhost by default; non-loopback is explicit)
 #   C. RPC proxy scope (no system()/popen() in HTTP handler path)
 #   D. CORS check (no wildcard Access-Control-Allow-Origin)
 #
@@ -139,6 +139,9 @@ echo "--- B. HTTP server binding check ---"
 # audit would go blind, so that is a hard failure, not a skip.
 HTTPD="$ROOT/src/ui/httpd.c"
 HTTP_SERVER="$ROOT/src/ui/http_server.c"
+UI_CONFIG="$ROOT/src/ui/config.h"
+UI_CONFIG_C="$ROOT/src/ui/config.c"
+MAIN="$ROOT/src/main.c"
 for f in "$HTTPD" "$HTTP_SERVER"; do
     if [[ ! -f "$f" ]]; then
         echo "BLOCKED: expected UI server source missing: $f"
@@ -147,20 +150,37 @@ for f in "$HTTPD" "$HTTP_SERVER"; do
 done
 
 if [[ -f "$HTTPD" ]]; then
-    # Must bind to 127.0.0.1 only
-    if grep -q '127\.0\.0\.1' "$HTTPD"; then
-        echo "OK: Server binds to 127.0.0.1"
+    # The safe default must remain localhost, including when loading an old
+    # config file that has no host field.
+    if [[ -f "$UI_CONFIG" ]] && grep -qE '#define CBM_UI_DEFAULT_HOST "127\.0\.0\.1"' "$UI_CONFIG" && \
+       [[ -f "$UI_CONFIG_C" ]] && grep -q 'CBM_UI_DEFAULT_HOST' "$UI_CONFIG_C"; then
+        echo "OK: Default UI host is 127.0.0.1"
     else
-        echo "BLOCKED: No 127.0.0.1 binding found in httpd.c"
+        echo "BLOCKED: Default UI host is not provably 127.0.0.1"
         FAIL=1
     fi
 
-    # Must NOT bind to 0.0.0.0 or INADDR_ANY
-    if cat "$HTTPD" "$HTTP_SERVER" 2>/dev/null | grep -E '0\.0\.0\.0|INADDR_ANY|in6addr_any' | grep -v '^\s*//' | grep -v '^\s*\*' > /dev/null 2>&1; then
-        echo "BLOCKED: Server may bind to all interfaces (0.0.0.0/INADDR_ANY found)"
-        FAIL=1
+    # Non-loopback binding must travel through the explicit numeric IPv4 flag
+    # and the validated host parameter; this prevents implicit exposure.
+    if grep -q '"--host="' "$MAIN" && grep -q 'cbm_ui_host_is_valid' "$MAIN" && \
+       grep -q 'cbm_httpd_listen(const char \*host, int port)' "$HTTPD" && \
+       grep -q 'inet_pton(AF_INET' "$HTTPD"; then
+        echo "OK: Non-loopback binding requires explicit validated IPv4 configuration"
     else
-        echo "OK: No 0.0.0.0/INADDR_ANY binding"
+        echo "BLOCKED: Host configuration does not prove explicit validated IPv4 binding"
+        FAIL=1
+    fi
+
+    # A non-loopback bind must be visibly warned about at the point of use.
+    if grep -q 'cbm_ui_host_is_loopback' "$HTTP_SERVER" && \
+       grep -qi 'no authentication' "$HTTP_SERVER" && \
+       grep -qi 'reachable over the network' "$HTTP_SERVER" && \
+       grep -qi 'codebase graph data' "$HTTP_SERVER" && \
+       grep -qi 'firewall' "$HTTP_SERVER"; then
+        echo "OK: Non-loopback binding emits a prominent security warning"
+    else
+        echo "BLOCKED: Non-loopback security warning is missing or incomplete"
+        FAIL=1
     fi
 fi
 

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
  *   --help          Print usage and exit
  *   --ui=true/false Enable/disable HTTP UI server (persisted)
  *   --port=N        Set HTTP UI port (persisted, default 9749)
+ *   --host=IPv4     Set HTTP UI host (persisted, default 127.0.0.1)
  *
  * Signal handling: SIGTERM/SIGINT trigger graceful shutdown.
  * Watcher runs in a background thread, polling for git changes.
@@ -28,6 +29,7 @@ enum {
     MAIN_CLI_ARGC = 2,
     MAIN_FLAG_OFF = 5, /* strlen("--ui=") */
     MAIN_PORT_OFF = 7, /* strlen("--port=") */
+    MAIN_HOST_OFF = 7, /* strlen("--host=") */
     MAIN_MAX_PORT = 65536,
     PARENT_WATCHDOG_STACK_SIZE = 64 * CBM_SZ_1K, /* watchdog only polls — tiny stack suffices */
 };
@@ -517,6 +519,7 @@ static void print_help(void) {
     printf("  --ui=true    Enable HTTP graph visualization (persisted)\n");
     printf("  --ui=false   Disable HTTP graph visualization (persisted)\n");
     printf("  --port=N     Set UI port (default 9749, persisted)\n");
+    printf("  --host=<IPv4> Set UI host (default 127.0.0.1, persisted)\n");
     printf("\nSupported agents (auto-detected):\n");
     printf("  Claude Code, Codex CLI, Gemini CLI, Zed, OpenCode,\n");
     printf("  Antigravity, Aider, KiloCode, Kiro\n");
@@ -570,8 +573,10 @@ static int handle_subcommand(int argc, char **argv) {
     return CBM_NOT_FOUND;
 }
 
-/* Parse --ui= and --port= flags. Returns true if config was modified. */
-static bool parse_ui_flags(int argc, char **argv, cbm_ui_config_t *cfg, bool *explicit_enable) {
+/* Parse --ui=, --port=, and --host= flags. Returns -1 on invalid input,
+ * 0 when unchanged, and 1 when config was modified. */
+static int parse_ui_flags(int argc, char **argv, cbm_ui_config_t *cfg, bool *explicit_enable,
+                          char *error, size_t error_size) {
     bool changed = false;
     for (int i = SKIP_ONE; i < argc; i++) {
         if (strncmp(argv[i], "--ui=", SLEN("--ui=")) == 0) {
@@ -588,8 +593,22 @@ static bool parse_ui_flags(int argc, char **argv, cbm_ui_config_t *cfg, bool *ex
                 changed = true;
             }
         }
+        if (strcmp(argv[i], "--host") == 0) {
+            snprintf(error, error_size, "--host requires a numeric IPv4 value (use --host=<IPv4>)");
+            return -1;
+        }
+        if (strncmp(argv[i], "--host=", SLEN("--host=")) == 0) {
+            const char *host = argv[i] + MAIN_HOST_OFF;
+            if (!cbm_ui_host_is_valid(host)) {
+                snprintf(error, error_size,
+                         "invalid --host value '%s'; expected a numeric IPv4 address", host);
+                return -1;
+            }
+            snprintf(cfg->ui_host, sizeof(cfg->ui_host), "%s", host);
+            changed = true;
+        }
     }
-    return changed;
+    return changed ? 1 : 0;
 }
 
 /* Install platform-specific signal handlers. */
@@ -722,7 +741,14 @@ int main(int argc, char **argv) {
     cbm_ui_config_t ui_cfg;
     cbm_ui_config_load(&ui_cfg);
     bool explicit_ui_enable = false;
-    if (parse_ui_flags(argc, argv, &ui_cfg, &explicit_ui_enable)) {
+    char ui_flag_error[256];
+    int ui_flags_rc = parse_ui_flags(argc, argv, &ui_cfg, &explicit_ui_enable, ui_flag_error,
+                                     sizeof(ui_flag_error));
+    if (ui_flags_rc < 0) {
+        (void)fprintf(stderr, "codebase-memory-mcp: %s\n", ui_flag_error);
+        return 2;
+    }
+    if (ui_flags_rc > 0) {
         cbm_ui_config_save(&ui_cfg);
     }
     /* If the user explicitly asked for the UI but this binary has no embedded
@@ -787,7 +813,7 @@ int main(int argc, char **argv) {
     bool http_started = false;
 
     if (ui_cfg.ui_enabled && CBM_EMBEDDED_FILE_COUNT > 0) {
-        g_http_server = cbm_http_server_new(ui_cfg.ui_port);
+        g_http_server = cbm_http_server_new(ui_cfg.ui_host, ui_cfg.ui_port);
         if (g_http_server) {
             cbm_http_server_set_watcher(g_http_server, g_watcher);
             if (cbm_thread_create(&http_tid, 0, http_thread, g_http_server) == 0) {

--- a/src/ui/config.c
+++ b/src/ui/config.c
@@ -2,8 +2,14 @@
  * config.c — Persistent UI configuration (JSON via yyjson).
  *
  * Config file: ~/.cache/codebase-memory-mcp/config.json
- * Format: {"ui_enabled": false, "ui_port": 9749}
+ * Format: {"ui_enabled": false, "ui_port": 9749, "ui_host": "127.0.0.1"}
  */
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <stdatomic.h>
+#endif
+
 #include "foundation/constants.h"
 #include "ui/config.h"
 #include "ui/embedded_assets.h"
@@ -15,8 +21,42 @@
 #include <yyjson/yyjson.h>
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef _WIN32
+#include <arpa/inet.h>
+#endif
+
+#ifdef _WIN32
+static void cbm_ui_host_socket_init(void) {
+    static atomic_int started = 0;
+    int expected = 0;
+    if (atomic_compare_exchange_strong(&started, &expected, 1)) {
+        WSADATA wsa;
+        (void)WSAStartup(MAKEWORD(2, 2), &wsa);
+    }
+}
+#endif
+
+bool cbm_ui_host_is_valid(const char *host) {
+    struct in_addr addr;
+#ifdef _WIN32
+    cbm_ui_host_socket_init();
+#endif
+    return host && host[0] != '\0' && inet_pton(AF_INET, host, &addr) == 1;
+}
+
+bool cbm_ui_host_is_loopback(const char *host) {
+    struct in_addr addr;
+#ifdef _WIN32
+    cbm_ui_host_socket_init();
+#endif
+    if (!host || inet_pton(AF_INET, host, &addr) != 1)
+        return false;
+    return (ntohl(addr.s_addr) & UINT32_C(0xff000000)) == UINT32_C(0x7f000000);
+}
 
 /* ── Path ────────────────────────────────────────────────────── */
 
@@ -33,6 +73,7 @@ void cbm_ui_config_path(char *buf, int bufsz) {
 void cbm_ui_config_load(cbm_ui_config_t *cfg) {
     cfg->ui_enabled = CBM_UI_DEFAULT_ENABLED;
     cfg->ui_port = CBM_UI_DEFAULT_PORT;
+    snprintf(cfg->ui_host, sizeof(cfg->ui_host), "%s", CBM_UI_DEFAULT_HOST);
 
     char path[CBM_SZ_1K];
     cbm_ui_config_path(path, (int)sizeof(path));
@@ -88,6 +129,14 @@ void cbm_ui_config_load(cbm_ui_config_t *cfg) {
         cfg->ui_port = (int)yyjson_get_int(v_port);
     }
 
+    yyjson_val *v_host = yyjson_obj_get(root, "ui_host");
+    if (yyjson_is_str(v_host)) {
+        const char *host = yyjson_get_str(v_host);
+        if (cbm_ui_host_is_valid(host)) {
+            snprintf(cfg->ui_host, sizeof(cfg->ui_host), "%s", host);
+        }
+    }
+
     yyjson_doc_free(doc);
 }
 
@@ -112,6 +161,8 @@ void cbm_ui_config_save(const cbm_ui_config_t *cfg) {
 
     yyjson_mut_obj_add_bool(doc, root, "ui_enabled", cfg->ui_enabled);
     yyjson_mut_obj_add_int(doc, root, "ui_port", cfg->ui_port);
+    yyjson_mut_obj_add_str(doc, root, "ui_host",
+                           cbm_ui_host_is_valid(cfg->ui_host) ? cfg->ui_host : CBM_UI_DEFAULT_HOST);
 
     size_t json_len = 0;
     char *json = yyjson_mut_write(doc, YYJSON_WRITE_PRETTY, &json_len);

--- a/src/ui/config.h
+++ b/src/ui/config.h
@@ -1,7 +1,7 @@
 /*
  * config.h — Persistent UI configuration.
  *
- * Stores ui_enabled and ui_port in ~/.cache/codebase-memory-mcp/config.json.
+ * Stores ui_enabled, ui_port, and ui_host in ~/.cache/codebase-memory-mcp/config.json.
  * Thread-safe: load/save are independent operations on the filesystem.
  */
 #ifndef CBM_UI_CONFIG_H
@@ -12,11 +12,18 @@
 /* Default values */
 #define CBM_UI_DEFAULT_PORT 9749
 #define CBM_UI_DEFAULT_ENABLED false
+#define CBM_UI_DEFAULT_HOST "127.0.0.1"
+#define CBM_UI_HOST_MAX 16 /* INET_ADDRSTRLEN: max IPv4 text length + NUL */
 
 typedef struct {
     bool ui_enabled;
     int ui_port;
+    char ui_host[CBM_UI_HOST_MAX];
 } cbm_ui_config_t;
+
+/* Validate numeric IPv4 text and identify IPv4 loopback addresses. */
+bool cbm_ui_host_is_valid(const char *host);
+bool cbm_ui_host_is_loopback(const char *host);
 
 /* Load config from disk. Missing/corrupt file → defaults. */
 void cbm_ui_config_load(cbm_ui_config_t *cfg);

--- a/src/ui/http_server.c
+++ b/src/ui/http_server.c
@@ -10,11 +10,12 @@
  *   GET/POST /api/... → UI support endpoints (layout, index, browse, …)
  *   *                 → 404
  *
- * Runs in a background pthread. Binds to 127.0.0.1 only (see httpd.c).
+ * Runs in a background pthread. Binds to the configured IPv4 address (see httpd.c).
  * Has its own cbm_mcp_server_t with a separate SQLite connection (WAL reader).
  */
 #include "ui/http_server.h"
 #include "ui/httpd.h"
+#include "ui/config.h"
 #include "ui/embedded_assets.h"
 #include "ui/layout3d.h"
 #include "mcp/mcp.h"
@@ -133,6 +134,7 @@ struct cbm_http_server {
     struct cbm_watcher *watcher; /* external watcher ref (not owned) */
     atomic_int stop_flag;
     int port;
+    char host[CBM_UI_HOST_MAX];
     bool listener_ok;
 };
 
@@ -1848,11 +1850,16 @@ static void dispatch_request(cbm_http_server_t *srv, cbm_http_conn_t *c,
 
 /* ── Public API ───────────────────────────────────────────────── */
 
-cbm_http_server_t *cbm_http_server_new(int port) {
+cbm_http_server_t *cbm_http_server_new(const char *host, int port) {
     cbm_http_server_t *srv = calloc(1, sizeof(*srv));
     if (!srv)
         return NULL;
 
+    if (!cbm_ui_host_is_valid(host)) {
+        free(srv);
+        return NULL;
+    }
+    snprintf(srv->host, sizeof(srv->host), "%s", host);
     srv->port = port;
     atomic_store(&srv->stop_flag, 0);
 
@@ -1864,8 +1871,7 @@ cbm_http_server_t *cbm_http_server_new(int port) {
         return NULL;
     }
 
-    /* Bind to localhost only (httpd refuses anything else by construction) */
-    srv->listener = cbm_httpd_listen(port);
+    srv->listener = cbm_httpd_listen(srv->host, port);
     if (!srv->listener) {
         char port_str[16];
         snprintf(port_str, sizeof(port_str), "%d", port);
@@ -1877,12 +1883,25 @@ cbm_http_server_t *cbm_http_server_new(int port) {
     }
 
     srv->port = cbm_httpd_port(srv->listener);
+    snprintf(srv->host, sizeof(srv->host), "%s", cbm_httpd_host(srv->listener));
     srv->listener_ok = true;
+
+    if (!cbm_ui_host_is_loopback(srv->host)) {
+        const char *scope = strcmp(srv->host, "0.0.0.0") == 0 ? " (all interfaces)" : "";
+        (void)fprintf(stderr,
+                      "\nWARNING: Graph UI is listening on %s:%d%s.\n"
+                      "The UI has no authentication, is reachable over the network, and may "
+                      "expose codebase graph data and UI actions.\n"
+                      "Protect it with a firewall or trusted network. Prefer binding to a "
+                      "specific LAN IP rather than 0.0.0.0.\n\n",
+                      srv->host, srv->port, scope);
+        (void)fflush(stderr);
+    }
 
     char port_str[16];
     snprintf(port_str, sizeof(port_str), "%d", srv->port);
     char url[64];
-    snprintf(url, sizeof(url), "http://127.0.0.1:%d", srv->port);
+    snprintf(url, sizeof(url), "http://%s:%d", srv->host, srv->port);
     cbm_log_info("ui.serving", "url", url, "port", port_str);
 
     return srv;
@@ -1938,6 +1957,10 @@ bool cbm_http_server_is_running(const cbm_http_server_t *srv) {
 
 int cbm_http_server_port(const cbm_http_server_t *srv) {
     return (srv && srv->listener_ok) ? srv->port : -1;
+}
+
+const char *cbm_http_server_host(const cbm_http_server_t *srv) {
+    return (srv && srv->listener_ok) ? srv->host : NULL;
 }
 
 void cbm_http_server_set_recv_deadline_ms(cbm_http_server_t *srv, int ms) {

--- a/src/ui/http_server.h
+++ b/src/ui/http_server.h
@@ -1,7 +1,7 @@
 /*
  * http_server.h — Embedded HTTP server for the graph visualization UI.
  *
- * Binds to 127.0.0.1:<port> only (localhost).
+ * Binds to a validated numeric IPv4 host:<port>; localhost remains the default.
  * Serves embedded frontend assets and proxies /rpc to a dedicated
  * read-only cbm_mcp_server_t instance.
  *
@@ -16,10 +16,10 @@
 typedef struct cbm_http_server cbm_http_server_t;
 struct cbm_watcher;
 
-/* Create an HTTP server on the given port.
+/* Create an HTTP server on the given numeric IPv4 host and port.
  * Creates its own cbm_mcp_server_t with a separate read-only SQLite connection.
  * Returns NULL on failure (e.g. port in use). */
-cbm_http_server_t *cbm_http_server_new(int port);
+cbm_http_server_t *cbm_http_server_new(const char *host, int port);
 
 /* Free the HTTP server (call after thread has been joined). */
 void cbm_http_server_free(cbm_http_server_t *srv);
@@ -36,6 +36,9 @@ bool cbm_http_server_is_running(const cbm_http_server_t *srv);
 
 /* The actually-bound port (useful when constructed with port 0 in tests). */
 int cbm_http_server_port(const cbm_http_server_t *srv);
+
+/* The configured IPv4 host used for the bind. */
+const char *cbm_http_server_host(const cbm_http_server_t *srv);
 
 /* Override the per-connection receive deadline (tests use short values). */
 void cbm_http_server_set_recv_deadline_ms(cbm_http_server_t *srv, int ms);

--- a/src/ui/httpd.c
+++ b/src/ui/httpd.c
@@ -3,7 +3,7 @@
  *
  * Original implementation written for this project from RFC 9112 and the
  * needs of our endpoints (see httpd.h for the full design constraints:
- * single-threaded, localhost-only, strict CRLF, Connection: close).
+ * single-threaded, IPv4-only, strict CRLF, Connection: close).
  */
 #include "ui/httpd.h"
 
@@ -46,6 +46,7 @@ typedef int cbm_sock_t;
 struct cbm_httpd {
     cbm_sock_t fd;
     int port;
+    char host[CBM_HTTPD_HOST_MAX];
     int recv_deadline_ms;
 };
 
@@ -111,7 +112,7 @@ static int send_all(cbm_sock_t fd, const void *data, size_t len) {
 
 /* ── Listener ─────────────────────────────────────────────────── */
 
-cbm_httpd_t *cbm_httpd_listen(int port) {
+cbm_httpd_t *cbm_httpd_listen(const char *host, int port) {
 #ifdef _WIN32
     static atomic_int wsa_started = 0;
     int expected = 0;
@@ -135,12 +136,16 @@ cbm_httpd_t *cbm_httpd_listen(int port) {
     setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
 #endif
 
-    /* Loopback only — never any other interface. */
+    /* The caller validates host for CLI/config use; validate again at the
+     * transport boundary so this API cannot accidentally resolve hostnames. */
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;
     addr.sin_port = htons((unsigned short)port);
-    addr.sin_addr.s_addr = htonl(0x7F000001); /* 127.0.0.1 */
+    if (!host || inet_pton(AF_INET, host, &addr.sin_addr) != 1) {
+        cbm_sock_close(fd);
+        return NULL;
+    }
 
     if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0 || listen(fd, 16) != 0) {
         cbm_sock_close(fd);
@@ -162,12 +167,17 @@ cbm_httpd_t *cbm_httpd_listen(int port) {
     }
     d->fd = fd;
     d->port = (int)ntohs(bound.sin_port);
+    snprintf(d->host, sizeof(d->host), "%s", host);
     d->recv_deadline_ms = CBM_HTTP_RECV_DEADLINE_MS;
     return d;
 }
 
 int cbm_httpd_port(const cbm_httpd_t *d) {
     return d ? d->port : -1;
+}
+
+const char *cbm_httpd_host(const cbm_httpd_t *d) {
+    return d ? d->host : NULL;
 }
 
 void cbm_httpd_set_recv_deadline_ms(cbm_httpd_t *d, int ms) {

--- a/src/ui/httpd.h
+++ b/src/ui/httpd.h
@@ -2,14 +2,14 @@
  * httpd.h — First-party HTTP/1.1 server transport for the graph UI.
  *
  * Original implementation written for this project from RFC 9112 and the
- * needs of the graph-UI endpoints. Localhost-only by construction.
+ * needs of the graph-UI endpoints. IPv4-only by construction.
  *
  * Design constraints (deliberate — do not "improve" without reading this):
  *   - SINGLE-THREADED, sequential request handling. The routing layer
  *     (http_server.c) keeps per-request state in static buffers; a thread
  *     pool would break it. One stalled client can hold the loop for at most
- *     the receive deadline (default 5 s) — acceptable for a localhost tool.
- *   - Binds 127.0.0.1 only (IPv4 loopback). Never any other interface.
+ *     the receive deadline (default 5 s) — acceptable for a local tool.
+ *   - Binds the validated numeric IPv4 address selected by the UI config.
  *   - Every response carries explicit Content-Length and "Connection: close";
  *     keep-alive is intentionally NOT implemented (smaller parsing surface;
  *     loopback reconnects are sub-millisecond). Known trade-off: on Windows,
@@ -41,6 +41,8 @@
 typedef struct cbm_httpd cbm_httpd_t;         /* listener */
 typedef struct cbm_http_conn cbm_http_conn_t; /* accepted connection */
 
+#define CBM_HTTPD_HOST_MAX 16 /* INET_ADDRSTRLEN */
+
 /* A parsed request. `path` and `query` are raw (NOT percent-decoded).
  * `origin` and `accept_language` are the header values consumed by the
  * routing layer ("" when absent). `body` is heap-allocated, NUL-terminated. */
@@ -57,12 +59,15 @@ typedef struct {
 
 /* ── Listener lifecycle ───────────────────────────────────────── */
 
-/* Listen on 127.0.0.1:<port>. port 0 binds an ephemeral port (tests).
- * Returns NULL if the port is unavailable. */
-cbm_httpd_t *cbm_httpd_listen(int port);
+/* Listen on numeric IPv4 host:<port>. port 0 binds an ephemeral port (tests).
+ * Returns NULL if the host/port is invalid or unavailable. */
+cbm_httpd_t *cbm_httpd_listen(const char *host, int port);
 
 /* The actually-bound port (differs from the requested one for port 0). */
 int cbm_httpd_port(const cbm_httpd_t *d);
+
+/* The configured IPv4 host used for the bind. */
+const char *cbm_httpd_host(const cbm_httpd_t *d);
 
 /* Override the per-connection receive deadline (tests use short values). */
 void cbm_httpd_set_recv_deadline_ms(cbm_httpd_t *d, int ms);

--- a/tests/test_httpd.c
+++ b/tests/test_httpd.c
@@ -376,10 +376,11 @@ TEST(httpd_resolves_bare_binary_path_from_path) {
 /* ── Transport integration (listener only) ────────────────────── */
 
 TEST(httpd_listen_ephemeral_port) {
-    cbm_httpd_t *d = cbm_httpd_listen(0);
+    cbm_httpd_t *d = cbm_httpd_listen("127.0.0.1", 0);
     ASSERT_NOT_NULL(d);
     int port = cbm_httpd_port(d);
     ASSERT_GT(port, 0);
+    ASSERT_STR_EQ(cbm_httpd_host(d), "127.0.0.1");
     /* accept with a short timeout and no client → NULL, promptly */
     cbm_http_conn_t *c = cbm_httpd_accept(d, 50);
     ASSERT_NULL(c);
@@ -388,11 +389,27 @@ TEST(httpd_listen_ephemeral_port) {
 }
 
 TEST(httpd_listen_port_collision_returns_null) {
-    cbm_httpd_t *d1 = cbm_httpd_listen(0);
+    cbm_httpd_t *d1 = cbm_httpd_listen("127.0.0.1", 0);
     ASSERT_NOT_NULL(d1);
-    cbm_httpd_t *d2 = cbm_httpd_listen(cbm_httpd_port(d1));
+    cbm_httpd_t *d2 = cbm_httpd_listen("127.0.0.1", cbm_httpd_port(d1));
     ASSERT_NULL(d2);
     cbm_httpd_close(d1);
+    PASS();
+}
+
+TEST(httpd_listen_all_interfaces) {
+    cbm_httpd_t *d = cbm_httpd_listen("0.0.0.0", 0);
+    ASSERT_NOT_NULL(d);
+    ASSERT_GT(cbm_httpd_port(d), 0);
+    ASSERT_STR_EQ(cbm_httpd_host(d), "0.0.0.0");
+    cbm_httpd_close(d);
+    PASS();
+}
+
+TEST(httpd_listen_rejects_invalid_host) {
+    ASSERT_NULL(cbm_httpd_listen("", 0));
+    ASSERT_NULL(cbm_httpd_listen("localhost", 0));
+    ASSERT_NULL(cbm_httpd_listen("999.1.1.1", 0));
     PASS();
 }
 
@@ -409,7 +426,7 @@ static void *th_server_thread(void *arg) {
 }
 
 static int th_server_start(th_server_t *ts) {
-    ts->srv = cbm_http_server_new(0);
+    ts->srv = cbm_http_server_new("127.0.0.1", 0);
     if (!ts->srv)
         return -1;
     if (cbm_thread_create(&ts->tid, 0, th_server_thread, ts->srv) != 0) {
@@ -420,7 +437,7 @@ static int th_server_start(th_server_t *ts) {
 }
 
 static int th_server_start_with_watcher(th_server_t *ts, cbm_watcher_t *watcher) {
-    ts->srv = cbm_http_server_new(0);
+    ts->srv = cbm_http_server_new("127.0.0.1", 0);
     if (!ts->srv)
         return -1;
     cbm_http_server_set_watcher(ts->srv, watcher);
@@ -1093,6 +1110,7 @@ TEST(git_context_resolve_no_hang_under_live_ui_sockets) {
 TEST(ui_server_rejects_non_loopback_host) {
     th_server_t ts;
     ASSERT_EQ(th_server_start(&ts), 0);
+    ASSERT_STR_EQ(cbm_http_server_host(ts.srv), "127.0.0.1");
     int port = cbm_http_server_port(ts.srv);
     char resp[4096];
 
@@ -1195,6 +1213,8 @@ SUITE(httpd) {
     /* Transport */
     RUN_TEST(httpd_listen_ephemeral_port);
     RUN_TEST(httpd_listen_port_collision_returns_null);
+    RUN_TEST(httpd_listen_all_interfaces);
+    RUN_TEST(httpd_listen_rejects_invalid_host);
 
     /* Full UI server */
     RUN_TEST(ui_server_rejects_non_loopback_host);

--- a/tests/test_ui.c
+++ b/tests/test_ui.c
@@ -41,6 +41,7 @@ TEST(config_load_defaults) {
 
     ASSERT_FALSE(cfg.ui_enabled);
     ASSERT_EQ(cfg.ui_port, 9749);
+    ASSERT_STR_EQ(cfg.ui_host, CBM_UI_DEFAULT_HOST);
 
     /* Restore HOME */
     if (old_home) {
@@ -61,7 +62,7 @@ TEST(config_save_and_reload) {
     cbm_setenv("HOME", td, 1);
 
     /* Save */
-    cbm_ui_config_t cfg = {.ui_enabled = true, .ui_port = 8080};
+    cbm_ui_config_t cfg = {.ui_enabled = true, .ui_port = 8080, .ui_host = "192.168.88.26"};
     cbm_ui_config_save(&cfg);
 
     /* Reload */
@@ -70,6 +71,7 @@ TEST(config_save_and_reload) {
 
     ASSERT_TRUE(loaded.ui_enabled);
     ASSERT_EQ(loaded.ui_port, 8080);
+    ASSERT_STR_EQ(loaded.ui_host, "192.168.88.26");
 
     if (old_home) {
         cbm_setenv("HOME", old_home, 1);
@@ -89,11 +91,11 @@ TEST(config_overwrite) {
     cbm_setenv("HOME", td, 1);
 
     /* Save with ui_enabled=true */
-    cbm_ui_config_t cfg1 = {.ui_enabled = true, .ui_port = 9749};
+    cbm_ui_config_t cfg1 = {.ui_enabled = true, .ui_port = 9749, .ui_host = "0.0.0.0"};
     cbm_ui_config_save(&cfg1);
 
     /* Overwrite with ui_enabled=false */
-    cbm_ui_config_t cfg2 = {.ui_enabled = false, .ui_port = 9749};
+    cbm_ui_config_t cfg2 = {.ui_enabled = false, .ui_port = 9749, .ui_host = "127.0.0.1"};
     cbm_ui_config_save(&cfg2);
 
     /* Reload should show false */
@@ -137,6 +139,7 @@ TEST(config_corrupt_file) {
     cbm_ui_config_load(&cfg);
     ASSERT_FALSE(cfg.ui_enabled);
     ASSERT_EQ(cfg.ui_port, 9749);
+    ASSERT_STR_EQ(cfg.ui_host, CBM_UI_DEFAULT_HOST);
 
     if (old_home) {
         cbm_setenv("HOME", old_home, 1);
@@ -172,12 +175,27 @@ TEST(config_missing_fields) {
     cbm_ui_config_load(&cfg);
     ASSERT_FALSE(cfg.ui_enabled); /* defaults for missing field */
     ASSERT_EQ(cfg.ui_port, 5555); /* present field loaded */
+    ASSERT_STR_EQ(cfg.ui_host, CBM_UI_DEFAULT_HOST); /* old config remains localhost-only */
 
     if (old_home) {
         cbm_setenv("HOME", old_home, 1);
         free(old_home);
     }
 
+    PASS();
+}
+
+TEST(config_host_validation_and_loopback) {
+    ASSERT_TRUE(cbm_ui_host_is_valid("127.0.0.1"));
+    ASSERT_TRUE(cbm_ui_host_is_valid("0.0.0.0"));
+    ASSERT_TRUE(cbm_ui_host_is_valid("192.168.88.26"));
+    ASSERT_FALSE(cbm_ui_host_is_valid(""));
+    ASSERT_FALSE(cbm_ui_host_is_valid("localhost"));
+    ASSERT_FALSE(cbm_ui_host_is_valid("999.1.1.1"));
+    ASSERT_TRUE(cbm_ui_host_is_loopback("127.0.0.1"));
+    ASSERT_TRUE(cbm_ui_host_is_loopback("127.0.0.2"));
+    ASSERT_FALSE(cbm_ui_host_is_loopback("0.0.0.0"));
+    ASSERT_FALSE(cbm_ui_host_is_loopback("192.168.88.26"));
     PASS();
 }
 
@@ -790,6 +808,7 @@ SUITE(ui) {
     RUN_TEST(config_overwrite);
     RUN_TEST(config_corrupt_file);
     RUN_TEST(config_missing_fields);
+    RUN_TEST(config_host_validation_and_loopback);
 
     /* Embedded assets (stub) */
     RUN_TEST(embedded_lookup_not_found);


### PR DESCRIPTION
## What does this PR do?

Adds a persisted `--host=<IPv4>` option for the embedded Graph UI.

The default remains `127.0.0.1`, preserving the existing localhost-only security posture and backward compatibility with older config files.

Supported examples:

    codebase-memory-mcp --ui=true --host=127.0.0.1 --port=9749
    codebase-memory-mcp --ui=true --host=192.168.88.26 --port=9749
    codebase-memory-mcp --ui=true --host=0.0.0.0 --port=9749

The implementation:

- accepts numeric IPv4 addresses only;
- rejects empty, malformed, and hostname values with exit status 2;
- persists `ui_host` alongside the existing UI settings;
- passes the configured host through the HTTP server/listener APIs;
- preserves port `0` support for tests;
- emits a prominent warning for non-loopback bindings;
- identifies `0.0.0.0` as all interfaces;
- keeps the existing CORS policy unchanged;
- updates documentation and the UI security audit.

Fixes #229

## Security

Non-loopback binding remains an explicit opt-in.

The warning explains that the UI:

- has no authentication;
- is reachable over the network;
- may expose codebase graph data and UI actions;
- should be protected with a firewall or trusted network.

The documentation recommends binding a specific LAN address instead of `0.0.0.0`.

## Validation

- [x] Every commit is signed off
- [x] `make -f Makefile.cbm test` — 6,012 passed, 1 platform-specific skip
- [x] `make -f Makefile.cbm lint-ci CPPCHECK=/opt/cppcheck/bin/cppcheck CLANG_FORMAT=clang-format-20`
- [x] `scripts/security-ui.sh`
- [x] `make -j$(nproc) -f Makefile.cbm cbm`
- [x] `make -j$(nproc) -f Makefile.cbm cbm-with-ui`
- [x] Focused UI/HTTP tests — 64 passed, 1 platform-specific skip
- [x] New behavior is covered by tests
- [x] Default `127.0.0.1` binding tested manually
- [x] `0.0.0.0` binding and warning tested manually
- [x] Specific `192.168.88.26` binding tested manually
- [x] Persisted host reuse tested manually
- [x] Invalid and empty host rejection tested manually

## Portability note

Windows runtime testing was not available locally. The Windows Winsock and `AF_INET` paths compile through the project code, with additional Windows validation left to the repository CI matrix.
