### PR TITLE
fix(tests): isolate Codex home from user state

### DIFF
--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -226,6 +226,19 @@ static void restore_test_env(const char *name, char *saved) {
     }
 }
 
+TEST(cli_runner_uses_private_codex_home) {
+    const char *home = getenv("HOME");
+    const char *codex_home = getenv("CODEX_HOME");
+    ASSERT_NOT_NULL(home);
+    ASSERT_NOT_NULL(codex_home);
+
+    char expected[1024];
+    int expected_len = snprintf(expected, sizeof(expected), "%s/.codex", home);
+    ASSERT(expected_len >= 0 && (size_t)expected_len < sizeof(expected));
+    ASSERT_STR_EQ(codex_home, expected);
+    PASS();
+}
+
 /* Helper: mkdirp */
 static int test_mkdirp(const char *path) {
     char tmp[1024];
@@ -2354,10 +2367,13 @@ TEST(cli_detect_agents_finds_codex) {
     snprintf(dir, sizeof(dir), "%s/.codex", tmpdir);
     test_mkdirp(dir);
 
+    char *saved_codex = save_test_env("CODEX_HOME");
+    cbm_unsetenv("CODEX_HOME");
     cbm_detected_agents_t agents = cbm_detect_agents(tmpdir);
-    ASSERT_TRUE(agents.codex);
+    restore_test_env("CODEX_HOME", saved_codex);
 
     test_rmdir_r(tmpdir);
+    ASSERT_TRUE(agents.codex);
     PASS();
 }
 
@@ -2395,7 +2411,10 @@ TEST(cli_install_plan_receipt_no_mutation_issue388) {
     snprintf(dir, sizeof(dir), "%s/.codex", tmpdir);
     test_mkdirp(dir);
 
+    char *saved_codex = save_test_env("CODEX_HOME");
+    cbm_unsetenv("CODEX_HOME");
     char *json = cbm_build_install_plan_json(tmpdir, "/usr/local/bin/codebase-memory-mcp");
+    restore_test_env("CODEX_HOME", saved_codex);
     ASSERT_NOT_NULL(json);
     ASSERT(strstr(json, "agent.install.plan.v1") != NULL);
     ASSERT(strstr(json, "writes_started") != NULL);
@@ -9643,6 +9662,7 @@ TEST(cli_sha256_file_matches_known_vector) {
  * ═══════════════════════════════════════════════════════════════════ */
 
 SUITE(cli) {
+    RUN_TEST(cli_runner_uses_private_codex_home);
     RUN_TEST(cli_sha256_file_matches_known_vector);
     /* Version (2 tests — selfupdate_test.go) */
     RUN_TEST(cli_compare_versions);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -25,10 +25,10 @@ int tf_skip_count = 0;
 #include <winsock2.h> /* #798 follow-up: socket-isolation re-exec probe */
 #endif
 
-/* Test handlers that exercise the production index_repository flow must never
- * inherit the user's real cache. Individual tests may temporarily override
- * this sentinel and restore it; atexit removes anything left behind by an
- * assertion that returns before fixture cleanup. */
+/* Test handlers that exercise production indexing or agent installation must
+ * never inherit the user's real cache or Codex configuration. Individual tests
+ * may temporarily override this sentinel and restore it; atexit removes
+ * anything left behind by an assertion that returns before fixture cleanup. */
 static char tf_home_sentinel[512];
 
 static void tf_cleanup_cache_sentinel(void) {
@@ -45,8 +45,14 @@ static bool tf_setup_cache_sentinel(void) {
     /* Legacy integration fixtures derive DB paths from HOME, while production
      * cache_dir() prefers CBM_CACHE_DIR. A private HOME plus no inherited cache
      * override keeps both conventions pointed at the same isolated tree. */
-    cbm_setenv("HOME", tf_home_sentinel, 1);
-    cbm_unsetenv("CBM_CACHE_DIR");
+    char codex_home[sizeof(tf_home_sentinel) + sizeof("/.codex")];
+    int codex_home_len = snprintf(codex_home, sizeof(codex_home), "%s/.codex", tf_home_sentinel);
+    if (codex_home_len < 0 || (size_t)codex_home_len >= sizeof(codex_home) ||
+        cbm_setenv("HOME", tf_home_sentinel, 1) != 0 ||
+        cbm_setenv("CODEX_HOME", codex_home, 1) != 0 || cbm_unsetenv("CBM_CACHE_DIR") != 0) {
+        tf_cleanup_cache_sentinel();
+        return false;
+    }
     atexit(tf_cleanup_cache_sentinel);
     return true;
 }
@@ -304,7 +310,7 @@ int main(int argc, char **argv) {
      * A test that exercises the supervisor must explicitly re-enable it. */
     cbm_setenv("CBM_INDEX_SUPERVISOR", "0", 1);
     if (!tf_setup_cache_sentinel()) {
-        fprintf(stderr, "failed to create isolated test cache\n");
+        fprintf(stderr, "failed to create isolated test home\n");
         return 2;
     }
 


### PR DESCRIPTION
## What does this PR do?

Completes the test-state isolation added in #1067. The runner replaced HOME and cleared CBM_CACHE_DIR, but it still inherited the invoking process's CODEX_HOME. When that directory existed, CLI fixtures detected the developer's real Codex installation and repeatedly installed and uninstalled MCP config, AGENTS.md content, skills, and Scout/Verify/Auditor profiles there.

A sentinel run on exact upstream/main e678b2b6acb02bc1ab84a854f2df0e1d092f2cc0 reproduced thousands of accesses and explicit write syscalls under the inherited CODEX_HOME, left an extra skills directory, and failed the install-plan no-mutation fixture because the inherited override shadowed its temporary .codex directory.

## Fix

- set CODEX_HOME to the private test HOME's .codex path before normal suites run;
- fail test-home setup instead of continuing if the environment isolation cannot be established;
- add a regression that binds CODEX_HOME to the private test HOME;
- explicitly unset and restore CODEX_HOME in the two tests that intentionally exercise the home-directory fallback.

Worker and socket-probe modes still exit before normal suite setup, as before.

## Validation

- ASan + UBSan test runner build with warnings as errors: passed;
- make -f Makefile.cbm test-focused TEST_SUITES=cli: 223 passed;
- inherited fresh CODEX_HOME sentinel under strace: 0 sentinel-path syscalls after the fix, identical file hashes and directory inventory;
- bash scripts/check-no-test-skips.sh: passed;
- bash scripts/security-audit.sh: passed with existing review notices only;
- bash scripts/security-vendored.sh: passed (75 files);
- git diff --check: passed;
- DCO check: passed.

Local CI lint was attempted but cppcheck was unavailable; clang-format and clang-tidy are also not installed in this environment. GitHub CI remains the lint authority.

## Coordination

#1149 overlaps the same install-plan fallback test for a separate fixture-lifetime issue. Whichever PR lands second will need to rebase and preserve both intents: free the receipt JSON on every validation-failure path, and explicitly isolate CODEX_HOME while exercising the fallback path.

## Scope

Only tests/test_main.c and tests/test_cli.c change. There is no production behavior or dependency change.
