### PR TITLE
fix(cypher): bound UNWIND literal-list buffer to prevent stack overflow

### DIFF
--- a/src/cypher/cypher.c
+++ b/src/cypher/cypher.c
@@ -1836,23 +1836,33 @@ static void parse_unwind_clause(parser_t *p, cbm_query_t *q) {
         advance(p);
         char buf[CBM_SZ_2K] = "[";
         int blen = SKIP_ONE;
+        /* snprintf returns the length it WOULD have written, so a single
+         * oversized token (string literals lex up to CBM_SZ_4K-1) can push
+         * blen past sizeof(buf). Clamp after every write and guard the raw
+         * buf[blen++] stores, mirroring format_collect_list(). */
+        const int cap = (int)sizeof(buf);
         while (!check(p, TOK_RBRACKET) && !check(p, TOK_EOF)) {
-            if (blen > SKIP_ONE) {
+            if (blen > SKIP_ONE && blen < cap - SKIP_ONE) {
                 buf[blen++] = ',';
             }
             if (check(p, TOK_STRING)) {
-                blen += snprintf(buf + blen, sizeof(buf) - blen, "\"%s\"", peek(p)->text);
+                blen += snprintf(buf + blen, (size_t)(cap - blen), "\"%s\"", peek(p)->text);
                 advance(p);
             } else if (check(p, TOK_NUMBER)) {
-                blen += snprintf(buf + blen, sizeof(buf) - blen, "%s", peek(p)->text);
+                blen += snprintf(buf + blen, (size_t)(cap - blen), "%s", peek(p)->text);
                 advance(p);
             } else {
                 advance(p);
             }
+            if (blen >= cap) {
+                blen = cap - SKIP_ONE;
+            }
             match(p, TOK_COMMA);
         }
         expect(p, TOK_RBRACKET);
-        buf[blen++] = ']';
+        if (blen < cap - SKIP_ONE) {
+            buf[blen++] = ']';
+        }
         buf[blen] = '\0';
         q->unwind_expr = heap_strdup(buf);
     } else if (check(p, TOK_IDENT)) {

--- a/tests/test_cypher.c
+++ b/tests/test_cypher.c
@@ -2762,6 +2762,51 @@ TEST(cypher_parse_unwind_var) {
     PASS();
 }
 
+/* Regression: an UNWIND literal list whose element is longer than the 2KB
+ * assembly buffer used to overflow the stack. snprintf reports the length it
+ * WOULD have written, so blen ran past sizeof(buf) and the trailing
+ * buf[blen++]=']' / buf[blen]='\0' wrote out of bounds (ASan: stack-buffer-
+ * overflow). The query text is agent-controlled via the MCP query tool. */
+TEST(cypher_parse_unwind_oversized_literal_no_overflow) {
+    char query[4096];
+    char big[3000];
+    memset(big, 'a', sizeof(big) - 1);
+    big[sizeof(big) - 1] = '\0';
+    snprintf(query, sizeof(query), "UNWIND [\"%s\"] AS x MATCH (f) RETURN f.name", big);
+
+    cbm_query_t *q = NULL;
+    char *err = NULL;
+    int rc = cbm_cypher_parse(query, &q, &err);
+    /* Must not crash and must produce a NUL-terminated, in-bounds expression. */
+    ASSERT_EQ(rc, 0);
+    ASSERT_NOT_NULL(q->unwind_expr);
+    ASSERT_STR_EQ(q->unwind_alias, "x");
+    cbm_query_free(q);
+    PASS();
+}
+
+/* Regression: many oversized elements accumulate blen well past the buffer,
+ * which also underflowed the (size_t)(cap - blen) length passed to snprintf. */
+TEST(cypher_parse_unwind_many_elements_no_overflow) {
+    /* 200 elements (~20 chars each) accumulate well past the 2KB assembly
+     * buffer, which also underflowed the (size_t)(cap - blen) length. */
+    char query[8192];
+    int off = snprintf(query, sizeof(query), "UNWIND [");
+    for (int i = 0; i < 200; i++) {
+        off += snprintf(query + off, sizeof(query) - (size_t)off, "%s\"element_value_%d\"",
+                        i ? "," : "", i);
+    }
+    snprintf(query + off, sizeof(query) - (size_t)off, "] AS x MATCH (f) RETURN f.name");
+
+    cbm_query_t *q = NULL;
+    char *err = NULL;
+    int rc = cbm_cypher_parse(query, &q, &err);
+    ASSERT_EQ(rc, 0);
+    ASSERT_NOT_NULL(q->unwind_expr);
+    cbm_query_free(q);
+    PASS();
+}
+
 /* ── Issue #389 group: Cypher feature reproductions ─────────────────
  * Each asserts the CORRECT behavior; a failure reproduces the bug. */
 
@@ -3218,6 +3263,8 @@ SUITE(cypher) {
     /* Phase 9: UNWIND */
     RUN_TEST(cypher_parse_unwind);
     RUN_TEST(cypher_parse_unwind_var);
+    RUN_TEST(cypher_parse_unwind_oversized_literal_no_overflow);
+    RUN_TEST(cypher_parse_unwind_many_elements_no_overflow);
     RUN_TEST(cypher_wide_return_projection_bounded);
     /* Composite property projection (arrays/objects, escaped quotes) */
     RUN_TEST(cypher_exec_prop_array_with_internal_commas);


### PR DESCRIPTION
## What does this PR do?

Fixes a stack out-of-bounds write (CWE-787) in the Cypher `UNWIND` literal-list
parser (`parse_unwind_clause`, `src/cypher/cypher.c`).

When assembling a literal list into the fixed 2 KB stack buffer
`char buf[CBM_SZ_2K]`, the code advances the write cursor by the return value of
`snprintf`:

```c
blen += snprintf(buf + blen, sizeof(buf) - blen, "\"%s\"", peek(p)->text);
```

`snprintf` returns the number of bytes it *would* have written, so a single
oversized element pushes `blen` past `sizeof(buf)`. The trailing writes are then
unguarded:

```c
buf[blen++] = ']';
buf[blen] = '\0';
```

and on multi-element lists the next iteration's `sizeof(buf) - blen` underflows
to a huge `size_t`, letting `snprintf` write far past the buffer.

The query string is agent-controlled through the MCP `query` tool, and Cypher
string literals lex up to `CBM_SZ_4K - 1` (4095) chars with no length cap before
parsing, so `UNWIND ["<~3000 chars>"] AS x MATCH (n) RETURN n` reaches the
overflow.

**Reproduced first (UBSan, before the fix):**

```
src/cypher/cypher.c:1855:12: runtime error: index 3002 out of bounds for type 'char [2048]'
src/cypher/cypher.c:1855:21: runtime error: store to address 0x... with insufficient space for an object of type 'char'
src/cypher/cypher.c:1856:12: runtime error: index 3003 out of bounds for type 'char [2048]'
```

**The fix** clamps `blen` after every `snprintf` and guards the raw
`buf[blen++]` stores — the same pattern already used by the sibling function
`format_collect_list()`, which builds an identical JSON array into a
`CBM_SZ_2K` buffer and was already hardened. After the fix all 161 cypher tests
pass with zero sanitizer errors.

Two regression tests are added (both fail under UBSan without the fix):
- `cypher_parse_unwind_oversized_literal_no_overflow` — single oversized element
- `cypher_parse_unwind_many_elements_no_overflow` — many elements accumulating past 2 KB

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test`)
- [ ] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)
