### PR TITLE
ci,test: keep a spaced SANITIZE value one make argument end to end

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -323,7 +323,7 @@ jobs:
           export TEMP="$(cygpath -m "$CBM_CI_TEMP_ROOT")"
           export TMP="$TEMP"
           export TMPDIR="$(cygpath -u "$CBM_CI_TEMP_ROOT")"
-          scripts/test.sh CC=clang CXX=clang++ ${{ matrix.os == 'windows-11-arm' && 'SANITIZE=-fsanitize=undefined -fsanitize-trap=undefined -fstack-protector-strong -fno-omit-frame-pointer' || '' }}
+          scripts/test.sh CC=clang CXX=clang++ ${{ matrix.os == 'windows-11-arm' && '"SANITIZE=-fsanitize=undefined -fsanitize-trap=undefined -fstack-protector-strong -fno-omit-frame-pointer"' || '' }}
         env:
           CBM_TEST_SHARD: ${{ matrix.shard }}
           CBM_TEST_LEG: ${{ matrix.os }}-${{ matrix.msystem }}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -43,15 +43,19 @@ source "$ROOT/scripts/path-safety.sh"
 # Forward CC/CXX and collect make-passthrough args. BUILD_DIR is honored for
 # the explicit target path below so containerized legs can build in their own
 # directory instead of clobbering the host's native build/c artifacts.
-MAKE_ARGS=""
+# MAKE_ARGS is an ARRAY so a VAR=VAL whose value contains spaces (the
+# windows-11-arm leg passes SANITIZE with four flags) survives as ONE make
+# argument. The old string accumulation re-split it at every expansion and
+# make swallowed the second flag's leading -f as its makefile option.
+MAKE_ARGS=()
 BUILD_DIR="build/c"
 for arg in "$@"; do
     case "$arg" in
         CC=*|CXX=*) export "${arg}" ;;
         --arch|--arch=*) ;; # already handled
         arm64|x86_64) ;; # already handled
-        BUILD_DIR=*) BUILD_DIR="${arg#BUILD_DIR=}"; MAKE_ARGS="$MAKE_ARGS $arg" ;;
-        *=*) MAKE_ARGS="$MAKE_ARGS $arg" ;; # forward any VAR=VAL to make
+        BUILD_DIR=*) BUILD_DIR="${arg#BUILD_DIR=}"; MAKE_ARGS+=("$arg") ;;
+        *=*) MAKE_ARGS+=("$arg") ;; # forward any VAR=VAL to make
     esac
 done
 
@@ -92,11 +96,11 @@ BUILD_DIR="$BUILD_DIR" scripts/clean.sh
 # the suite set is enumerated from the runner itself and union-guarded, and
 # pass/fail/skip totals aggregate to the same numbers as the sequential run).
 # CBM_TEST_SEQUENTIAL=1 restores the single-process runner.
-make -j"$NPROC" -f Makefile.cbm "$BUILD_DIR/test-runner" $MAKE_ARGS
+make -j"$NPROC" -f Makefile.cbm "$BUILD_DIR/test-runner" ${MAKE_ARGS[@]+"${MAKE_ARGS[@]}"}
 if [ "${CBM_TEST_SEQUENTIAL:-0}" = "1" ]; then
-    make -f Makefile.cbm test $MAKE_ARGS
+    make -f Makefile.cbm test ${MAKE_ARGS[@]+"${MAKE_ARGS[@]}"}
 else
-    make -f Makefile.cbm test-par $MAKE_ARGS
+    make -f Makefile.cbm test-par ${MAKE_ARGS[@]+"${MAKE_ARGS[@]}"}
 fi
 
 # Step 4: C++ large-TU index-hang regression guard (#410). Runs the PROD binary
@@ -111,7 +115,7 @@ fi
 # Step 5: Parent-death watchdog regression (#406/#407). Builds the prod stdio
 # binary and verifies it self-exits when its launching parent is killed.
 echo "=== Step 5: parent-death watchdog regression (#406/#407) ==="
-make -j"$NPROC" -f Makefile.cbm cbm $MAKE_ARGS
+make -j"$NPROC" -f Makefile.cbm cbm ${MAKE_ARGS[@]+"${MAKE_ARGS[@]}"}
 bash "$ROOT/tests/test_parent_watchdog.sh"
 
 # Step 5b: worker-mode parent-death watchdog (#845). A supervised index worker


### PR DESCRIPTION
The windows-11-arm leg's first execution (broad matrix, release dry run) died before any test ran: the trap-UBSan `SANITIZE` value passed unquoted through the workflow ternary, so `-fsanitize-trap=undefined` arrived as its own word and make consumed the leading `-f` as its makefile flag.

- The workflow quotes the ternary value so `test.sh` receives one argument.
- `test.sh` forwards make arguments through an array instead of a re-split string, so a `VAR=VAL` whose value contains spaces survives every boundary (empty-array expansion kept bash-3.2-safe for the macOS runners under `set -u`).

Verified: argument-parse proof (argc=1 with the four-flag value) and a full macOS suite run through the changed plumbing — 6776 passed, 0 failed, identical totals. The windows-11-arm leg itself is broad-matrix-only; the follow-up release dry run after this merges is its validation.