### PR TITLE
fix: create the first persistent artifact on the incremental path

### DIFF
--- a/src/pipeline/pipeline_incremental.c
+++ b/src/pipeline/pipeline_incremental.c
@@ -1493,10 +1493,6 @@ static int dump_and_persist(cbm_gbuf_t *gbuf, const char *db_path, const char *p
         return rc;
     }
 
-    /* Auto-update artifact if one already exists (persistence was enabled previously) */
-    if (repo_path && cbm_artifact_exists(repo_path)) {
-        cbm_artifact_export(db_path, repo_path, project, CBM_ARTIFACT_FAST);
-    }
     return 0;
 }
 
@@ -2488,7 +2484,9 @@ int cbm_pipeline_run_incremental(cbm_pipeline_t *p, const char *db_path, cbm_fil
         free_mode_skipped(mode_skipped, mode_skipped_count);
         cbm_store_free_file_hashes(stored, stored_count);
         cbm_store_close(store);
-        return 0;
+        /* Same contract as the semantic_manifest_equal no-op above: a run that
+         * changed nothing still owes the first artifact when persistence is on. */
+        return cbm_pipeline_refresh_artifact(p, db_path);
     }
 
 #if defined(CBM_INCREMENTAL_TEST_API) && CBM_INCREMENTAL_TEST_API
@@ -2859,5 +2857,11 @@ int cbm_pipeline_run_incremental(cbm_pipeline_t *p, const char *db_path, cbm_fil
     cbm_gbuf_free(existing);
 
     cbm_log_info("incremental.done", "elapsed_ms", itoa_buf((int)elapsed_ms(t0)));
-    return persist_rc;
+    if (persist_rc != 0) {
+        return persist_rc;
+    }
+    /* Mirrors the full path: publication succeeded, so refresh the artifact.
+     * The helper creates the FIRST one when persistence is on and propagates
+     * an export failure instead of leaving the run looking successful. */
+    return cbm_pipeline_refresh_artifact(p, db_path);
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #434: enabling `persistence=true` did not create the first persistent artifact on the incremental indexing path. `dump_and_persist` in `pipeline_incremental.c` only refreshed an artifact that already existed and never created one on first run, so a `persistence=true` request was silently a no-op until an artifact happened to exist. `git ai stats`-style consumers saw the index reported as successful with no persistent artifact written.

This threads a new `cbm_pipeline_persistence()` accessor into the incremental path (mirroring the existing `cbm_pipeline_repo_path` / `cbm_pipeline_project_name` accessors) so it exports the first artifact with `CBM_ARTIFACT_BEST` when persistence is requested and none exists, matching the full pipeline. Existing artifacts keep refreshing with `CBM_ARTIFACT_FAST`. It covers changed-file, deleted-file, and no-op incremental runs, and it now propagates a failed `cbm_artifact_export` as a run error instead of reporting a successful index when the artifact could not be written.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test`)
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)
