### PR TITLE
fix(build): mark Nomic ELF blob stack non-executable

### DIFF
--- a/scripts/extract_nomic_vectors.py
+++ b/scripts/extract_nomic_vectors.py
@@ -332,9 +332,12 @@ static inline const int8_t *pretrained_vec_at(int i) {{
 
 
 def write_blob_s(path: str, incbin_path: str):
-    """Write assembler .incbin directive."""
+    """Write the cross-platform assembler .incbin wrapper."""
     with open(path, "w") as f:
-        f.write(f"""/* nomic-embed-code vector blob embedded via assembler. */
+        f.write(f"""/* nomic-embed-code vector blob embedded via assembler.
+ * Cross-platform: macOS (Mach-O) vs Linux (ELF) vs Windows (COFF). */
+
+#if defined(__APPLE__)
     .section __DATA,__const
     .globl _PRETRAINED_VECTOR_BLOB
     .globl _PRETRAINED_VECTOR_BLOB_LEN
@@ -347,6 +350,37 @@ _PRETRAINED_VECTOR_BLOB_END:
     .p2align 2
 _PRETRAINED_VECTOR_BLOB_LEN:
     .long _PRETRAINED_VECTOR_BLOB_END - _PRETRAINED_VECTOR_BLOB
+
+#elif defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW32__)
+    .section .rdata,"dr"
+    .globl PRETRAINED_VECTOR_BLOB
+    .globl PRETRAINED_VECTOR_BLOB_LEN
+    .p2align 4
+PRETRAINED_VECTOR_BLOB:
+    .incbin "{incbin_path}"
+PRETRAINED_VECTOR_BLOB_END:
+
+    .section .rdata,"dr"
+    .p2align 2
+PRETRAINED_VECTOR_BLOB_LEN:
+    .long PRETRAINED_VECTOR_BLOB_END - PRETRAINED_VECTOR_BLOB
+
+#else
+    .section .rodata,"a",@progbits
+    .globl PRETRAINED_VECTOR_BLOB
+    .globl PRETRAINED_VECTOR_BLOB_LEN
+    .p2align 4
+PRETRAINED_VECTOR_BLOB:
+    .incbin "{incbin_path}"
+PRETRAINED_VECTOR_BLOB_END:
+
+    .section .rodata,"a",@progbits
+    .p2align 2
+PRETRAINED_VECTOR_BLOB_LEN:
+    .long PRETRAINED_VECTOR_BLOB_END - PRETRAINED_VECTOR_BLOB
+
+    .section .note.GNU-stack,"",@progbits
+#endif
 """)
     print(f"  {path}: written")
 

--- a/vendored/nomic/code_vectors_blob.S
+++ b/vendored/nomic/code_vectors_blob.S
@@ -42,4 +42,6 @@ PRETRAINED_VECTOR_BLOB_END:
     .p2align 2
 PRETRAINED_VECTOR_BLOB_LEN:
     .long PRETRAINED_VECTOR_BLOB_END - PRETRAINED_VECTOR_BLOB
+
+    .section .note.GNU-stack,"",@progbits
 #endif


### PR DESCRIPTION
## What does this PR do?

The generated Nomic vector blob omitted the ELF .note.GNU-stack section. GNU ld therefore warned that the object implied an executable stack, and the linked binary exposed GNU_STACK RWE.

## Fix

- add an empty, flagless .note.GNU-stack section only in the ELF branch of vendored/nomic/code_vectors_blob.S;
- update write_blob_s() so its generated output exactly reproduces the current cross-platform assembly wrapper plus the ELF-only note.

The generator update is required for this fix to survive regeneration. Before this patch the generator was stale and emitted only the Mach-O form, while the tracked generated artifact already contained Mach-O, COFF, and ELF branches.

## Validation

- base reproduction: GNU ld warning and linked GNU_STACK RWE;
- fixed GCC and Clang objects: empty, flagless .note.GNU-stack;
- fixed linked binaries: GNU_STACK RW;
- GNU and Clang assembly accepted for x86-64 and AArch64;
- generated file: 1,334 bytes and byte-identical to the tracked artifact;
- Mach-O and COFF preprocessed branches: byte-unchanged;
- Python syntax, focused semantic tests 33/33, final production build, DCO, and git diff --check: passed;
- full scripts/test.sh printed every test case as PASS, then exited 2 only for the separate CLI LeakSanitizer fixture issue addressed by #1149.

## Scope

Only scripts/extract_nomic_vectors.py and vendored/nomic/code_vectors_blob.S change. No dependency, API, or runtime behavior changes beyond restoring the non-executable ELF stack declaration.

## Residual validation

Native macOS and Windows assembly and the full lint toolchain were unavailable locally. The unchanged preprocessed platform branches and GitHub CI remain authoritative for those gates.