### PR TITLE
fix(store): clamp ADR render cursor to prevent stack overflow

### DIFF
--- a/src/store/store.c
+++ b/src/store/store.c
@@ -7002,12 +7002,33 @@ cbm_adr_sections_t cbm_adr_parse_sections(const char *content) {
     return result;
 }
 
-/* Append a section to the render buffer. */
+/* Append a section to the render buffer.
+ *
+ * snprintf returns the length it WOULD have written, so a section larger than
+ * the space left would otherwise push pos past buf_sz; the next call would then
+ * compute a wrapped (huge) remaining size from (buf_sz - pos) and write out of
+ * bounds. Clamp pos into [0, buf_sz-1] after every write so each snprintf gets
+ * a positive size and the returned cursor never escapes the buffer. */
 static int adr_render_section(char *buf, int buf_sz, int pos, const char *key, const char *value) {
-    if (pos > 0) {
-        pos += snprintf(buf + pos, buf_sz - pos, "\n\n");
+    if (buf_sz <= 0) {
+        return 0;
     }
-    pos += snprintf(buf + pos, buf_sz - pos, "## %s\n%s", key, value);
+    if (pos < 0) {
+        pos = 0;
+    }
+    if (pos >= buf_sz) {
+        return buf_sz - SKIP_ONE;
+    }
+    if (pos > 0) {
+        pos += snprintf(buf + pos, (size_t)(buf_sz - pos), "\n\n");
+        if (pos >= buf_sz) {
+            return buf_sz - SKIP_ONE;
+        }
+    }
+    pos += snprintf(buf + pos, (size_t)(buf_sz - pos), "## %s\n%s", key, value);
+    if (pos >= buf_sz) {
+        pos = buf_sz - SKIP_ONE;
+    }
     return pos;
 }
 

--- a/tests/test_store_arch.c
+++ b/tests/test_store_arch.c
@@ -741,6 +741,52 @@ TEST(adr_render_empty) {
     PASS();
 }
 
+/* Helper: allocate a NUL-terminated buffer of `len` 'x' characters. */
+static char *adr_test_fill(int len) {
+    char *s = malloc((size_t)len + 1);
+    if (s) {
+        memset(s, 'x', (size_t)len);
+        s[len] = '\0';
+    }
+    return s;
+}
+
+/* Regression: sections whose combined size exceeds the fixed render buffer used
+ * to overflow it. adr_render_section advanced pos by snprintf's return value
+ * (the length it WOULD have written); once pos passed buf_sz the next section
+ * computed a wrapped (huge) remaining size from (buf_sz - pos) and wrote past
+ * the stack buffer (ASan: stack-buffer-overflow WRITE).
+ *
+ * The render buffer is ST_MAX_DEGREE*ST_GROWTH = 16384. Sizes below drive the
+ * cursor to exactly buf_sz+8 after section "B" (a truncating write that stays
+ * in bounds), so section "C" performs the first out-of-bounds write right at
+ * the buffer's tail — into ASan's redzone, where it is reliably caught.
+ * Non-canonical keys render in alphabetical order (A, B, C). */
+TEST(adr_render_oversized_sections_no_overflow) {
+    enum { ADR_RENDER_BUFSZ = 16384 };
+    cbm_adr_sections_t sec = {.count = 3};
+    /* A is first: header "## A\n" (5) + value -> pos = 16000. */
+    sec.keys[0] = strdup("A");
+    sec.values[0] = adr_test_fill(15995);
+    /* B: header "\n\n## B\n" (7) + value -> intended pos = 16000+7+385 = 16392
+     * (= buf_sz + 8); the write itself truncates safely in bounds. */
+    sec.keys[1] = strdup("B");
+    sec.values[1] = adr_test_fill(385);
+    /* C: rendered with pos = 16392 > buf_sz -> "\n\n" written at buf+16392. */
+    sec.keys[2] = strdup("C");
+    sec.values[2] = strdup("z");
+    for (int i = 0; i < 3; i++) {
+        ASSERT_NOT_NULL(sec.values[i]);
+    }
+    char *rendered = cbm_adr_render(&sec);
+    /* Must not crash; result must be NUL-terminated within the render buffer. */
+    ASSERT_NOT_NULL(rendered);
+    ASSERT_TRUE(strlen(rendered) < ADR_RENDER_BUFSZ);
+    free(rendered);
+    cbm_adr_sections_free(&sec);
+    PASS();
+}
+
 TEST(adr_parse_render_roundtrip) {
     const char *original =
         "## PURPOSE\nTest project\n\n## STACK\n- Go: speed\n- SQLite: embedded\n\n"
@@ -1393,6 +1439,7 @@ SUITE(store_arch) {
     RUN_TEST(adr_render_all_sections);
     RUN_TEST(adr_render_non_canonical);
     RUN_TEST(adr_render_empty);
+    RUN_TEST(adr_render_oversized_sections_no_overflow);
     RUN_TEST(adr_parse_render_roundtrip);
     RUN_TEST(adr_update_sections);
     RUN_TEST(adr_update_overflow);


### PR DESCRIPTION
## What does this PR do?

Fixes a stack out-of-bounds write (CWE-787) in `adr_render_section`
(`src/store/store.c`), the helper `cbm_adr_render` uses to concatenate ADR
sections into a fixed 16 KB stack buffer (`buf[ST_MAX_DEGREE * ST_GROWTH]`).

The cursor was advanced by the return value of `snprintf`:

```c
pos += snprintf(buf + pos, buf_sz - pos, "\n\n");
pos += snprintf(buf + pos, buf_sz - pos, "## %s\n%s", key, value);
```

`snprintf` returns the number of bytes it *would* have written, so once the
accumulated sections exceed `buf_sz`, `pos` moves past the end. On the next
section `buf + pos` points past the buffer and `buf_sz - pos` (an `int`
subtraction) goes negative, converting to a huge `size_t` — so `snprintf`
writes out of bounds.

The fix clamps `pos` into `[0, buf_sz - 1]` after every write, so each
`snprintf` receives a positive size and the returned cursor never escapes the
buffer. This mirrors the clamping already done by `http_appendf` in
`src/ui/http_server.c` and the sibling accumulators in `store.c`
(`search_build_exclude_labels`, `bfs_build_types_clause`).

**Reproduced first (ASan, before the fix):**

```
==ERROR: AddressSanitizer: stack-buffer-overflow ... WRITE of size 3
    #3 adr_render_section src/store/store.c:7008
    #4 cbm_adr_render     src/store/store.c:7057
    #5 test_adr_render_oversized_sections_no_overflow tests/test_store_arch.c
SUMMARY: AddressSanitizer: stack-buffer-overflow ... in vsnprintf
```

After the fix the full `store_arch` suite (53 tests) passes with no sanitizer
errors.

Adds a regression test `adr_render_oversized_sections_no_overflow` that sizes
three sections so the cursor lands exactly `buf_sz + 8` after the second
section — the third section then performs the first out-of-bounds write right
at the buffer tail (ASan redzone), making the failure deterministic.

### Note on scope

`cbm_adr_render` / `cbm_store_adr_update_sections` are exported in `store.h`
and exercised by the test suite, but currently have no production caller — the
`manage_adr` MCP tool and the UI `/api/adr` endpoint both persist raw content
via `cbm_store_adr_store`. So this is a latent defect in exported API rather
than a live remote overflow; the fix hardens the renderer before anything
wires up the section-merge path.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test`)
- [ ] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)
