### PR TITLE
fix(tests): isolate integration caches from user state

### DIFF
--- a/tests/test_lang_contract.c
+++ b/tests/test_lang_contract.c
@@ -71,13 +71,18 @@ static cbm_store_t *lang_open_indexed(LangProj *lp) {
     if (!lp->project) {
         return NULL;
     }
-    const char *home = getenv("HOME");
-    if (!home) {
-        home = "/tmp";
-    }
     char cache_dir[512];
-    snprintf(cache_dir, sizeof(cache_dir), "%s/.cache/codebase-memory-mcp", home);
-    cbm_mkdir(cache_dir);
+    const char *configured_cache = getenv("CBM_CACHE_DIR");
+    if (configured_cache && configured_cache[0]) {
+        snprintf(cache_dir, sizeof(cache_dir), "%s", configured_cache);
+    } else {
+        const char *home = getenv("HOME");
+        if (!home) {
+            home = "/tmp";
+        }
+        snprintf(cache_dir, sizeof(cache_dir), "%s/.cache/codebase-memory-mcp", home);
+    }
+    cbm_mkdir_p(cache_dir, 0755);
     snprintf(lp->dbpath, sizeof(lp->dbpath), "%s/%s.db", cache_dir, lp->project);
     unlink(lp->dbpath);
     lp->srv = cbm_mcp_server_new(NULL);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -9,6 +9,7 @@ int tf_fail_count = 0;
 int tf_skip_count = 0;
 
 #include "test_framework.h"
+#include "test_helpers.h"
 #include "foundation/compat.h"    /* cbm_setenv — #845 supervisor kill switch */
 #include "foundation/compat_fs.h" /* cbm_fopen — worker response file */
 #include "foundation/mem.h"       /* cbm_mem_init — worker budget */
@@ -23,6 +24,32 @@ int tf_skip_count = 0;
 #ifdef _WIN32
 #include <winsock2.h> /* #798 follow-up: socket-isolation re-exec probe */
 #endif
+
+/* Test handlers that exercise the production index_repository flow must never
+ * inherit the user's real cache. Individual tests may temporarily override
+ * this sentinel and restore it; atexit removes anything left behind by an
+ * assertion that returns before fixture cleanup. */
+static char tf_home_sentinel[512];
+
+static void tf_cleanup_cache_sentinel(void) {
+    if (tf_home_sentinel[0]) {
+        th_rmtree(tf_home_sentinel);
+    }
+}
+
+static bool tf_setup_cache_sentinel(void) {
+    snprintf(tf_home_sentinel, sizeof(tf_home_sentinel), "/tmp/cbm-test-home-XXXXXX");
+    if (!cbm_mkdtemp(tf_home_sentinel)) {
+        return false;
+    }
+    /* Legacy integration fixtures derive DB paths from HOME, while production
+     * cache_dir() prefers CBM_CACHE_DIR. A private HOME plus no inherited cache
+     * override keeps both conventions pointed at the same isolated tree. */
+    cbm_setenv("HOME", tf_home_sentinel, 1);
+    cbm_unsetenv("CBM_CACHE_DIR");
+    atexit(tf_cleanup_cache_sentinel);
+    return true;
+}
 
 /* #832 guard support: when the index supervisor spawns THIS binary as
  * `<self> cli --index-worker index_repository <args_json> --response-out <file>`
@@ -267,6 +294,10 @@ int main(int argc, char **argv) {
      * binary as `<self> cli --index-worker …` and recursively re-run suites.
      * A test that exercises the supervisor must explicitly re-enable it. */
     cbm_setenv("CBM_INDEX_SUPERVISOR", "0", 1);
+    if (!tf_setup_cache_sentinel()) {
+        fprintf(stderr, "failed to create isolated test cache\n");
+        return 2;
+    }
 
     g_suite_argc = argc;
     g_suite_argv = argv;


### PR DESCRIPTION
## What does this PR do?

Prevents the C test runner from reading or writing a user's real codebase-memory cache.

Several integration fixtures exercise the production `index_repository` flow. The production cache resolver prefers `CBM_CACHE_DIR`, while older fixtures derive the expected database path from `HOME/.cache/codebase-memory-mcp`. When the runner inherited a real cache, early assertion returns could leave fixture databases behind. Setting only `CBM_CACHE_DIR` was also insufficient because those legacy paths diverged.

## Fix

- create a private temporary `HOME` for every normal test-runner process;
- clear inherited `CBM_CACHE_DIR`, so production code and legacy fixtures converge on the private HOME cache;
- delete the sentinel tree with `atexit`, including after early test returns;
- make the lang-contract helper honor an explicit `CBM_CACHE_DIR` when a test intentionally sets one.

Worker/probe subprocess modes still exit before the sentinel setup.

## Validation

Windows GCC build after rebasing onto current `main`:

- full C runner: **5831 passed, 22 skipped**;
- production-cache sentinel: **501 DB files before, 501 after**;
- added files: **0**;
- removed files: **0**.

The same run previously left `cbm_seq898_*`, `cbm_lc_*`, and `cbm_fcw_*` fixture databases in the inherited cache.

## Checklist

- [x] Every commit is signed off (`git commit -s`)
- [x] Full C test runner passes locally
- [ ] Full lint (left to CI)
- [x] Behavior validated with a before/after cache sentinel
