### PR TITLE
feat(nix): add UI-embedded flake package, refresh lock + docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ graph-ui/.npm-cache-local/
 # Python bytecode from tests/windows/ harness
 __pycache__/
 *.pyc
+
+# Nix build symlinks (nix build → ./result, ./result-1, …)
+/result
+/result-*

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ soak-results-query-leak/
 # Scorecard as a binary artifact in source). Source only, never the build.
 /pkg/go/codebase-memory-mcp
 /pkg/go/codebase-memory-mcp.exe
+
+# Nix build symlinks (nix build → ./result, ./result-1, …)
+/result
+/result-*

--- a/README.md
+++ b/README.md
@@ -346,6 +346,38 @@ scripts/build.sh --with-ui          # with graph visualization
 # Binary at: build/c/codebase-memory-mcp
 ```
 
+### Nix (flake)
+
+The flake exposes two server packages plus the standalone frontend:
+
+| Package | Contents |
+|---------|----------|
+| `default` (`codebase-memory-mcp`) | Standard server, no UI |
+| `codebase-memory-mcp-ui` | Server with the graph UI embedded (`--ui=true` works) |
+| `graph-ui` | Just the built frontend assets (`dist/`) |
+
+Run directly without installing:
+
+```bash
+# Standard server
+nix run github:DeusData/codebase-memory-mcp
+
+# Server with the embedded graph UI
+nix run github:DeusData/codebase-memory-mcp#codebase-memory-mcp-ui -- --ui=true --port=9749
+# then open http://127.0.0.1:9749
+```
+
+Or build a binary into `./result/bin/codebase-memory-mcp`:
+
+```bash
+nix build github:DeusData/codebase-memory-mcp                          # standard
+nix build github:DeusData/codebase-memory-mcp#codebase-memory-mcp-ui   # with UI
+```
+
+Working in a clone? Use `.` in place of the flake URL, e.g. `nix run .#codebase-memory-mcp-ui -- --ui=true`, or drop into a shell that puts the binary on `PATH` with `nix shell .#codebase-memory-mcp-ui`.
+
+> **Note:** launched by hand (not from an MCP client) the server exits as soon as `stdin` closes — that's normal MCP behaviour. Keep `stdin` open while testing the UI, e.g. `sleep infinity | codebase-memory-mcp --ui=true --port=9749`. The `codebase-memory-mcp-ui` package embeds the UI at build time; `nix run`'ing the standard `default` package with `--ui=true` will refuse to start the HTTP server.
+
 ### Manual MCP Configuration
 
 <details>

--- a/README.md
+++ b/README.md
@@ -353,6 +353,38 @@ paru -S codebase-memory-mcp-bin
 
 The `codebase-memory-mcp-bin` package is available at: https://aur.archlinux.org/packages/codebase-memory-mcp-bin
 
+### Nix (flake)
+
+The flake exposes two server packages plus the standalone frontend:
+
+| Package | Contents |
+|---------|----------|
+| `default` (`codebase-memory-mcp`) | Standard server, no UI |
+| `codebase-memory-mcp-ui` | Server with the graph UI embedded (`--ui=true` works) |
+| `graph-ui` | Just the built frontend assets (`dist/`) |
+
+Run directly without installing:
+
+```bash
+# Standard server
+nix run github:DeusData/codebase-memory-mcp
+
+# Server with the embedded graph UI
+nix run github:DeusData/codebase-memory-mcp#codebase-memory-mcp-ui -- --ui=true --port=9749
+# then open http://127.0.0.1:9749
+```
+
+Or build a binary into `./result/bin/codebase-memory-mcp`:
+
+```bash
+nix build github:DeusData/codebase-memory-mcp                          # standard
+nix build github:DeusData/codebase-memory-mcp#codebase-memory-mcp-ui   # with UI
+```
+
+Working in a clone? Use `.` in place of the flake URL, e.g. `nix run .#codebase-memory-mcp-ui -- --ui=true`, or drop into a shell that puts the binary on `PATH` with `nix shell .#codebase-memory-mcp-ui`.
+
+> **Note:** launched by hand (not from an MCP client) the server exits as soon as `stdin` closes — that's normal MCP behaviour. Keep `stdin` open while testing the UI, e.g. `sleep infinity | codebase-memory-mcp --ui=true --port=9749`. The `codebase-memory-mcp-ui` package embeds the UI at build time; `nix run`'ing the standard `default` package with `--ui=true` will refuse to start the HTTP server.
+
 ### Install via Claude Code
 
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776255774,
-        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
+        "lastModified": 1783915482,
+        "narHash": "sha256-FmieJB8/OUvNxbkboi7+IGfIuSXY3nF/hZQm8kD0r50=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "rev": "6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,10 +9,10 @@
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
     in
     {
-      packages = forAllSystems (pkgs: {
+      packages = forAllSystems (pkgs: rec {
         default = pkgs.stdenv.mkDerivation {
           pname = "codebase-memory-mcp";
-          version = "0.6.0";
+          version = "0.9.0";
 
           src = ./.;
 
@@ -39,6 +39,56 @@
             platforms = systems;
           };
         };
+
+        # The graph-ui React frontend, built to static assets (graph-ui/dist).
+        # buildNpmPackage fetches npm deps offline via the pinned package-lock.json;
+        # bump npmDepsHash whenever that lockfile changes:
+        #   nix run nixpkgs#prefetch-npm-deps -- graph-ui/package-lock.json
+        graph-ui = pkgs.buildNpmPackage {
+          pname = "codebase-memory-graph-ui";
+          version = "0.1.0";
+
+          src = ./graph-ui;
+
+          npmDepsHash = "sha256-P1JVo+GFr+Gsq88dnn9OsedZqrTaj3DDGbej+nHbp4U=";
+
+          # `npm run build` runs `tsc -b && vite build`, emitting to dist/.
+          installPhase = ''
+            runHook preInstall
+            cp -r dist $out
+            runHook postInstall
+          '';
+        };
+
+        # Same server binary as `default`, but with the graph-ui assets embedded
+        # so `--ui=true` starts the HTTP server. The frontend is built separately
+        # by the graph-ui package above; here we drop its dist/ into place and run
+        # the embed + link path (cbm-with-ui) — no network access needed.
+        codebase-memory-mcp-ui = default.overrideAttrs (old: {
+          pname = "codebase-memory-mcp-ui";
+
+          buildPhase = ''
+            # cbm-with-ui depends on `embed`, which depends on `frontend`, which
+            # runs `npm ci && npm run build` — needs network access, unavailable
+            # in the sandbox. Supply the pre-built assets, run the embed script
+            # directly, then link with `cbm-with-ui` while telling make its
+            # `frontend`/`embed` prerequisites are already up to date (-o) so it
+            # won't re-run the npm build.
+            mkdir -p graph-ui/dist
+            cp -r ${graph-ui}/. graph-ui/dist/
+            chmod -R u+w graph-ui/dist
+
+            bash scripts/embed-frontend.sh graph-ui/dist build/c/embedded
+
+            make -j$NIX_BUILD_CORES -f Makefile.cbm \
+              -o frontend -o embed \
+              cbm-with-ui
+          '';
+
+          meta = old.meta // {
+            description = "codebase-memory-mcp with the embedded graph UI (--ui)";
+          };
+        });
       });
 
       devShells = forAllSystems (pkgs: {

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
       packages = forAllSystems (pkgs: rec {
         default = pkgs.stdenv.mkDerivation {
           pname = "codebase-memory-mcp";
-          version = "0.9.0";
+          version = "0.10.8";
 
           src = ./.;
 

--- a/flake.nix
+++ b/flake.nix
@@ -60,10 +60,10 @@
         };
     in
     {
-      packages = forAllSystems (pkgs: {
+      packages = forAllSystems (pkgs: rec {
         default = pkgs.stdenv.mkDerivation {
           pname = "codebase-memory-mcp";
-          version = "0.6.0";
+          version = "0.9.0";
 
           src = ./.;
 
@@ -90,6 +90,56 @@
             platforms = systems;
           };
         };
+
+        # The graph-ui React frontend, built to static assets (graph-ui/dist).
+        # buildNpmPackage fetches npm deps offline via the pinned package-lock.json;
+        # bump npmDepsHash whenever that lockfile changes:
+        #   nix run nixpkgs#prefetch-npm-deps -- graph-ui/package-lock.json
+        graph-ui = pkgs.buildNpmPackage {
+          pname = "codebase-memory-graph-ui";
+          version = "0.1.0";
+
+          src = ./graph-ui;
+
+          npmDepsHash = "sha256-P1JVo+GFr+Gsq88dnn9OsedZqrTaj3DDGbej+nHbp4U=";
+
+          # `npm run build` runs `tsc -b && vite build`, emitting to dist/.
+          installPhase = ''
+            runHook preInstall
+            cp -r dist $out
+            runHook postInstall
+          '';
+        };
+
+        # Same server binary as `default`, but with the graph-ui assets embedded
+        # so `--ui=true` starts the HTTP server. The frontend is built separately
+        # by the graph-ui package above; here we drop its dist/ into place and run
+        # the embed + link path (cbm-with-ui) — no network access needed.
+        codebase-memory-mcp-ui = default.overrideAttrs (old: {
+          pname = "codebase-memory-mcp-ui";
+
+          buildPhase = ''
+            # cbm-with-ui depends on `embed`, which depends on `frontend`, which
+            # runs `npm ci && npm run build` — needs network access, unavailable
+            # in the sandbox. Supply the pre-built assets, run the embed script
+            # directly, then link with `cbm-with-ui` while telling make its
+            # `frontend`/`embed` prerequisites are already up to date (-o) so it
+            # won't re-run the npm build.
+            mkdir -p graph-ui/dist
+            cp -r ${graph-ui}/. graph-ui/dist/
+            chmod -R u+w graph-ui/dist
+
+            bash scripts/embed-frontend.sh graph-ui/dist build/c/embedded
+
+            make -j$NIX_BUILD_CORES -f Makefile.cbm \
+              -o frontend -o embed \
+              cbm-with-ui
+          '';
+
+          meta = old.meta // {
+            description = "codebase-memory-mcp with the embedded graph UI (--ui)";
+          };
+        });
       });
 
       devShells = forAllSystems (pkgs: {


### PR DESCRIPTION
Fixes #1088

## Problem

The flake only built the standard `cbm` target, which links `src/ui/embedded_stub.c` (no assets). So a binary from `nix run`/`nix shell`/`nix build` had no embedded UI, and `--ui=true` refused to start the HTTP server:

> `--ui requested, but this binary was built without the embedded UI, so the HTTP server will not start.`

There was no Nix-native way to get the UI-embedded server, because `cbm-with-ui` runs `npm ci && npm run build`, which needs network access and can't run in the build sandbox as wired.

## Changes

- **`codebase-memory-mcp-ui` flake package** — the server with the graph UI embedded. Drops the prebuilt `dist/` into `graph-ui/dist`, runs `scripts/embed-frontend.sh` directly, then `make cbm-with-ui` with `frontend`/`embed` marked up-to-date (`-o`) so npm never runs in the sandbox.
- **`graph-ui` flake package** — the React frontend built via `buildNpmPackage` (deps fetched offline from the pinned `graph-ui/package-lock.json` via `npmDepsHash`).
- **README** — Installation → Nix section documenting both server packages, `nix run`/`nix build`, and the stdin-EOF behaviour when run by hand.

Adjacent Nix cleanups folded in (same surface, kept to one focused PR):

- **flake version** `0.6.0` → `0.9.0` to match the current release.
- **`flake.lock`** refreshed (nixpkgs ~2026-04 `566acc0` → 2026-07 `6cdc7fc`, ~3 months stale).
- **`.gitignore`** — ignore `nix build` output symlinks (`/result`, `/result-*`).

## Verification (x86_64-linux)

- `nix flake check` passes.
- `nix build .#default` and `nix build .#codebase-memory-mcp-ui` both succeed on the refreshed lock (`npmDepsHash` still validates).
- UI binary serves over HTTP: `GET /` → 200 (index.html), `/assets/*.js` → 200 (1.3 MB, `application/javascript`), `/assets/*.css` → 200 (`text/css`); logs `msg=ui.serving` instead of the no-UI refusal.

> **Note on the version bump / lockfile / gitignore:** these are per CONTRIBUTING.md build-system-adjacent — happy to split any of them into separate PRs if a maintainer prefers.