### PR TITLE
fix(mcp): preserve coverage scope labels

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -3511,7 +3511,7 @@ static char *handle_check_index_coverage(cbm_mcp_server_t *srv, const char *args
                 yyjson_mut_arr_add_val(scope_results, item);
                 continue;
             }
-            yyjson_mut_obj_add_str(doc, item, "scope", scope[0] ? scope : ".");
+            yyjson_mut_obj_add_strcpy(doc, item, "scope", scope[0] ? scope : ".");
             cbm_coverage_row_t *rows = NULL;
             int row_count = 0;
             int cov_rc = cbm_store_coverage_get_scope(store, project, scope, &rows, &row_count);

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -1458,6 +1458,40 @@ TEST(tool_check_index_coverage_reports_paths_scopes_and_ranges) {
     PASS();
 }
 
+TEST(tool_check_index_coverage_preserves_multiple_scope_labels) {
+    char tmp[256];
+    cbm_mcp_server_t *srv = setup_snippet_server(tmp, sizeof(tmp));
+    ASSERT_NOT_NULL(srv);
+
+    char *coverage = cbm_mcp_handle_tool(srv, "check_index_coverage",
+                                         "{\"project\":\"test-project\","
+                                         "\"scopes\":[\"alpha/one\",\"bravo/two\",\"charl/tri\"]}");
+    ASSERT_NOT_NULL(coverage);
+    char *inner = extract_text_content(coverage);
+    ASSERT_NOT_NULL(inner);
+    yyjson_doc *doc = yyjson_read(inner, strlen(inner), 0);
+    ASSERT_NOT_NULL(doc);
+    yyjson_val *scopes = yyjson_obj_get(yyjson_doc_get_root(doc), "scopes");
+    ASSERT_NOT_NULL(scopes);
+    ASSERT_TRUE(yyjson_is_arr(scopes));
+    ASSERT_EQ(yyjson_arr_size(scopes), 3);
+
+    const char *expected[] = {"alpha/one", "bravo/two", "charl/tri"};
+    for (size_t i = 0; i < 3; i++) {
+        yyjson_val *scope = yyjson_obj_get(yyjson_arr_get(scopes, i), "scope");
+        ASSERT_NOT_NULL(scope);
+        ASSERT_TRUE(yyjson_is_str(scope));
+        ASSERT_STR_EQ(yyjson_get_str(scope), expected[i]);
+    }
+
+    yyjson_doc_free(doc);
+    free(inner);
+    free(coverage);
+    cbm_mcp_server_free(srv);
+    cleanup_snippet_dir(tmp);
+    PASS();
+}
+
 static int write_coverage_meta(cbm_store_t *store, const char *generation,
                                const char *recording_status) {
     cbm_coverage_meta_t meta = {
@@ -6411,6 +6445,7 @@ SUITE(mcp) {
     RUN_TEST(tool_index_status_no_project);
     RUN_TEST(tool_check_index_coverage_finds_path_beyond_status_cap);
     RUN_TEST(tool_check_index_coverage_reports_paths_scopes_and_ranges);
+    RUN_TEST(tool_check_index_coverage_preserves_multiple_scope_labels);
     RUN_TEST(tool_check_index_coverage_rejects_stale_generation);
     RUN_TEST(tool_check_index_coverage_requires_source_when_file_metadata_changed);
     RUN_TEST(tool_check_index_coverage_surfaces_lookup_errors);


### PR DESCRIPTION
## What does this PR do?

`check_index_coverage` stored each normalized scope with yyjson's non-copying
string API even though the source was a loop-local buffer. With multiple
scopes, later iterations could overwrite earlier labels; AddressSanitizer also
reported a stack-use-after-scope when the response was serialized.

Use `yyjson_mut_obj_add_strcpy` so the mutable document owns each scope label.
Add a regression that requests three distinct, equal-length scopes and asserts
that every returned label and its order are preserved.

This PR is intentionally limited to one issue and two files:

- `src/mcp/mcp.c`
- `tests/test_mcp.c`

It does not change coverage semantics, tool inputs, schemas, pagination, or
status handling.

### Verification

- Reproduce-first: the focused MCP sanitizer suite aborted before the fix with
  `stack-use-after-scope` in `handle_check_index_coverage` during yyjson
  serialization.
- `make -j4 -f Makefile.cbm test-focused TEST_SUITES=mcp`: 166/166 passed.
- `scripts/lint.sh --ci` with CI's clang-format 20.1.8 and cppcheck 2.20.0:
  passed.
- `make -j"$(nproc)" -f Makefile.cbm security`: all seven security layers
  passed, including MCP robustness 23/23.
- Focused review: 0 High, 0 Medium, 0 Low findings.

The broad `scripts/test.sh` run reached the end with all test cases reporting
`PASS`, then LeakSanitizer exited nonzero for a 4,976-byte allocation originating
from the unchanged `cli_install_plan_receipt_no_mutation_issue388` test path
(`tests/test_cli.c:2398` / `src/cli/cli.c:7539`). This PR does not touch that
path; it is being kept out of this one-issue change and investigated separately.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Tests pass locally (`make -f Makefile.cbm test`) — all cases passed, but
      the separate unchanged CLI LeakSanitizer finding above made the process
      exit nonzero
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)
