### PR TITLE
fix(install): give Aider CLI-form instructions instead of MCP tool calls

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -1268,6 +1268,46 @@ static const char agent_instructions_content[] =
     "- Who calls it: `trace_path(function_name=\"OrderHandler\", direction=\"inbound\")`\n"
     "- Read source: `get_code_snippet(qualified_name=\"pkg/orders.OrderHandler\")`\n";
 
+/* #1032: Aider has NO MCP support — it reads CONVENTIONS.md but can only run
+ * shell commands. Installing the MCP-tool-centric instructions above told the
+ * model to call tools it cannot invoke. Aider gets a CLI-form variant: the
+ * exact same discovery priority, expressed as runnable `codebase-memory-mcp
+ * cli` commands (usable via Aider's /run or auto-approved shell). */
+static const char aider_instructions_content[] =
+    "# Codebase Knowledge Graph (codebase-memory-mcp)\n"
+    "\n"
+    "This project uses codebase-memory-mcp to maintain a knowledge graph of the codebase.\n"
+    "Aider has no MCP support, so invoke the graph through the CLI (e.g. via /run).\n"
+    "ALWAYS prefer these commands over grep/glob/file-search for code discovery.\n"
+    "\n"
+    "## Priority Order (CLI form)\n"
+    "1. Find functions/classes/routes:\n"
+    "   codebase-memory-mcp cli search_graph "
+    "'{\"project\":\"<name>\",\"name_pattern\":\".*Foo.*\"}'\n"
+    "2. Who calls X / what does X call:\n"
+    "   codebase-memory-mcp cli trace_path "
+    "'{\"project\":\"<name>\",\"function_name\":\"Foo\",\"direction\":\"both\"}'\n"
+    "3. Read a specific function/class:\n"
+    "   codebase-memory-mcp cli get_code_snippet "
+    "'{\"project\":\"<name>\",\"qualified_name\":\"<qn>\"}'\n"
+    "4. Complex patterns (Cypher):\n"
+    "   codebase-memory-mcp cli query_graph '{\"project\":\"<name>\",\"query\":\"MATCH ...\"}'\n"
+    "5. Project overview:\n"
+    "   codebase-memory-mcp cli get_architecture '{\"project\":\"<name>\"}'\n"
+    "\n"
+    "First use in a repo: codebase-memory-mcp cli index_repository '{\"repo_path\":\"<abs "
+    "path>\"}'\n"
+    "List indexed projects (for <name>): codebase-memory-mcp cli list_projects '{}'\n"
+    "\n"
+    "## When to fall back to grep/glob\n"
+    "- Searching for string literals, error messages, config values\n"
+    "- Searching non-code files (Dockerfiles, shell scripts, configs)\n"
+    "- When the CLI returns insufficient results\n";
+
+const char *cbm_get_aider_instructions(void) {
+    return aider_instructions_content;
+}
+
 const char *cbm_get_agent_instructions(void) {
     return agent_instructions_content;
 }
@@ -3432,7 +3472,8 @@ static void install_cli_agent_configs(const cbm_detected_agents_t *agents, const
         } else {
             printf("Aider:\n");
             if (!dry_run) {
-                cbm_upsert_instructions(ip, agent_instructions_content);
+                /* #1032: Aider cannot call MCP tools — CLI-form instructions. */
+                cbm_upsert_instructions(ip, aider_instructions_content);
             }
             printf("  instructions: %s\n", ip);
         }

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -204,6 +204,9 @@ int cbm_remove_instructions(const char *path);
 /* Get the shared agent instructions content (markdown). */
 const char *cbm_get_agent_instructions(void);
 
+/* #1032: Aider variant — CLI-form discovery commands (Aider has no MCP). */
+const char *cbm_get_aider_instructions(void);
+
 /* ── Pre-tool hook management ─────────────────────────────────── */
 
 /* Upsert a PreToolUse hook in ~/.claude/settings.json for Claude Code.

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -2260,6 +2260,23 @@ TEST(cli_upsert_antigravity_mcp_replace) {
  *  Group C: Instructions File Upsert
  * ═══════════════════════════════════════════════════════════════════ */
 
+/* #1032: Aider has no MCP support, but its installed CONVENTIONS.md told the
+ * model to call MCP tools it cannot invoke (search_graph(...) style). The
+ * Aider variant must teach the runnable CLI form instead. */
+TEST(cli_aider_instructions_are_cli_form_issue1032) {
+    const char *content = cbm_get_aider_instructions();
+    ASSERT_NOT_NULL(content);
+    /* Every discovery example is a runnable CLI command... */
+    ASSERT(strstr(content, "codebase-memory-mcp cli search_graph") != NULL);
+    ASSERT(strstr(content, "codebase-memory-mcp cli trace_path") != NULL);
+    ASSERT(strstr(content, "codebase-memory-mcp cli index_repository") != NULL);
+    /* ...and no bare MCP-call syntax remains to mislead the model. */
+    ASSERT_NULL(strstr(content, "search_graph(name_pattern"));
+    /* States the constraint explicitly. */
+    ASSERT(strstr(content, "no MCP support") != NULL);
+    PASS();
+}
+
 TEST(cli_upsert_instructions_fresh) {
     char tmpdir[256];
     snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-instr-XXXXXX");
@@ -3201,6 +3218,7 @@ SUITE(cli) {
     RUN_TEST(cli_upsert_antigravity_mcp_replace);
 
     /* Instructions file upsert (6 tests — group C) */
+    RUN_TEST(cli_aider_instructions_are_cli_form_issue1032);
     RUN_TEST(cli_upsert_instructions_fresh);
     RUN_TEST(cli_upsert_instructions_existing);
     RUN_TEST(cli_upsert_instructions_replace);


### PR DESCRIPTION
Closes #1032

The reporter's question exposed a real integration bug: Aider has no MCP support — it reads `CONVENTIONS.md` but can only run shell commands — yet the installer wrote the shared MCP-tool-centric instructions there, telling the model to call `search_graph(...)` and friends, tools Aider can never invoke.

Aider now gets a dedicated instructions variant: the same discovery priority order, expressed as runnable `codebase-memory-mcp cli` commands (usable via Aider's `/run`), including `index_repository` bootstrap and `list_projects` for the project name, with the no-MCP constraint stated explicitly so the model doesn't hallucinate tool access. Guard test asserts the Aider content is CLI-form (and contains no bare MCP-call syntax).

I'll answer the reporter's question on the issue with the working CLI workflow once this lands.

Full local suite 6005 passed, 1 skipped; lint-ci clean.