### PR TITLE
test(cli): isolate install plan receipt fixture

### DIFF
--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -2388,6 +2388,11 @@ TEST(cli_install_plan_receipt_no_mutation_issue388) {
     if (!cbm_mkdtemp(tmpdir))
         FAIL("cbm_mkdtemp failed");
 
+    /* Production correctly honors CODEX_HOME, but this fixture must not inherit
+     * the developer or CI runner's real Codex home. */
+    char *saved_codex_home = save_test_env("CODEX_HOME");
+    cbm_unsetenv("CODEX_HOME");
+
     /* Make Cursor + Codex "detected". */
     char dir[512];
     snprintf(dir, sizeof(dir), "%s/.cursor", tmpdir);
@@ -2396,24 +2401,26 @@ TEST(cli_install_plan_receipt_no_mutation_issue388) {
     test_mkdirp(dir);
 
     char *json = cbm_build_install_plan_json(tmpdir, "/usr/local/bin/codebase-memory-mcp");
-    ASSERT_NOT_NULL(json);
-    ASSERT(strstr(json, "agent.install.plan.v1") != NULL);
-    ASSERT(strstr(json, "writes_started") != NULL);
-    ASSERT(strstr(json, "next_safe_command") != NULL);
-    ASSERT(strstr(json, "cursor") != NULL);
-    ASSERT(strstr(json, ".cursor/mcp.json") != NULL);
-    ASSERT(strstr(json, ".codex/config.toml") != NULL);
+    bool receipt_valid = json && strstr(json, "agent.install.plan.v1") &&
+                         strstr(json, "writes_started") && strstr(json, "next_safe_command") &&
+                         strstr(json, "cursor") && strstr(json, ".cursor/mcp.json") &&
+                         strstr(json, ".codex/config.toml");
     free(json);
 
     /* Critical: building the plan must NOT have created any config file. */
     char cfg[512];
     struct stat st;
     snprintf(cfg, sizeof(cfg), "%s/.cursor/mcp.json", tmpdir);
-    ASSERT(stat(cfg, &st) != 0); /* must not exist */
+    bool cursor_untouched = stat(cfg, &st) != 0;
     snprintf(cfg, sizeof(cfg), "%s/.codex/config.toml", tmpdir);
-    ASSERT(stat(cfg, &st) != 0); /* must not exist */
+    bool codex_untouched = stat(cfg, &st) != 0;
 
+    restore_test_env("CODEX_HOME", saved_codex_home);
     test_rmdir_r(tmpdir);
+    if (!receipt_valid)
+        FAIL("install plan receipt must describe the detected Cursor and Codex fixtures");
+    if (!cursor_untouched || !codex_untouched)
+        FAIL("building an install plan must not create agent config files");
     PASS();
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the cli_install_plan_receipt_no_mutation_issue388 test harness so it cannot inherit a developer or CI runner CODEX_HOME while using a temporary HOME fixture.

The observed 4,976-byte LeakSanitizer report was a harness-cleanup symptom, not a production allocation defect:

- With inherited CODEX_HOME, production correctly resolved the Codex path outside the temporary fixture.
- The receipt assertion then failed before free(json).
- The same pre-fix sanitizer binary passed all 222 CLI tests when run with CODEX_HOME unset.

The fixture now saves, unsets, and restores CODEX_HOME. It also records the receipt and no-mutation results, then frees the JSON, restores the environment, and removes the temporary directory before reporting an assertion failure.

## Reproduce-first evidence

- RED: with inherited CODEX_HOME, ASan/UBSan CLI execution failed at the install-plan receipt assertion and LeakSanitizer reported 4,976 bytes allocated through yyjson in cbm_build_install_plan_json.
- CONTROL: the same pre-fix binary with CODEX_HOME unset passed 222/222 CLI tests without a leak.
- GREEN: the patched focused CLI ASan/UBSan suite passes 222/222 under the inherited CODEX_HOME environment, without a sanitizer report.

## Checks

- [x] One signed-off commit; scripts/check-dco.sh upstream/main..HEAD passes
- [x] Focused CLI ASan/UBSan suite: 222/222
- [x] scripts/lint.sh --ci
- [x] make -f Makefile.cbm security
- [x] scripts/check-no-test-skips.sh
- [x] clang-format 20.1.8 dry-run
- [x] git diff --check
- [x] Independent focused review: 0 High / 0 Medium / 0 Low
- [ ] Full local scripts/test.sh: started but stopped after the relevant CLI phase while unrelated deep/matrix suites continued pathologically long; it did not reach a final summary. GitHub CI is authoritative for the exhaustive suite.

## Scope

Only tests/test_cli.c changes. Production behavior is unchanged.