### PR TITLE
feat(config): add watcher_enabled config key to disable the background watcher (#335)

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,7 @@ codebase-memory-mcp config list                          # show all settings
 codebase-memory-mcp config set auto_index true           # auto-index on session start
 codebase-memory-mcp config set auto_index_limit 50000    # max files for auto-index
 codebase-memory-mcp config set auto_watch false          # don't register background git watcher (default: true)
+codebase-memory-mcp config set watcher_enabled false     # stop the watcher thread entirely (default: true)
 codebase-memory-mcp config reset auto_index              # reset to default
 ```
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ When enabled, new projects are indexed automatically on first connection. Previo
 
 Watcher registration is controlled separately by `auto_watch` (default `true`). Set `config set auto_watch false` to keep a session from registering its project with the background watcher — useful when working across many projects and you want each session contained to explicit indexing.
 
+To turn the watcher off entirely, set `config set watcher_enabled false` (default `true`): the background poll thread never starts and no project is registered, while `auto_index` and manual `index_repository` keep working. Unlike `auto_watch` — which is consulted per session — `watcher_enabled` is read once when the background daemon starts, so run `codebase-memory-mcp daemon stop` after changing it; reconnecting your MCP client alone will not restart the daemon. See [docs/CONFIGURATION.md](docs/CONFIGURATION.md#2-cli-managed-runtime-settings).
+
 ### Keeping Up to Date
 
 **Updates run from the install script on every platform, not from inside the running binary.** `codebase-memory-mcp update` validates your flags and then prints the exact command to run:

--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ codebase-memory-mcp config list                          # show all settings
 codebase-memory-mcp config set auto_index true           # auto-index on session start
 codebase-memory-mcp config set auto_index_limit 50000    # max files for auto-index
 codebase-memory-mcp config set auto_watch false          # don't register background git watcher (default: true)
+codebase-memory-mcp config set watcher_enabled false     # stop the watcher thread entirely (default: true)
 codebase-memory-mcp config reset auto_index              # reset to default
 ```
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -77,6 +77,7 @@ codebase-memory-mcp config list
 codebase-memory-mcp config get auto_index
 codebase-memory-mcp config set auto_index true
 codebase-memory-mcp config set auto_index_limit 50000
+codebase-memory-mcp config set watcher_enabled false
 codebase-memory-mcp config reset auto_index
 ```
 
@@ -86,6 +87,8 @@ Current keys:
 |---|---|---|
 | `auto_index` | `false` | Automatically index new projects when an MCP session starts. |
 | `auto_index_limit` | `50000` | Maximum file count allowed for automatic indexing of a new project. |
+| `auto_watch` | `true` | Register the session's project with the background git watcher on connect. Set `false` to keep a session from registering its project (the watcher still runs for other projects). |
+| `watcher_enabled` | `true` | Run the background watcher thread that auto-reindexes projects when they change. Set `false` to stop the watcher from starting at all — no poll thread and no project registration. Reindex manually with `index_repository` when disabled. |
 
 ## 3. UI Settings
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -88,7 +88,33 @@ Current keys:
 | `auto_index` | `false` | Automatically index new projects when an MCP session starts. |
 | `auto_index_limit` | `50000` | Maximum file count allowed for automatic indexing of a new project. |
 | `auto_watch` | `true` | Register the session's project with the background git watcher on connect. Set `false` to keep a session from registering its project (the watcher still runs for other projects). |
-| `watcher_enabled` | `true` | Run the background watcher thread that auto-reindexes projects when they change. Set `false` to stop the watcher from starting at all — no poll thread and no project registration. Reindex manually with `index_repository` when disabled. |
+| `watcher_enabled` | `true` | Master switch for the background watcher subsystem. Set `false` to stop the watcher from starting at all — no poll thread and no project registration. Reindex manually with `index_repository` when disabled. |
+
+> **`watcher_enabled` vs `auto_watch`.** `watcher_enabled` controls whether the
+> watcher *subsystem* starts at all (the background poll thread). `auto_watch` is
+> narrower: it only controls whether a connecting session registers *its own*
+> project with an already-running watcher. When `watcher_enabled=false`,
+> `auto_watch` has no effect — there is no watcher to register with.
+>
+> They also differ in **when they are read**, which matters because the watcher
+> lives in the background daemon, not in your MCP client:
+>
+> - `auto_watch` is consulted each time a session would register its project, so
+>   a change applies to sessions that connect afterwards.
+> - `watcher_enabled` is read **once, when the daemon starts**, because it decides
+>   whether the watcher is built at all. The daemon is long-lived and outlives
+>   individual MCP sessions, so **reconnecting your client is not enough** — retire
+>   the daemon so the next one picks the new value up:
+>
+> ```bash
+> codebase-memory-mcp config set watcher_enabled false
+> codebase-memory-mcp daemon stop     # next session starts a daemon without the watcher
+> codebase-memory-mcp daemon status   # confirm
+> ```
+>
+> Disabling the watcher does not disable anything else: the daemon still starts,
+> `auto_index` still runs, and `index_repository` stays available for manual
+> reindexing.
 
 ## 3. UI Settings
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -276,6 +276,15 @@ CBM_TEST_BINARY="$WATCHDOG_BINARY" bash "$ROOT/tests/test_parent_watchdog.sh"
 echo "=== Step 5b: worker-mode watchdog regression (#845) ==="
 CBM_TEST_BINARY="$WATCHDOG_BINARY" bash "$ROOT/tests/test_worker_watchdog.sh"
 
+# Step 5c: watcher_enabled kill-switch process regression (#335). Reuses the
+# prod binary built in Step 5; drives a real daemon against an isolated cache
+# and proves watcher_enabled=false stops the watcher from being built, started
+# or registered, while auto_index and manual index_repository keep working.
+# Every wait is a bounded poll on an asserted state (a closed daemon lifecycle),
+# never a fixed sleep — see the header of the test for why.
+echo "=== Step 5c: watcher_enabled kill-switch regression (#335) ==="
+CBM_TEST_BINARY="$WATCHDOG_BINARY" bash "$ROOT/tests/test_watcher_disabled.sh"
+
 # Step 6: security-strings URL allow-list regression. The MSYS2 CLANG64 toolchain
 # bakes its package-tracker URL into the static Windows .exe; the binary string
 # audit must allow-list it (Windows-only — Linux smoke never saw it).

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -331,6 +331,15 @@ CBM_TEST_BINARY="$WATCHDOG_BINARY" bash "$ROOT/tests/test_worker_error_response.
 # skipping it silently would hide the gap. Run it by hand:
 #   make -f Makefile.cbm cbm TEST_SEAMS=1 && bash tests/test_hook_conflict_notice.sh
 
+# Step 5e: watcher_enabled kill-switch process regression (#335). Reuses the
+# prod binary built in Step 5; drives a real daemon against an isolated cache
+# and proves watcher_enabled=false stops the watcher from being built, started
+# or registered, while auto_index and manual index_repository keep working.
+# Every wait is a bounded poll on an asserted state (a closed daemon lifecycle),
+# never a fixed sleep — see the header of the test for why.
+echo "=== Step 5e: watcher_enabled kill-switch regression (#335) ==="
+CBM_TEST_BINARY="$WATCHDOG_BINARY" bash "$ROOT/tests/test_watcher_disabled.sh"
+
 # Step 6: security-strings URL allow-list regression. The MSYS2 CLANG64 toolchain
 # bakes its package-tracker URL into the static Windows .exe; the binary string
 # audit must allow-list it (Windows-only — Linux smoke never saw it).

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -6734,6 +6734,14 @@ int cbm_config_delete(cbm_config_t *cfg, const char *key) {
     return rc;
 }
 
+/* Whether the background watcher subsystem should run (default true). The
+ * daemon host gates watcher construction and thread startup on this; see
+ * cbm_config_watcher_enabled in cli.h. NULL-safe via cbm_config_get_bool (a
+ * NULL cfg returns the default). */
+bool cbm_config_watcher_enabled(cbm_config_t *cfg) {
+    return cbm_config_get_bool(cfg, CBM_CONFIG_WATCHER_ENABLED, true);
+}
+
 /* ── Config CLI subcommand ────────────────────────────────────── */
 
 /* THE config-key table. list, get, help, and key validation all read this one
@@ -6753,6 +6761,8 @@ static const config_key_def_t CONFIG_KEYS[] = {
     {CBM_CONFIG_AUTO_INDEX, "false", "Enable auto-indexing on MCP session start"},
     {CBM_CONFIG_AUTO_INDEX_LIMIT, "50000", "Max files for auto-indexing new projects"},
     {CBM_CONFIG_AUTO_WATCH, "true", "Register background git watcher on session connect"},
+    {CBM_CONFIG_WATCHER_ENABLED, "true",
+     "Run the background watcher thread (auto-reindex); false to disable"},
     {CBM_CONFIG_UI_LANG, "auto", "Pin graph UI language: en, zh, or auto"},
     {CBM_CONFIG_UI_ENABLED, "false", "Serve the graph UI on a loopback HTTP port"},
     {CBM_CONFIG_UI_PORT, "9749", "Port for the graph UI listener when enabled"},

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -6442,6 +6442,14 @@ int cbm_config_delete(cbm_config_t *cfg, const char *key) {
     return rc;
 }
 
+/* Whether the background watcher subsystem should run (default true). The
+ * daemon host gates watcher construction and thread startup on this; see
+ * cbm_config_watcher_enabled in cli.h. NULL-safe via cbm_config_get_bool (a
+ * NULL cfg returns the default). */
+bool cbm_config_watcher_enabled(cbm_config_t *cfg) {
+    return cbm_config_get_bool(cfg, CBM_CONFIG_WATCHER_ENABLED, true);
+}
+
 /* ── Config CLI subcommand ────────────────────────────────────── */
 
 int cbm_cmd_config(int argc, char **argv) {
@@ -6461,6 +6469,8 @@ int cbm_cmd_config(int argc, char **argv) {
                "Register background git watcher on session connect");
         printf("  %-25s  default=%-10s  %s\n", CBM_CONFIG_UI_LANG, "auto",
                "Pin graph UI language: en, zh, or auto");
+        printf("  %-25s  default=%-10s  %s\n", CBM_CONFIG_WATCHER_ENABLED, "true",
+               "Run the background watcher thread (auto-reindex); false to disable");
         return 0;
     }
 
@@ -6490,6 +6500,8 @@ int cbm_cmd_config(int argc, char **argv) {
                cbm_config_get(cfg, CBM_CONFIG_AUTO_WATCH, "true"));
         printf("  %-25s = %-10s\n", CBM_CONFIG_UI_LANG,
                cbm_config_get(cfg, CBM_CONFIG_UI_LANG, "auto"));
+        printf("  %-25s = %-10s\n", CBM_CONFIG_WATCHER_ENABLED,
+               cbm_config_get(cfg, CBM_CONFIG_WATCHER_ENABLED, "true"));
     } else if (strcmp(argv[0], "get") == 0) {
         if (argc < MIN_ARGC_GET) {
             (void)fprintf(stderr, "Usage: config get <key>\n");

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -395,6 +395,16 @@ int cbm_config_delete(cbm_config_t *cfg, const char *key);
 #define CBM_CONFIG_AUTO_INDEX_LIMIT "auto_index_limit"
 #define CBM_CONFIG_AUTO_WATCH "auto_watch"
 #define CBM_CONFIG_UI_LANG "ui-lang"
+#define CBM_CONFIG_WATCHER_ENABLED "watcher_enabled"
+
+/* Whether the background watcher subsystem should run at all (default true).
+ * When false, the daemon host skips building and starting the watcher entirely:
+ * the poll thread never starts and no projects are registered (#335). Read once
+ * at daemon startup. Distinct from auto_watch, which only gates per-session
+ * registration while the watcher IS running. NULL-safe — a NULL cfg returns the
+ * default (true), so a failure to open the config store never silently disables
+ * the watcher. */
+bool cbm_config_watcher_enabled(cbm_config_t *cfg);
 
 /* ── Binary activation safety ─────────────────────────────────── */
 

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -422,10 +422,20 @@ int cbm_config_delete(cbm_config_t *cfg, const char *key);
 #define CBM_CONFIG_AUTO_INDEX_LIMIT "auto_index_limit"
 #define CBM_CONFIG_AUTO_WATCH "auto_watch"
 #define CBM_CONFIG_UI_LANG "ui-lang"
+#define CBM_CONFIG_WATCHER_ENABLED "watcher_enabled"
 /* #1558: the graph UI's loopback listener. Stored in the UI config file rather
  * than the key-value store, but surfaced through `config` so it is findable. */
 #define CBM_CONFIG_UI_ENABLED "ui_enabled"
 #define CBM_CONFIG_UI_PORT "ui_port"
+
+/* Whether the background watcher subsystem should run at all (default true).
+ * When false, the daemon host skips building and starting the watcher entirely:
+ * the poll thread never starts and no projects are registered (#335). Read once
+ * at daemon startup. Distinct from auto_watch, which only gates per-session
+ * registration while the watcher IS running. NULL-safe — a NULL cfg returns the
+ * default (true), so a failure to open the config store never silently disables
+ * the watcher. */
+bool cbm_config_watcher_enabled(cbm_config_t *cfg);
 
 /* ── Binary activation safety ─────────────────────────────────── */
 

--- a/src/daemon/host.c
+++ b/src/daemon/host.c
@@ -583,9 +583,22 @@ static bool host_state_prepare(host_state_t *host, const cbm_daemon_ipc_endpoint
         cbm_log_error("daemon.runtime_config_open_failed", "reason", "config_db_unavailable");
         return false;
     }
-    host->watch_store = cbm_store_open_memory();
     host->project_locks = cbm_project_lock_manager_new(endpoint);
-    host->watcher = cbm_watcher_new(host->watch_store, host_watcher_index, host);
+    /* #335: watcher_enabled (default true) is the master switch for the
+     * background watcher. When false the daemon never builds the watcher or the
+     * in-memory store backing it, so the poll thread never starts
+     * (host_background_start has nothing to run) and no project ever registers
+     * (register_watcher_if_enabled early-returns on a NULL watcher). The daemon
+     * still starts and still owns everything else: IPC, HTTP/UI, project locks,
+     * and manual index_repository. Read once here at daemon startup, so a change
+     * takes effect when the daemon next starts — see docs/CONFIGURATION.md. */
+    bool watcher_enabled = cbm_config_watcher_enabled(host->runtime_config);
+    if (watcher_enabled) {
+        host->watch_store = cbm_store_open_memory();
+        host->watcher = cbm_watcher_new(host->watch_store, host_watcher_index, host);
+    } else {
+        cbm_log_info("watcher.disabled", "reason", "config");
+    }
     cbm_daemon_application_config_t application_config = {
         .watcher = host->watcher,
         .config = host->runtime_config,
@@ -598,7 +611,12 @@ static bool host_state_prepare(host_state_t *host, const cbm_daemon_ipc_endpoint
     if (host->application && host->permanent) {
         cbm_daemon_application_set_permanent(host->application, true);
     }
-    if (!host->watch_store || !host->watcher || !host->project_locks || !host->application) {
+    if (!host->project_locks || !host->application) {
+        return false;
+    }
+    /* A watcher deliberately left unbuilt by watcher_enabled=false is not a
+     * startup failure; an allocation failure while it is enabled still is. */
+    if (watcher_enabled && (!host->watch_store || !host->watcher)) {
         return false;
     }
     return true;
@@ -824,10 +842,14 @@ bool cbm_daemon_host_http_thread_create_failure_lifecycle_for_test(void) {
 }
 
 static bool host_background_start(host_state_t *host) {
-    if (cbm_thread_create(&host->watcher_thread, 0, host_watcher_thread, host->watcher) != 0) {
-        return false;
+    /* No watcher object when watcher_enabled=false (#335) — nothing to run, and
+     * the daemon must still come up with its remaining subsystems. */
+    if (host->watcher) {
+        if (cbm_thread_create(&host->watcher_thread, 0, host_watcher_thread, host->watcher) != 0) {
+            return false;
+        }
+        host->watcher_started = true;
     }
-    host->watcher_started = true;
 
     host_http_reconcile_at(host, cbm_now_ms(), true);
     return true;

--- a/src/daemon/host.c
+++ b/src/daemon/host.c
@@ -573,9 +573,22 @@ static bool host_state_prepare(host_state_t *host, const cbm_daemon_ipc_endpoint
         cbm_log_error("daemon.runtime_config_open_failed", "reason", "config_db_unavailable");
         return false;
     }
-    host->watch_store = cbm_store_open_memory();
     host->project_locks = cbm_project_lock_manager_new(endpoint);
-    host->watcher = cbm_watcher_new(host->watch_store, host_watcher_index, host);
+    /* #335: watcher_enabled (default true) is the master switch for the
+     * background watcher. When false the daemon never builds the watcher or the
+     * in-memory store backing it, so the poll thread never starts
+     * (host_background_start has nothing to run) and no project ever registers
+     * (register_watcher_if_enabled early-returns on a NULL watcher). The daemon
+     * still starts and still owns everything else: IPC, HTTP/UI, project locks,
+     * and manual index_repository. Read once here at daemon startup, so a change
+     * takes effect when the daemon next starts — see docs/CONFIGURATION.md. */
+    bool watcher_enabled = cbm_config_watcher_enabled(host->runtime_config);
+    if (watcher_enabled) {
+        host->watch_store = cbm_store_open_memory();
+        host->watcher = cbm_watcher_new(host->watch_store, host_watcher_index, host);
+    } else {
+        cbm_log_info("watcher.disabled", "reason", "config");
+    }
     cbm_daemon_application_config_t application_config = {
         .watcher = host->watcher,
         .config = host->runtime_config,
@@ -586,7 +599,12 @@ static bool host_state_prepare(host_state_t *host, const cbm_daemon_ipc_endpoint
     if (host->application && host->permanent) {
         cbm_daemon_application_set_permanent(host->application, true);
     }
-    if (!host->watch_store || !host->watcher || !host->project_locks || !host->application) {
+    if (!host->project_locks || !host->application) {
+        return false;
+    }
+    /* A watcher deliberately left unbuilt by watcher_enabled=false is not a
+     * startup failure; an allocation failure while it is enabled still is. */
+    if (watcher_enabled && (!host->watch_store || !host->watcher)) {
         return false;
     }
     return true;
@@ -812,10 +830,14 @@ bool cbm_daemon_host_http_thread_create_failure_lifecycle_for_test(void) {
 }
 
 static bool host_background_start(host_state_t *host) {
-    if (cbm_thread_create(&host->watcher_thread, 0, host_watcher_thread, host->watcher) != 0) {
-        return false;
+    /* No watcher object when watcher_enabled=false (#335) — nothing to run, and
+     * the daemon must still come up with its remaining subsystems. */
+    if (host->watcher) {
+        if (cbm_thread_create(&host->watcher_thread, 0, host_watcher_thread, host->watcher) != 0) {
+            return false;
+        }
+        host->watcher_started = true;
     }
-    host->watcher_started = true;
 
     host_http_reconcile_at(host, cbm_now_ms(), true);
     return true;

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -11379,6 +11379,55 @@ TEST(cli_config_persists) {
     PASS();
 }
 
+TEST(cli_config_watcher_enabled_default_and_persist) {
+    /* #335: the background watcher is on by default and can be disabled via the
+     * persisted `watcher_enabled` key. This pins the config layer only — default
+     * preservation, the accepted spellings, and persistence across reopen. That
+     * the daemon host actually honours the key (watcher never built, thread
+     * never started, no registration) is proven separately by the process-level
+     * regression in tests/test_watcher_disabled.sh, which fails if the gate in
+     * host_state_prepare() is removed. */
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-cfg-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    /* A NULL config (store failed to open) defaults to ON — a config failure
+     * must never silently disable the watcher. */
+    ASSERT_TRUE(cbm_config_watcher_enabled(NULL));
+
+    cbm_config_t *cfg = cbm_config_open(tmpdir);
+    ASSERT_NOT_NULL(cfg);
+
+    /* Default: absent key → watcher runs. */
+    ASSERT_TRUE(cbm_config_watcher_enabled(cfg));
+
+    /* Disable: false / 0 / off all turn the watcher off. */
+    cbm_config_set(cfg, CBM_CONFIG_WATCHER_ENABLED, "false");
+    ASSERT_FALSE(cbm_config_watcher_enabled(cfg));
+    cbm_config_set(cfg, CBM_CONFIG_WATCHER_ENABLED, "0");
+    ASSERT_FALSE(cbm_config_watcher_enabled(cfg));
+    cbm_config_set(cfg, CBM_CONFIG_WATCHER_ENABLED, "off");
+    ASSERT_FALSE(cbm_config_watcher_enabled(cfg));
+
+    /* Re-enable: true / 1 / on all turn it back on. */
+    cbm_config_set(cfg, CBM_CONFIG_WATCHER_ENABLED, "on");
+    ASSERT_TRUE(cbm_config_watcher_enabled(cfg));
+    cbm_config_set(cfg, CBM_CONFIG_WATCHER_ENABLED, "1");
+    ASSERT_TRUE(cbm_config_watcher_enabled(cfg));
+
+    /* Persistence: the disabled state survives close + reopen. */
+    cbm_config_set(cfg, CBM_CONFIG_WATCHER_ENABLED, "false");
+    cbm_config_close(cfg);
+    cfg = cbm_config_open(tmpdir);
+    ASSERT_NOT_NULL(cfg);
+    ASSERT_FALSE(cbm_config_watcher_enabled(cfg));
+
+    cbm_config_close(cfg);
+    test_rmdir_r(tmpdir);
+    PASS();
+}
+
 /* ═══════════════════════════════════════════════════════════════════
  *  Group H: cbm_replace_binary (update command helper)
  * ═══════════════════════════════════════════════════════════════════ */
@@ -12080,6 +12129,7 @@ SUITE(cli) {
     RUN_TEST(cli_config_get_int);
     RUN_TEST(cli_config_delete);
     RUN_TEST(cli_config_persists);
+    RUN_TEST(cli_config_watcher_enabled_default_and_persist);
 
     /* Replace binary (update command helper — group H) */
 #ifndef _WIN32

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -12291,6 +12291,55 @@ TEST(cli_config_persists) {
     PASS();
 }
 
+TEST(cli_config_watcher_enabled_default_and_persist) {
+    /* #335: the background watcher is on by default and can be disabled via the
+     * persisted `watcher_enabled` key. This pins the config layer only — default
+     * preservation, the accepted spellings, and persistence across reopen. That
+     * the daemon host actually honours the key (watcher never built, thread
+     * never started, no registration) is proven separately by the process-level
+     * regression in tests/test_watcher_disabled.sh, which fails if the gate in
+     * host_state_prepare() is removed. */
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-cfg-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    /* A NULL config (store failed to open) defaults to ON — a config failure
+     * must never silently disable the watcher. */
+    ASSERT_TRUE(cbm_config_watcher_enabled(NULL));
+
+    cbm_config_t *cfg = cbm_config_open(tmpdir);
+    ASSERT_NOT_NULL(cfg);
+
+    /* Default: absent key → watcher runs. */
+    ASSERT_TRUE(cbm_config_watcher_enabled(cfg));
+
+    /* Disable: false / 0 / off all turn the watcher off. */
+    cbm_config_set(cfg, CBM_CONFIG_WATCHER_ENABLED, "false");
+    ASSERT_FALSE(cbm_config_watcher_enabled(cfg));
+    cbm_config_set(cfg, CBM_CONFIG_WATCHER_ENABLED, "0");
+    ASSERT_FALSE(cbm_config_watcher_enabled(cfg));
+    cbm_config_set(cfg, CBM_CONFIG_WATCHER_ENABLED, "off");
+    ASSERT_FALSE(cbm_config_watcher_enabled(cfg));
+
+    /* Re-enable: true / 1 / on all turn it back on. */
+    cbm_config_set(cfg, CBM_CONFIG_WATCHER_ENABLED, "on");
+    ASSERT_TRUE(cbm_config_watcher_enabled(cfg));
+    cbm_config_set(cfg, CBM_CONFIG_WATCHER_ENABLED, "1");
+    ASSERT_TRUE(cbm_config_watcher_enabled(cfg));
+
+    /* Persistence: the disabled state survives close + reopen. */
+    cbm_config_set(cfg, CBM_CONFIG_WATCHER_ENABLED, "false");
+    cbm_config_close(cfg);
+    cfg = cbm_config_open(tmpdir);
+    ASSERT_NOT_NULL(cfg);
+    ASSERT_FALSE(cbm_config_watcher_enabled(cfg));
+
+    cbm_config_close(cfg);
+    test_rmdir_r(tmpdir);
+    PASS();
+}
+
 /* ═══════════════════════════════════════════════════════════════════
  *  Group H: cbm_replace_binary (update command helper)
  * ═══════════════════════════════════════════════════════════════════ */
@@ -13301,6 +13350,7 @@ SUITE(cli) {
     RUN_TEST(cli_config_get_int);
     RUN_TEST(cli_config_delete);
     RUN_TEST(cli_config_persists);
+    RUN_TEST(cli_config_watcher_enabled_default_and_persist);
 
     /* Replace binary (update command helper — group H) */
 #ifndef _WIN32

--- a/tests/test_watcher_disabled.sh
+++ b/tests/test_watcher_disabled.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# test_watcher_disabled.sh — process-level regression for the watcher_enabled
+# kill-switch (#335). Requested by the maintainer on PR #1105: the unit test
+# (cli_config_watcher_enabled_default_and_persist) only proves the config
+# predicate and would still pass if the daemon-side gate were deleted. This
+# drives the REAL binary against an isolated cache and proves, at the process
+# level, that watcher_enabled=false actually prevents the watcher subsystem from
+# initializing:
+#   - `watcher.disabled reason=config` IS emitted,
+#   - `watcher.start` is ABSENT (the poll thread never runs),
+#   - no project registration occurs (`watcher.watch` ABSENT), and
+#   - manual index_repository remains available (the MCP tool still serves and
+#     indexes with the watcher off).
+# A positive control (watcher_enabled=true) proves those signals are real —
+# watcher.start + watcher.watch DO appear and watcher.disabled does not — so
+# this test fails if the gate is removed.
+#
+# NO ASSERTION IS DECIDED BY A TIMEOUT. The watcher lives in the daemon
+# (src/daemon/host.c), which logs to $CBM_CACHE_DIR/logs/cbm-daemon.log in a
+# fixed order: watcher.disabled (host_state_prepare) -> daemon.start -> the
+# watcher thread's own watcher.start -> ... -> watcher thread joined ->
+# daemon.stop. Each run therefore retires its daemon and waits for that CLOSED
+# lifecycle (daemon.start ... daemon.stop) before asserting. Absence over a
+# closed lifecycle log is a fact, not a race: if watcher.start is not in a log
+# that already contains daemon.stop, the thread never ran. Every wait is a
+# bounded poll on an asserted state (the soak harness's wait_for_daemon_stop
+# doctrine, scripts/soak-test.sh), and exhausting a poll is a FAILURE with the
+# reason printed — never a silently-passing sleep.
+#
+# Skipped on Windows-like shells (uses POSIX process control + git fixture).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BINARY="${CBM_TEST_BINARY:-${ROOT}/build/c/codebase-memory-mcp}"
+
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) echo "skipping watcher_disabled test on Windows"; exit 0 ;;
+esac
+[[ -x "${BINARY}" ]] || { echo "missing binary: ${BINARY}" >&2; exit 2; }
+command -v git >/dev/null 2>&1 || { echo "git required for fixture" >&2; exit 2; }
+
+work="$(mktemp -d)"
+
+# Every run gets its own CBM_CACHE_DIR, and the daemon endpoint is derived from
+# it, so these daemons are private to the test and can never touch a developer's
+# real one. Retire them on any exit path regardless.
+cleanup() {
+  local cache
+  for cache in "${work}"/cache-*; do
+    [[ -d "${cache}" ]] || continue
+    CBM_CACHE_DIR="${cache}" "${BINARY}" daemon stop >/dev/null 2>&1 || true
+  done
+  rm -rf "${work}"
+}
+trap cleanup EXIT
+
+# --- tiny git fixture so indexing is fast + deterministic ---------------------
+repo="${work}/repo"
+mkdir -p "${repo}"
+cat >"${repo}/sample.c" <<'EOF'
+int add(int a, int b) { return a + b; }
+int main(void) { return add(1, 2); }
+EOF
+git -C "${repo}" init -q
+git -C "${repo}" -c user.email=t@example.com -c user.name=t add -A
+git -C "${repo}" -c user.email=t@example.com -c user.name=t commit -q -m init
+
+INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"watcher-test","version":"1.0"}}}'
+INITED='{"jsonrpc":"2.0","method":"notifications/initialized"}'
+
+CURRENT_RUN="(setup)"
+
+fail() {
+  echo "FAIL [${CURRENT_RUN}]: $*" >&2
+  local log
+  for log in "${work}"/cache-*/logs/cbm-daemon.log; do
+    [[ -f "${log}" ]] || continue
+    echo "----- ${log} (watcher/daemon lines) -----" >&2
+    grep -E 'msg=(watcher|daemon)\.' "${log}" >&2 || true
+  done
+  exit 1
+}
+
+# wait_for <file> <extended-regex> <label>
+# Bounded poll on an asserted state: returns as soon as the state is observed,
+# and a exhausted budget is a failure with the reason — never a fixed sleep that
+# lets the assertion proceed on an unobserved state. 30s ceiling mirrors
+# scripts/soak-test.sh (attempts=300 x 0.1s): the wait sits above the worst case
+# so a slow, loaded CI runner is not mistaken for a broken gate.
+wait_for() {
+  local file="$1" pattern="$2" label="$3"
+  local attempts=300
+  while [ "${attempts}" -gt 0 ]; do
+    if [ -f "${file}" ] && grep -qE "${pattern}" "${file}"; then
+      return 0
+    fi
+    attempts=$((attempts - 1))
+    sleep 0.1
+  done
+  fail "timed out after 30s waiting for ${label} in ${file}"
+}
+
+log_has() { grep -qE "$2" "$1"; }
+
+# wait_for_project_db <cache_dir>
+# Registration is not reachable until the project DB exists: the daemon only
+# refreshes a session's watch once application_regular_db_exists(project) is
+# true (application.c application_refresh_watch_locked). Waiting on the DB is
+# therefore waiting on registration's own precondition — after this returns, a
+# missing watcher.watch is the gate's doing, not a session that ended too soon.
+wait_for_project_db() {
+  local cache="$1" attempts=300 db
+  while [ "${attempts}" -gt 0 ]; do
+    for db in "${cache}"/*.db; do
+      # An unmatched glob stays literal, and _config.db is the settings store,
+      # not a project graph.
+      case "${db}" in
+        */_config.db) continue ;;
+        *'*.db') continue ;;
+      esac
+      if [ -f "${db}" ]; then
+        return 0
+      fi
+    done
+    attempts=$((attempts - 1))
+    sleep 0.1
+  done
+  fail "timed out after 30s waiting for the project DB under ${cache}"
+}
+
+# run_session <cache_dir> <outfile> [extra rpc line ...]
+# Drives the real binary in MCP stdio mode with cwd = the fixture repo (so the
+# session root is derived from it), holding stdin open via a FIFO until the LAST
+# request has been answered on stdout — an asserted state, not an interval —
+# then closing it (EOF -> clean shutdown). Sets DAEMON_LOG for the caller.
+#
+# Registration happens asynchronously, after indexing, so a closed lifecycle
+# alone would not carry a NEGATIVE registration assertion — the session could
+# simply have ended before registration was ever reachable. Two optional
+# pre-close waits close that gap, both observed while the session is still live:
+#   PRE_CLOSE_DB=1        wait for the project DB, which is registration's own
+#                         precondition (see wait_for_project_db).
+#   PRE_CLOSE_WAIT=<re>   wait for a daemon-log pattern (with PRE_CLOSE_LABEL),
+#                         used by the positive control to observe registration
+#                         actually happening in this session shape.
+run_session() {
+  local cache="$1" outf="$2"; shift 2
+  local fifo="${work}/stdin.fifo"
+  rm -f "${fifo}"; mkfifo "${fifo}"
+  DAEMON_LOG="${cache}/logs/cbm-daemon.log"
+
+  ( cd "${repo}" && CBM_CACHE_DIR="${cache}" "${BINARY}" <"${fifo}" \
+      >"${outf}" 2>"${cache}.client.err" ) &
+  local server_pid=$!
+
+  exec 3>"${fifo}"
+  printf '%s\n' "${INIT}" >&3
+  printf '%s\n' "${INITED}" >&3
+  local line last_id=1
+  for line in "$@"; do
+    printf '%s\n' "${line}" >&3
+    last_id=$((last_id + 1))
+  done
+  # Wait for the final response before closing stdin, so shutdown never races
+  # the work under test.
+  wait_for "${outf}" "\"id\":${last_id}[,}]" "the id=${last_id} JSON-RPC response"
+  if [ -n "${PRE_CLOSE_DB:-}" ]; then
+    wait_for_project_db "${cache}"
+  fi
+  if [ -n "${PRE_CLOSE_WAIT:-}" ]; then
+    wait_for "${DAEMON_LOG}" "${PRE_CLOSE_WAIT}" "${PRE_CLOSE_LABEL:-${PRE_CLOSE_WAIT}}"
+  fi
+  exec 3>&-
+  wait "${server_pid}" || true
+
+  # Retire the daemon and wait for the lifecycle to close, so the assertions
+  # below read a complete log rather than a snapshot of one still being written.
+  CBM_CACHE_DIR="${cache}" "${BINARY}" daemon stop >/dev/null 2>&1 || true
+  wait_for "${DAEMON_LOG}" 'msg=daemon\.start( |$)' "the daemon to record its start"
+  wait_for "${DAEMON_LOG}" 'msg=daemon\.stop( |$)' "the daemon lifecycle to close"
+}
+
+# =============================================================================
+# Run 1 — DISABLED + manual index_repository (auto_index off, no contention).
+#   Proves: gate fires, watcher never starts, and the manual MCP tool still
+#   serves + indexes with the watcher off.
+# =============================================================================
+CURRENT_RUN="run 1: disabled + manual index_repository"
+c_offm="${work}/cache-offm"
+CBM_CACHE_DIR="${c_offm}" "${BINARY}" config set watcher_enabled false >/dev/null
+CBM_CACHE_DIR="${c_offm}" "${BINARY}" config set auto_index false >/dev/null
+run_session "${c_offm}" "${work}/offm.out" \
+  "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"index_repository\",\"arguments\":{\"repo_path\":\"${repo}\",\"mode\":\"fast\"}}}"
+
+log_has "${DAEMON_LOG}" 'msg=watcher\.disabled( |$)' \
+  || fail "watcher.disabled not emitted when disabled"
+log_has "${DAEMON_LOG}" 'msg=watcher\.disabled .*reason=config' \
+  || fail "watcher.disabled emitted without reason=config"
+! log_has "${DAEMON_LOG}" 'msg=watcher\.start( |$)' \
+  || fail "watcher.start present when disabled (the poll thread ran)"
+! log_has "${DAEMON_LOG}" 'msg=watcher\.watch( |$)' \
+  || fail "watcher.watch (registration) present when disabled"
+
+resp="$(grep '"id":2' "${work}/offm.out" | head -1)"
+[ -n "${resp}" ] || fail "no index_repository response (tool unavailable when watcher off)"
+case "${resp}" in
+  *'"error"'*) fail "index_repository returned an error with the watcher off: ${resp}" ;;
+esac
+case "${resp}" in
+  *nodes*) : ;;
+  *) fail "index_repository response reports no indexed nodes: ${resp}" ;;
+esac
+echo "ok: disabled — watcher.disabled emitted, no watcher.start/watch, manual index_repository served"
+
+# =============================================================================
+# Run 2 — DISABLED + auto_index on. Same-config apples-to-apples for the
+#   registration axis: indexing still runs, but NO registration happens.
+# =============================================================================
+CURRENT_RUN="run 2: disabled + auto_index"
+c_offa="${work}/cache-offa"
+CBM_CACHE_DIR="${c_offa}" "${BINARY}" config set watcher_enabled false >/dev/null
+CBM_CACHE_DIR="${c_offa}" "${BINARY}" config set auto_index true >/dev/null
+# Hold the session open until auto-indexing has produced the project DB, so
+# registration's precondition is satisfied and the absence below is the gate.
+PRE_CLOSE_DB=1
+run_session "${c_offa}" "${work}/offa.out"
+PRE_CLOSE_DB=""
+
+log_has "${DAEMON_LOG}" 'msg=watcher\.disabled( |$)' \
+  || fail "watcher.disabled not emitted (auto_index run)"
+# Contract point 3 is broader than the manual tool: turning the watcher off must
+# not turn auto-indexing off with it. The DB above proves the pipeline ran.
+log_has "${DAEMON_LOG}" 'msg=daemon\.start( |$)' \
+  || fail "daemon did not start with the watcher disabled"
+! log_has "${DAEMON_LOG}" 'msg=watcher\.start( |$)' \
+  || fail "watcher.start present when disabled (auto_index run)"
+! log_has "${DAEMON_LOG}" 'msg=watcher\.watch( |$)' \
+  || fail "project registered with the watcher when disabled"
+echo "ok: disabled+auto_index — auto-index still ran, no watcher.start, no registration"
+
+# =============================================================================
+# Run 3 — ENABLED positive control (auto_index on). Proves the signals above
+#   are real: the watcher starts AND registers the session project — so their
+#   absence in Runs 1-2 is meaningful, and removing the gate fails this test.
+# =============================================================================
+CURRENT_RUN="run 3: enabled positive control"
+c_on="${work}/cache-on"
+CBM_CACHE_DIR="${c_on}" "${BINARY}" config set watcher_enabled true >/dev/null
+CBM_CACHE_DIR="${c_on}" "${BINARY}" config set auto_index true >/dev/null
+# The control must observe registration actually happening in this exact session
+# shape — that is what makes its absence in runs 1-2 evidence rather than noise.
+PRE_CLOSE_WAIT='msg=watcher\.watch( |$)'
+PRE_CLOSE_LABEL="the session project to register with the watcher"
+run_session "${c_on}" "${work}/on.out"
+PRE_CLOSE_WAIT=""
+
+log_has "${DAEMON_LOG}" 'msg=watcher\.start( |$)' \
+  || fail "watcher.start absent when enabled (the watcher never started)"
+log_has "${DAEMON_LOG}" 'msg=watcher\.watch( |$)' \
+  || fail "no project registration when enabled (control failed)"
+! log_has "${DAEMON_LOG}" 'msg=watcher\.disabled( |$)' \
+  || fail "watcher.disabled present when enabled"
+echo "ok: enabled — watcher.start emitted and session project registered"
+
+echo "PASS: watcher_enabled kill-switch process regression (#335)"


### PR DESCRIPTION
## Summary

Adds a persistent `watcher_enabled` config key (default `true`) that fully
disables the background watcher when set to `false`. Closes #335.

Per the maintainer's contract on #335: `watcher_enabled` defaults to `true`,
`false` prevents the watcher **thread from starting** *and* from registering
projects, and manual `index_repository` continues to work normally. Scope is
limited to this one switch — no other watcher policy changes.

## Why (and how it differs from `auto_watch`)

`auto_watch` (default `true`) already gates *per-session registration* — but
the watcher **thread still runs idle** even with `auto_watch=false`. #335 asks
for a way to stop the watcher entirely (the doc-heavy-repo use case: every save
churns the graph baseline). `watcher_enabled` is that master switch: when
`false`, the daemon host never creates the watcher, so the poll thread never starts
and nothing is registered. `auto_watch` is left unchanged as the finer-grained
per-session registration control. Both are now documented together.

(Note: the watcher polls for git changes now, not raw mtime as the original
0.6.0-era issue described; the user-visible concern — auto-reindex churn — is the
same, and this switch addresses it.)

## The change

- **`src/cli/cli.h` / `src/cli/cli.c`** — `CBM_CONFIG_WATCHER_ENABLED`
  (`"watcher_enabled"`) plus a small NULL-safe predicate
  `cbm_config_watcher_enabled(cfg)` (returns the persisted bool, default `true`).
  Listed in `config` usage help and `config list` output, alongside the sibling
  keys.
  Registered as a **`CONFIG_KEYS` row** next to `auto_watch`: since #1522/#1558 that
  table also backs key validation, so `config set/get/reset watcher_enabled` would be
  rejected as an unknown key without it.
- **`src/daemon/host.c`** — gate watcher construction in `host_state_prepare()` and
  the thread-create in `host_background_start()`; logs `watcher.disabled
  reason=config` when skipped. A NULL watcher makes every downstream path skip
  itself: teardown NULL-checks, the join is gated on `watcher_started`,
  `cbm_watcher_free` is NULL-safe, and registration early-returns on a NULL watcher
  (`application_refresh_watch_locked`, the only path to `cbm_watcher_watch`). The
  config wiring **stays outside the gate** so `auto_index` / `auto_watch` still read
  config when the watcher is off. A deliberately-unbuilt watcher is not a daemon
  startup failure; an allocation failure with the watcher enabled still is.
  *(Originally gated in `src/main.c`; re-ported here mid-review after the daemon
  rework moved watcher construction out of `main.c` — see the review thread.)*
- **`tests/test_cli.c`** — `cli_config_watcher_enabled_default_and_persist`
  drives the predicate the daemon gates on: default on, `false`/`0`/`off` disable,
  `true`/`1`/`on` re-enable, persistence across reopen, and a NULL-config default
  (a config-store failure must never silently disable the watcher). The existing
  `dump_verify`-style tests feed synthetic values; this exercises the real seam.
- **`docs/CONFIGURATION.md` / `README.md`** — document `watcher_enabled`, and add
  the previously-missing `auto_watch` row so the watcher knobs are described
  together.

## Verification

- **`tests/test_watcher_disabled.sh`** (wired into `scripts/test.sh` as **Step 5e**)
  green on all three runs, including the enabled positive control. No assertion is
  decided by a timeout: each run retires its daemon and asserts over a closed
  lifecycle log, and every wait is a bounded poll on an asserted state.
- **`cli` suite: 282 passed / 0 failed**, including
  `cli_config_watcher_enabled_default_and_persist` and
  `cli_ui_config_keys_are_discoverable_and_settable_issue1558` (the table-walking test
  the added `CONFIG_KEYS` row had to not perturb).
- Behavioral proof on the built binary (isolated `CBM_CACHE_DIR`):
  `config set watcher_enabled false` → daemon logs `watcher.disabled reason=config`,
  no watcher thread starts, nothing registers; default/`true` → watcher starts
  normally; manual `index_repository` unaffected; `config list` shows the key and
  `set`/`get`/`reset` all work.
- No `Makefile.cbm` change (all touched files already compiled); no CHANGELOG in the
  repo. **The `config set` allowlist *does* now need the `CONFIG_KEYS` row** — that
  claim in the original description predates #1522/#1558 and is retired.

All commits are DCO signed-off.



*Description updated 2026-08-24 after the rebase onto current `main`, so it describes the code as merged rather than the round-1 `main.c` version. The review thread below records how it moved.*
