### PR TITLE
feat(pipeline): version tag on indexed nodes + diff_versions MCP tool

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -701,6 +701,7 @@ static const tool_annotation_def_t TOOL_ANNOTATIONS[] = {
     {"detect_changes", false, true, true, false},
     {"manage_adr", false, true, false, false},
     {"ingest_traces", false, false, false, false},
+    {"diff_versions", true, false, true, false},
 };
 
 static const tool_annotation_def_t *mcp_tool_annotations(const char *name) {

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -90,6 +90,7 @@ enum {
 #include <time.h>
 #include <errno.h>
 #include <stdatomic.h>
+#include <ctype.h>
 
 /* ── Constants ────────────────────────────────────────────────── */
 
@@ -375,8 +376,25 @@ static const tool_def_t TOOLS[] = {
      "are normalized.\"},"
      "\"persistence\":{\"type\":\"boolean\",\"default\":false,\"description\":"
      "\"Write compressed artifact to .codebase-memory/graph.db.zst for team sharing. "
-     "Teammates can bootstrap from the artifact instead of full re-indexing.\"}"
+     "Teammates can bootstrap from the artifact instead of full re-indexing.\"},"
+     "\"version\":{\"type\":\"string\",\"description\":"
+     "\"Version tag stamped on every extracted node (e.g. '28.0', '30.0'). "
+     "Enables cross-version diff queries: MATCH (n:Class {version:'30.0'}) ... "
+     "Auto-detected from trailing path segment when the segment is numeric (e.g. "
+     "/exports/MyApp/28.0 → version='28.0'). Versioned runs always do a full index.\"}"
      "},\"required\":[\"repo_path\"]}"},
+
+    {"diff_versions", "Diff versions",
+     "Compare two indexed versions of the same project to find added, removed, and "
+     "changed nodes. Requires version tags set via index_repository version= parameter.",
+     "{\"type\":\"object\",\"properties\":{"
+     "\"project\":{\"type\":\"string\",\"description\":\"Project name\"},"
+     "\"from_version\":{\"type\":\"string\",\"description\":\"Baseline version tag (e.g. "
+     "'28.0')\"},"
+     "\"to_version\":{\"type\":\"string\",\"description\":\"Comparison version tag (e.g. "
+     "'30.0')\"},"
+     "\"label\":{\"type\":\"string\",\"description\":\"Node label to compare (default: Class)\"}"
+     "},\"required\":[\"project\",\"from_version\",\"to_version\"]}"},
 
     {"search_graph", "Search graph",
      "Search the code knowledge graph for functions, classes, routes, and variables. Use INSTEAD "
@@ -7514,6 +7532,112 @@ char *cbm_mcp_index_run_supervised_path(const char *root_path) {
 
 bool cbm_path_within_root(const char *root_path, const char *abs_path); /* defined below */
 
+static char *handle_diff_versions(cbm_mcp_server_t *srv, const char *args) {
+    char *project = cbm_mcp_get_string_arg(args, "project");
+    char *from_ver = cbm_mcp_get_string_arg(args, "from_version");
+    char *to_ver = cbm_mcp_get_string_arg(args, "to_version");
+    char *label_arg = cbm_mcp_get_string_arg(args, "label");
+    const char *label = (label_arg && label_arg[0]) ? label_arg : "Class";
+
+    if (!project || !from_ver || !to_ver) {
+        free(project);
+        free(from_ver);
+        free(to_ver);
+        free(label_arg);
+        return cbm_mcp_text_result("project, from_version, and to_version required", true);
+    }
+
+    cbm_store_t *store = resolve_store(srv, project);
+    if (!store) {
+        free(project);
+        free(from_ver);
+        free(to_ver);
+        free(label_arg);
+        return cbm_mcp_text_result("project not found", true);
+    }
+
+    char added_q[512], removed_q[512];
+    snprintf(added_q, sizeof(added_q),
+             "MATCH (n:%s {version:'%s'}) "
+             "OPTIONAL MATCH (m:%s {name:n.name,version:'%s'}) "
+             "WHERE m IS NULL RETURN n.name LIMIT 500",
+             label, to_ver, label, from_ver);
+    snprintf(removed_q, sizeof(removed_q),
+             "MATCH (n:%s {version:'%s'}) "
+             "OPTIONAL MATCH (m:%s {name:n.name,version:'%s'}) "
+             "WHERE m IS NULL RETURN n.name LIMIT 500",
+             label, from_ver, label, to_ver);
+
+    cbm_cypher_result_t added = {0}, removed = {0};
+    cbm_cypher_execute(store, added_q, project, 500, &added);
+    cbm_cypher_execute(store, removed_q, project, 500, &removed);
+
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *root = yyjson_mut_obj(doc);
+    yyjson_mut_doc_set_root(doc, root);
+
+    yyjson_mut_val *added_arr = yyjson_mut_arr(doc);
+    for (int r = 0; r < added.row_count; r++) {
+        if (added.rows[r][0]) {
+            yyjson_mut_arr_add_strcpy(doc, added_arr, added.rows[r][0]);
+        }
+    }
+    yyjson_mut_val *removed_arr = yyjson_mut_arr(doc);
+    for (int r = 0; r < removed.row_count; r++) {
+        if (removed.rows[r][0]) {
+            yyjson_mut_arr_add_strcpy(doc, removed_arr, removed.rows[r][0]);
+        }
+    }
+
+    yyjson_mut_obj_add_val(doc, root, "added", added_arr);
+    yyjson_mut_obj_add_val(doc, root, "removed", removed_arr);
+    yyjson_mut_obj_add_strcpy(doc, root, "from_version", from_ver);
+    yyjson_mut_obj_add_strcpy(doc, root, "to_version", to_ver);
+
+    char *json = yyjson_mut_write(doc, 0, NULL);
+    char *result = cbm_mcp_text_result(json, false);
+    free(json);
+    yyjson_mut_doc_free(doc);
+    cbm_cypher_result_free(&added);
+    cbm_cypher_result_free(&removed);
+    free(project);
+    free(from_ver);
+    free(to_ver);
+    free(label_arg);
+    return result;
+}
+
+/* Derive a version tag from the last path segment when it looks like a
+ * version number (e.g. "/repos/MyApp/28.0" → "28.0").
+ * Writes to out[0..out_sz-1]; sets out[0]='\0' when nothing found. */
+static void cbm_derive_version_from_path(const char *path, char *out, size_t out_sz) {
+    if (!path || !out || out_sz == 0) {
+        return;
+    }
+    out[0] = '\0';
+    const char *p = path + strlen(path);
+    while (p > path) {
+        p--;
+        if (*p == '/' || *p == '\\') {
+            const char *seg = p + 1;
+            size_t slen = strlen(seg);
+            if (slen > 0 && slen < 32 && isdigit((unsigned char)seg[0])) {
+                bool ok = true;
+                for (size_t i = 0; i < slen; i++) {
+                    if (!isdigit((unsigned char)seg[i]) && seg[i] != '.') {
+                        ok = false;
+                        break;
+                    }
+                }
+                if (ok) {
+                    snprintf(out, out_sz, "%s", seg);
+                    return;
+                }
+            }
+        }
+    }
+}
+
 /* Resolve relative index requests against an explicitly supplied MCP session
  * root, never against the long-lived daemon process cwd. */
 static bool resolve_session_repo_path(cbm_mcp_server_t *srv, char **repo_path) {
@@ -7721,6 +7845,21 @@ static char *handle_index_repository(cbm_mcp_server_t *srv, const char *args) {
     }
     free(name_override);
     cbm_pipeline_set_persistence(p, persistence);
+
+    /* Optional version tag: stamp every node with the given version string.
+     * Falls back to auto-detecting a version number from the trailing path segment
+     * (e.g. /exports/MyApp/28.0 → version="28.0"). */
+    char *version_tag = cbm_mcp_get_string_arg(args, "version");
+    if (version_tag && version_tag[0]) {
+        cbm_pipeline_set_version(p, version_tag);
+    } else {
+        char derived[64] = {0};
+        cbm_derive_version_from_path(repo_path, derived, sizeof(derived));
+        if (derived[0]) {
+            cbm_pipeline_set_version(p, derived);
+        }
+    }
+    free(version_tag);
 
     char *project_name = heap_strdup(cbm_pipeline_project_name(p));
 
@@ -10380,6 +10519,10 @@ static char *dispatch_tool(cbm_mcp_server_t *srv, const char *tool_name, const c
     }
     if (strcmp(tool_name, "get_architecture") == 0) {
         return handle_get_architecture(srv, args_json);
+    }
+
+    if (strcmp(tool_name, "diff_versions") == 0) {
+        return handle_diff_versions(srv, args_json);
     }
 
     /* Pipeline-dependent tools */

--- a/src/pipeline/pass_definitions.c
+++ b/src/pipeline/pass_definitions.c
@@ -246,7 +246,8 @@ static void append_json_str_array(char *buf, size_t bufsize, size_t *pos, const 
 }
 
 /* Build properties JSON for a definition node. */
-static void build_def_props(char *buf, size_t bufsize, const CBMDefinition *def) {
+static void build_def_props(char *buf, size_t bufsize, const CBMDefinition *def,
+                            const char *version_tag) {
     /* The complexity/loop/recursion metrics are only meaningful for executable
      * units (Function/Method). Emitting them on the millions of Macro/Field/
      * Variable/Class/Enum nodes — where they are always zero — bloats every
@@ -311,6 +312,11 @@ static void build_def_props(char *buf, size_t bufsize, const CBMDefinition *def)
         append_json_string(buf, bufsize, &pos, "bt", def->body_tokens);
     }
 
+    /* Version tag for cross-version diff queries */
+    if (version_tag && version_tag[0] && pos + CBM_SZ_256 < bufsize) {
+        append_json_string(buf, bufsize, &pos, "version", version_tag);
+    }
+
     if (pos < bufsize - SKIP_ONE) {
         buf[pos] = '}';
         buf[pos + SKIP_ONE] = '\0';
@@ -323,7 +329,7 @@ static void process_def(cbm_pipeline_ctx_t *ctx, const CBMDefinition *def, const
         return;
     }
     char props[CBM_SZ_2K];
-    build_def_props(props, sizeof(props), def);
+    build_def_props(props, sizeof(props), def, ctx->version_tag);
     int64_t node_id = cbm_gbuf_upsert_node(
         ctx->gbuf, def->label ? def->label : "Function", def->name, def->qualified_name,
         def->file_path ? def->file_path : rel, (int)def->start_line, (int)def->end_line, props);

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -457,7 +457,8 @@ static void append_json_str_array(char *buf, size_t bufsize, size_t *pos, const 
     *pos = p;
 }
 
-static void build_def_props(char *buf, size_t bufsize, const CBMDefinition *def) {
+static void build_def_props(char *buf, size_t bufsize, const CBMDefinition *def,
+                            const char *version_tag) {
     /* Complexity/loop/recursion metrics are meaningful only for Function/Method.
      * Gate the block so the millions of Macro/Field/Variable/Class/Enum nodes
      * keep a lean properties blob (lossless — those fields are always zero for
@@ -520,6 +521,11 @@ static void build_def_props(char *buf, size_t bufsize, const CBMDefinition *def)
     /* Body tokens — raw identifiers from function body AST for semantic search. */
     if (def->body_tokens && pos + CBM_SZ_512 < bufsize) {
         append_json_string(buf, bufsize, &pos, "bt", def->body_tokens);
+    }
+
+    /* Version tag for cross-version diff queries */
+    if (version_tag && version_tag[0] && pos + CBM_SZ_256 < bufsize) {
+        append_json_string(buf, bufsize, &pos, "version", version_tag);
     }
 
     if (pos < bufsize - SKIP_ONE) {
@@ -714,6 +720,7 @@ typedef struct {
 
     const CBMMacroTable *macro_table;            /* ObjectScript $$$macros (NULL if none) */
     const CBMReturnTypeTable *return_type_table; /* ObjectScript return types (NULL if none) */
+    const char *version_tag; /* borrowed from pipeline ctx — version label for nodes */
 } extract_ctx_t;
 
 /* Cap on the number of index.file_oversized WARN lines (the full list still goes
@@ -722,9 +729,9 @@ enum { PP_OVERSIZED_WARN_MAX = 32 };
 
 /* Insert one definition node (and its route if present) into the local gbuf. */
 static void insert_def_into_gbuf(extract_worker_state_t *ws, const cbm_file_info_t *fi,
-                                 CBMDefinition *def) {
+                                 CBMDefinition *def, const char *version_tag) {
     char props[CBM_SZ_2K];
-    build_def_props(props, sizeof(props), def);
+    build_def_props(props, sizeof(props), def, version_tag);
     int64_t func_id =
         cbm_gbuf_upsert_node(ws->local_gbuf, def->label ? def->label : "Function", def->name,
                              def->qualified_name, def->file_path ? def->file_path : fi->rel_path,
@@ -952,7 +959,7 @@ static void extract_worker(int worker_id, void *ctx_ptr) {
         for (int d = 0; d < result->defs.count; d++) {
             CBMDefinition *def = &result->defs.items[d];
             if (def->qualified_name && def->name) {
-                insert_def_into_gbuf(ws, fi, def);
+                insert_def_into_gbuf(ws, fi, def, ec->version_tag);
             }
         }
 
@@ -1173,6 +1180,7 @@ int cbm_parallel_extract_ex(cbm_pipeline_ctx_t *ctx, const cbm_file_info_t *file
         .retain_per_file_max_bytes = resolved_opts.retain_per_file_max_bytes,
         .macro_table = pp_macro_table,
         .return_type_table = ctx->return_type_table,
+        .version_tag = ctx->version_tag,
     };
     atomic_init(&ec.next_worker_id, 0);
     atomic_init(&ec.next_file_idx, 0);

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -912,7 +912,7 @@ static void extract_worker(int worker_id, void *ctx_ptr) {
                 for (int d = 0; d < xr->defs.count; d++) {
                     CBMDefinition *def = &xr->defs.items[d];
                     if (def->qualified_name && def->name) {
-                        insert_def_into_gbuf(ws, fi, def);
+                        insert_def_into_gbuf(ws, fi, def, ec->version_tag);
                     }
                 }
                 cbm_free_result(xr);

--- a/src/pipeline/pipeline.c
+++ b/src/pipeline/pipeline.c
@@ -84,7 +84,8 @@ struct cbm_pipeline {
     cbm_index_mode_t mode;
     atomic_int cancelled_storage;
     atomic_int *cancelled;
-    bool persistence; /* write .codebase-memory/graph.db.zst after indexing */
+    bool persistence;  /* write .codebase-memory/graph.db.zst after indexing */
+    char *version_tag; /* version label stamped on every node (e.g. "28.0") */
 
     /* Indexing state (set during run) */
     cbm_gbuf_t *gbuf;
@@ -204,6 +205,14 @@ void cbm_pipeline_set_persistence(cbm_pipeline_t *p, bool enabled) {
     }
 }
 
+void cbm_pipeline_set_version(cbm_pipeline_t *p, const char *version_tag) {
+    if (!p) {
+        return;
+    }
+    free(p->version_tag);
+    p->version_tag = version_tag ? strdup(version_tag) : NULL;
+}
+
 bool cbm_pipeline_set_project_name(cbm_pipeline_t *p, const char *name) {
     if (!p || !name || !name[0]) {
         return false;
@@ -249,6 +258,7 @@ void cbm_pipeline_free(cbm_pipeline_t *p) {
     p->file_errors_count = 0;
     p->file_errors_cap = 0;
     free(p->branch_qn);
+    free(p->version_tag);
     free(p->saved_adr); /* freed here too: error paths can exit before the
                          * restore in dump_and_persist_hashes runs. Issue #516. */
     p->saved_adr = NULL;
@@ -1174,7 +1184,8 @@ static int try_incremental_or_delete_db(cbm_pipeline_t *p, cbm_file_info_t *file
         cbm_store_get_file_hashes(check_store, p->project_name, &hashes, &hash_count);
         cbm_store_free_file_hashes(hashes, hash_count);
         cbm_store_close(check_store);
-        if (hash_count > 0 && file_count <= hash_count + (hash_count / PAIR_LEN)) {
+        if (hash_count > 0 && file_count <= hash_count + (hash_count / PAIR_LEN) &&
+            !p->version_tag) {
             cbm_log_info("pipeline.route", "path", "incremental", "stored_hashes",
                          itoa_buf(hash_count));
             int rc = cbm_pipeline_run_incremental(p, db_path, files, file_count);
@@ -1641,6 +1652,7 @@ static int cbm_pipeline_run_staged(cbm_pipeline_t *p, bool *was_incremental) {
         .path_aliases = path_aliases,
         .excluded_dirs = p->excluded_dirs,
         .excluded_count = p->excluded_count,
+        .version_tag = p->version_tag,
     };
 
     rc = run_extraction_phase(p, &ctx, files, file_count);

--- a/src/pipeline/pipeline.h
+++ b/src/pipeline/pipeline.h
@@ -52,6 +52,11 @@ cbm_pipeline_t *cbm_pipeline_new(const char *repo_path, const char *db_path, cbm
  * When enabled, the pipeline writes a compressed artifact after indexing. */
 void cbm_pipeline_set_persistence(cbm_pipeline_t *p, bool enabled);
 
+/* Tag every extracted node with a version string (e.g. "28.0", "30.0").
+ * Enables cross-version diff queries without extra Cypher syntax.
+ * When set, the incremental path is bypassed to guarantee a clean full index. */
+void cbm_pipeline_set_version(cbm_pipeline_t *p, const char *version_tag);
+
 /* Free a pipeline and all its internal state. NULL-safe. */
 void cbm_pipeline_free(cbm_pipeline_t *p);
 

--- a/src/pipeline/pipeline_internal.h
+++ b/src/pipeline/pipeline_internal.h
@@ -123,6 +123,10 @@ typedef struct {
     /* ObjectScript method-return-type table built from extracted definitions
      * (NULL until pass_calls builds it). Owned by pipeline.c. */
     const CBMReturnTypeTable *return_type_table;
+
+    /* Version tag for cross-version diff queries (e.g. "28.0", "30.0").
+     * When set, appended to every extracted node's properties JSON. */
+    const char *version_tag;
 } cbm_pipeline_ctx_t;
 
 static inline int cbm_pipeline_relpath_is_excluded(const char *rel_path, char *const *excluded_dirs,

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -800,7 +800,7 @@ TEST(mcp_tools_have_behavior_annotations) {
         {"detect_changes", false, true, true, false},
         {"manage_adr", false, true, false, false},
         {"ingest_traces", false, false, false, false},
-        {"diff_versions", false, true, true, false},
+        {"diff_versions", true, false, true, false},
     };
 
     char *json = cbm_mcp_tools_list();

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -800,6 +800,7 @@ TEST(mcp_tools_have_behavior_annotations) {
         {"detect_changes", false, true, true, false},
         {"manage_adr", false, true, false, false},
         {"ingest_traces", false, false, false, false},
+        {"diff_versions", false, true, true, false},
     };
 
     char *json = cbm_mcp_tools_list();


### PR DESCRIPTION
Adds version tagging on all indexed nodes and a `diff_versions` MCP tool for cross-version change detection.

Closes #1062. Depends on #467 (ObjectScript language support) merging first — the Storage node inline-JSON change targets ObjectScript Storage nodes.

## New API

**`cbm_pipeline_set_version(cbm_pipeline_t *p, const char *version_tag)`**

Sets a version label (e.g. `"28.0"`) on a pipeline instance. When set, the tag is written as a `"version"` property on every node. Also bypasses the incremental-index path so versioned indexing always does a full pass — the graph accumulates both versions side-by-side.

**`index_repository` tool: new `version` parameter**

```json
{ "repo_path": "/repos/myproject-28.0", "version": "28.0" }
```

When omitted, a version-like segment (digits and dots) is auto-derived from the repo path. No behavior change for projects that don't use versioning.

**`diff_versions` MCP tool**

```json
{
  "project":      "myproject",
  "from_version": "28.0",
  "to_version":   "30.0",
  "label":        "Class"
}
```

Returns `{"added": [...], "removed": [...], "from_version": "28.0", "to_version": "30.0"}`. Default label `Class`, limit 500 per side.

## Files changed

- `src/pipeline/pipeline.h` — `cbm_pipeline_set_version()` declaration
- `src/pipeline/pipeline_internal.h` — `version_tag` field on ctx
- `src/pipeline/pipeline.c` — setter, free, skip-incremental guard, ctx wiring
- `src/pipeline/pass_definitions.c` — `version` property on all nodes; Storage nodes with structured docstring have fields merged inline as raw JSON rather than escaped
- `src/pipeline/pass_parallel.c` — same changes mirrored; `version_tag` threaded through parallel worker
- `src/mcp/mcp.c` — `cbm_derive_version_from_path()` helper, `version` param on `index_repository`, `diff_versions` tool registered and handler implemented