### PR TITLE
fix(foundation): use HW_PHYSMEM for physical memory detection on FreeBSD

### DIFF
--- a/src/foundation/system_info.c
+++ b/src/foundation/system_info.c
@@ -95,7 +95,7 @@ static cbm_system_info_t detect_system_bsd(void) {
     info.total_cores = nprocs > 0 ? (int)nprocs : 1;
     info.perf_cores = info.total_cores;
 
-#if defined(__OpenBSD__)
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
     int mib[2] = {CTL_HW, HW_PHYSMEM};
 #else
     int mib[2] = {CTL_HW, HW_PHYSMEM64};

--- a/tests/test_platform.c
+++ b/tests/test_platform.c
@@ -132,6 +132,13 @@ TEST(platform_default_workers_env_unset) {
     PASS();
 }
 
+TEST(platform_system_info) {
+    cbm_system_info_t info = cbm_system_info();
+    ASSERT_GT(info.total_cores, 0);
+    ASSERT_GT(info.total_ram, 0);
+    PASS();
+}
+
 /* ── cgroup-aware detection (Linux only) ─────────────────────────── */
 
 #ifdef __linux__
@@ -316,6 +323,7 @@ SUITE(platform) {
     RUN_TEST(platform_default_workers_env_override);
     RUN_TEST(platform_default_workers_env_invalid);
     RUN_TEST(platform_default_workers_env_unset);
+    RUN_TEST(platform_system_info);
 #ifdef __linux__
     RUN_TEST(cgroup_v2_cpu_quota);
     RUN_TEST(cgroup_v2_cpu_quota_rounds_up);


### PR DESCRIPTION
## What does this PR do?

This PR fixes physical memory detection on FreeBSD by using the standard `HW_PHYSMEM` sysctl in `detect_system_bsd()`.

On FreeBSD 15.1-STABLE, the current implementation using `HW_PHYSMEM64` does not return the expected physical memory size during system initialization. This change routes FreeBSD through the existing `HW_PHYSMEM` code path already used by OpenBSD.

## Changes

* Updated `src/foundation/system_info.c`.
* Extended the BSD-specific condition:

```c
#if defined(__OpenBSD__)
```

to:

```c
#if defined(__OpenBSD__) || defined(__FreeBSD__)
```

so FreeBSD uses `HW_PHYSMEM` for physical memory detection.

## Testing

Tested on **FreeBSD 15.1-STABLE (amd64)**.

Validation performed:

* Successfully built `codebase-memory-mcp` using:

```sh
gmake -f Makefile.cbm cbm
```

* Successfully ran the CI linters:

```sh
gmake -f Makefile.cbm lint-ci CLANG_FORMAT=clang-format21
```

Result:

```text
=== cppcheck ===
=== clang-format ===
=== NOLINT check ===
=== CI linters passed ===
```

* Verified that the detected physical memory size is reported correctly after this change.

The test suite was also executed:

```sh
gmake -f Makefile.cbm test
```

However, the test build currently fails during linking with an unrelated AddressSanitizer duplicate symbol error:

```text
duplicate symbol: bsearch
>>> defined at asan_interceptors.cpp
>>> defined at internal/cbm/vendored/grammars/perl/bsearch.h
```

This failure is independent from this change and occurs in the test infrastructure/linking stage before the tests are executed.

## Why this is safe

This is a small, localized, platform-specific change affecting only the FreeBSD BSD implementation path.

Linux, macOS, Windows, and other supported platforms are unaffected. The change reuses the existing `HW_PHYSMEM` implementation already used for OpenBSD and does not modify the behavior of other operating systems.

## Checklist

* [x] Every commit is signed off (`git commit -s`) — required, CI rejects unsigned commits ([[DCO](https://chatgpt.com/DCO)](../DCO), see [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md))
* [ ] Tests pass locally (`make -f Makefile.cbm test`)
* [x] Lint passes (`make -f Makefile.cbm lint-ci`)
* [ ] New behavior is covered by a test (reproduce-first for bug fixes)