### PR TITLE
fix(mcp): ignore ::missed shadow rows when resolving a db's project name

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -1335,10 +1335,23 @@ static bool db_internal_project_name(const char *full_path, char *name_out, size
     cbm_project_t *projs = NULL;
     int n = 0;
     bool ok = false;
-    if (cbm_store_list_projects(st, &projs, &n) == CBM_STORE_OK && n == 1 && projs[0].name &&
-        projs[0].name[0]) {
-        snprintf(name_out, name_sz, "%s", projs[0].name);
-        ok = true;
+    if (cbm_store_list_projects(st, &projs, &n) == CBM_STORE_OK) {
+        /* Ignore internal shadow projects ("<name>::missed" miss-graph rows):
+         * they share the db with the primary project and must not make it
+         * unresolvable — requiring n == 1 over ALL rows made every project
+         * with a miss graph vanish from list_projects and the UI (#1044). */
+        int primary = -1;
+        int primary_count = 0;
+        for (int i = 0; i < n; i++) {
+            if (projs[i].name && projs[i].name[0] && !strstr(projs[i].name, "::")) {
+                primary = i;
+                primary_count++;
+            }
+        }
+        if (primary_count == 1) {
+            snprintf(name_out, name_sz, "%s", projs[primary].name);
+            ok = true;
+        }
     }
     cbm_store_free_projects(projs, n);
     if (ok && out_store) {

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -4134,6 +4134,81 @@ TEST(tool_resolve_store_by_internal_name_issue704) {
     PASS();
 }
 
+/* ── #1044: a "<name>::missed" shadow row must not hide the project ──
+ *
+ * The miss-graph pass inserts a second `projects` row ("<name>::missed") so
+ * its nodes satisfy the FK on nodes.project. db_internal_project_name
+ * required the projects table to hold EXACTLY ONE row, so any project with
+ * a miss graph vanished from list_projects and the graph UI, and the
+ * fallback-scan resolve path failed.
+ *
+ * RED on buggy code / GREEN on the fix:
+ *   A. list_projects still advertises "delta1044" while the shadow row exists.
+ *   B. the shadow name itself is never advertised.
+ *   C. search_graph(project="delta1044") still resolves and returns the node.
+ */
+TEST(tool_list_projects_ignores_missed_shadow_issue1044) {
+    char cache[256];
+    snprintf(cache, sizeof(cache), "/tmp/cbm-issue1044-XXXXXX");
+    if (!cbm_mkdtemp(cache)) {
+        PASS(); /* skip if mkdtemp fails — not a #1044 signal */
+    }
+
+    const char *saved = getenv("CBM_CACHE_DIR");
+    char *saved_copy = saved ? strdup(saved) : NULL;
+    cbm_setenv("CBM_CACHE_DIR", cache, 1);
+
+    ASSERT_TRUE(issue704_make_db(cache, "delta1044.db", "delta1044", "deltaFunc1044"));
+
+    /* Add the shadow row exactly the way the miss-graph pass does. */
+    char db_path[700];
+    snprintf(db_path, sizeof(db_path), "%s/delta1044.db", cache);
+    cbm_store_t *st = cbm_store_open_path(db_path);
+    ASSERT_NOT_NULL(st);
+    ASSERT_EQ(cbm_store_upsert_project(st, "delta1044::missed", ""), CBM_STORE_OK);
+    cbm_store_close(st);
+
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+
+    /* ── A + B: primary advertised, shadow hidden ─────────────────── */
+    char *list =
+        cbm_mcp_server_handle(srv, "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
+                                   "\"params\":{\"name\":\"list_projects\",\"arguments\":{}}}");
+    ASSERT_NOT_NULL(list);
+    ASSERT_NOT_NULL(strstr(list, "delta1044")); /* RED before: db skipped as ghost */
+    ASSERT_NULL(strstr(list, "::missed"));      /* shadow never advertised */
+    free(list);
+
+    /* ── C: the project still resolves and returns its node ───────── */
+    char *q = cbm_mcp_server_handle(
+        srv, "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\","
+             "\"params\":{\"name\":\"search_graph\",\"arguments\":{"
+             "\"project\":\"delta1044\",\"name_pattern\":\"deltaFunc1044\",\"limit\":5}}}");
+    ASSERT_NOT_NULL(q);
+    ASSERT_NOT_NULL(strstr(q, "deltaFunc1044"));
+    ASSERT_NULL(strstr(q, "not found"));
+    free(q);
+
+    cbm_mcp_server_free(srv);
+
+    /* ── cleanup ───────────────────────────────────────────────────── */
+    if (saved_copy) {
+        cbm_setenv("CBM_CACHE_DIR", saved_copy, 1);
+        free(saved_copy);
+    } else {
+        cbm_unsetenv("CBM_CACHE_DIR");
+    }
+    cbm_unlink(db_path);
+    char side1044[740];
+    snprintf(side1044, sizeof(side1044), "%s-wal", db_path);
+    cbm_unlink(side1044);
+    snprintf(side1044, sizeof(side1044), "%s-shm", db_path);
+    cbm_unlink(side1044);
+    cbm_rmdir(cache);
+    PASS();
+}
+
 /* ══════════════════════════════════════════════════════════════════
  *  QUERY STORE READ-ONLY  (data-integrity reproductions)
  *
@@ -5763,6 +5838,7 @@ SUITE(mcp) {
     RUN_TEST(tool_bad_project_name_no_overflow_issue235);
     RUN_TEST(tool_bad_project_error_valid_json_issue235);
     RUN_TEST(tool_resolve_store_by_internal_name_issue704);
+    RUN_TEST(tool_list_projects_ignores_missed_shadow_issue1044);
 
     /* auto_watch gate (distilled from PR #625) */
     RUN_TEST(mcp_auto_watch_default_registers_watcher_on_connect);


### PR DESCRIPTION
Fixes #1044

## Problem

Any project whose db carries a `<name>::missed` shadow row — created by the miss-graph pass for projects with at least one parse/index failure, i.e. most real-world repos — **vanished from `list_projects` and the graph UI**, and the fallback-scan resolve path failed. Directly-addressed tools kept working, which made the failure look like "nothing is indexed" while the index was fully present.

Root cause (details in the issue): since #704, `build_project_json_entry` and `resolve_store_fallback_scan` derive the db's internal name via `db_internal_project_name`, which required the per-db `projects` table to hold **exactly one** row (`n == 1`). The miss-graph pass adds a second row (`<name>::missed`, needed for the FK on `nodes.project`), so `n == 2` and the whole db was skipped as "ghost / unreadable". The comment in `store.c` still claims the shadow row is "invisible to list_projects" — that stopped being true when #704 made listing key on this table.

## Fix

`db_internal_project_name` now ignores internal shadow rows (names containing `::`) and requires exactly one **primary** row. Shadow rows keep satisfying the FK, never surface in listings, and no longer make the primary project unresolvable.

## Test

`tool_list_projects_ignores_missed_shadow_issue1044` in `tests/test_mcp.c`, modeled on the #704 reproduce-first fixture (isolated `CBM_CACHE_DIR`, db built via `issue704_make_db`, shadow row added exactly the way the miss-graph pass does):

- A: `list_projects` still advertises the primary project while the shadow row exists — **RED before this fix** (verified: `150 passed, 1 failed` on unpatched code), GREEN after (`151 passed`);
- B: the shadow name is never advertised;
- C: `search_graph` on the project still resolves and returns its node.

`scripts/test.sh` (ASan+UBSan) passes locally on macOS arm64. `clang-format --dry-run` reports zero warnings on the changed hunks (the 3 pre-existing warnings at `tests/test_mcp.c:967-968` are untouched, unrelated lines); cppcheck clean. clang-tidy was not available locally — relying on CI for that layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
