### PR TITLE
fix(win): compile cleanly with MinGW GCC

### DIFF
--- a/src/daemon/ipc.c
+++ b/src/daemon/ipc.c
@@ -3554,13 +3554,13 @@ static void *win_token_user_query(win_security_t *security, HANDLE token, PSID *
     return buffer;
 }
 
-#define RESOLVE_ADVAPI_MEMBER(context, member, type, symbol)                   \
-    do {                                                                       \
-        (context)->member = (type)GetProcAddress((context)->advapi, (symbol)); \
-        if (!(context)->member) {                                              \
-            win_security_destroy((context));                                   \
-            return false;                                                      \
-        }                                                                      \
+#define RESOLVE_ADVAPI_MEMBER(context, member, type, symbol)                                   \
+    do {                                                                                       \
+        (context)->member = (type)(void (*)(void))GetProcAddress((context)->advapi, (symbol)); \
+        if (!(context)->member) {                                                              \
+            win_security_destroy((context));                                                   \
+            return false;                                                                      \
+        }                                                                                      \
     } while (0)
 
 static bool win_security_init(win_security_t *security) {
@@ -4619,7 +4619,8 @@ static bool win_generation_nonce(uint8_t nonce[CBM_DAEMON_IPC_WINDOWS_NONCE_SIZE
     enum { WIN_BCRYPT_USE_SYSTEM_PREFERRED_RNG = 0x00000002 };
     HMODULE bcrypt = LoadLibraryW(L"bcrypt.dll");
     bcrypt_gen_random_fn generate =
-        bcrypt ? (bcrypt_gen_random_fn)GetProcAddress(bcrypt, "BCryptGenRandom") : NULL;
+        bcrypt ? (bcrypt_gen_random_fn)(void (*)(void))GetProcAddress(bcrypt, "BCryptGenRandom")
+               : NULL;
     LONG status = generate ? generate(NULL, nonce, CBM_DAEMON_IPC_WINDOWS_NONCE_SIZE,
                                       WIN_BCRYPT_USE_SYSTEM_PREFERRED_RNG)
                            : (LONG)-1;
@@ -5174,8 +5175,8 @@ static bool win_pipe_client_is_current_user(HANDLE pipe) {
      * has completed a read, which accept must not require. */
     HMODULE kernel = GetModuleHandleW(L"kernel32.dll");
     get_named_pipe_server_process_id_fn get_client_pid =
-        kernel ? (get_named_pipe_server_process_id_fn)GetProcAddress(kernel,
-                                                                     "GetNamedPipeClientProcessId")
+        kernel ? (get_named_pipe_server_process_id_fn)(void (*)(void))GetProcAddress(
+                     kernel, "GetNamedPipeClientProcessId")
                : NULL;
     if (!get_client_pid) {
         cbm_log_warn("daemon.accept.client_identity", "step", "pid_fn_missing");
@@ -5319,8 +5320,8 @@ int cbm_daemon_ipc_accept(cbm_daemon_ipc_listener_t *listener, uint32_t timeout_
 static bool win_pipe_server_is_current_user(HANDLE pipe) {
     HMODULE kernel = GetModuleHandleW(L"kernel32.dll");
     get_named_pipe_server_process_id_fn get_server_pid =
-        kernel ? (get_named_pipe_server_process_id_fn)GetProcAddress(kernel,
-                                                                     "GetNamedPipeServerProcessId")
+        kernel ? (get_named_pipe_server_process_id_fn)(void (*)(void))GetProcAddress(
+                     kernel, "GetNamedPipeServerProcessId")
                : NULL;
     ULONG process_id = 0;
     if (!get_server_pid) {
@@ -5612,7 +5613,7 @@ uint64_t cbm_daemon_ipc_connection_peer_pid(const cbm_daemon_ipc_connection_t *c
     ULONG process_id = 0;
     if (connection->role == CBM_DAEMON_IPC_PIPE_ROLE_ACCEPTED_SERVER) {
         get_named_pipe_client_process_id_fn get_client_pid =
-            kernel ? (get_named_pipe_client_process_id_fn)GetProcAddress(
+            kernel ? (get_named_pipe_client_process_id_fn)(void (*)(void))GetProcAddress(
                          kernel, "GetNamedPipeClientProcessId")
                    : NULL;
         if (!get_client_pid || !get_client_pid(connection->handle, &process_id)) {
@@ -5620,7 +5621,7 @@ uint64_t cbm_daemon_ipc_connection_peer_pid(const cbm_daemon_ipc_connection_t *c
         }
     } else if (connection->role == CBM_DAEMON_IPC_PIPE_ROLE_CONNECTED_CLIENT) {
         get_named_pipe_server_process_id_fn get_server_pid =
-            kernel ? (get_named_pipe_server_process_id_fn)GetProcAddress(
+            kernel ? (get_named_pipe_server_process_id_fn)(void (*)(void))GetProcAddress(
                          kernel, "GetNamedPipeServerProcessId")
                    : NULL;
         if (!get_server_pid || !get_server_pid(connection->handle, &process_id)) {

--- a/src/foundation/compat_fs.c
+++ b/src/foundation/compat_fs.c
@@ -883,7 +883,9 @@ int cbm_canonical_path(const char *path, char *out, size_t out_sz) {
     }
     DWORD needed =
         GetFinalPathNameByHandleW(handle, NULL, 0, FILE_NAME_NORMALIZED | VOLUME_NAME_DOS);
-    if (needed == 0 || needed == MAXDWORD || (size_t)needed > SIZE_MAX / sizeof(wchar_t) - 1) {
+    /* MAXDWORD keeps the +1 below safe; calloc rejects an unrepresentable
+     * capacity * sizeof(wchar_t) allocation on narrower size_t targets. */
+    if (needed == 0 || needed == MAXDWORD) {
         (void)CloseHandle(handle);
         return 0;
     }

--- a/src/foundation/private_file_lock.c
+++ b/src/foundation/private_file_lock.c
@@ -735,13 +735,13 @@ static void *private_win_token_user_query(private_win_security_t *security, HAND
     return buffer;
 }
 
-#define PRIVATE_RESOLVE_ADVAPI(context, member, type, symbol)                  \
-    do {                                                                       \
-        (context)->member = (type)GetProcAddress((context)->advapi, (symbol)); \
-        if (!(context)->member) {                                              \
-            private_win_security_destroy((context));                           \
-            return false;                                                      \
-        }                                                                      \
+#define PRIVATE_RESOLVE_ADVAPI(context, member, type, symbol)                                  \
+    do {                                                                                       \
+        (context)->member = (type)(void (*)(void))GetProcAddress((context)->advapi, (symbol)); \
+        if (!(context)->member) {                                                              \
+            private_win_security_destroy((context));                                           \
+            return false;                                                                      \
+        }                                                                                      \
     } while (0)
 
 static bool private_win_security_init(private_win_security_t *security) {

--- a/tests/test_daemon_ipc.c
+++ b/tests/test_daemon_ipc.c
@@ -847,10 +847,12 @@ TEST(daemon_ipc_windows_legacy_bridge_covers_handoff_and_lifetime) {
     typedef BOOL(WINAPI * ipc_test_set_dacl_fn)(PSECURITY_DESCRIPTOR, BOOL, PACL, BOOL);
     HMODULE advapi = LoadLibraryW(L"advapi32.dll");
     ipc_test_initialize_sd_fn initialize_sd =
-        advapi ? (ipc_test_initialize_sd_fn)GetProcAddress(advapi, "InitializeSecurityDescriptor")
+        advapi ? (ipc_test_initialize_sd_fn)(void (*)(void))GetProcAddress(
+                     advapi, "InitializeSecurityDescriptor")
                : NULL;
-    ipc_test_set_dacl_fn set_dacl =
-        advapi ? (ipc_test_set_dacl_fn)GetProcAddress(advapi, "SetSecurityDescriptorDacl") : NULL;
+    ipc_test_set_dacl_fn set_dacl = advapi ? (ipc_test_set_dacl_fn)(void (*)(void))GetProcAddress(
+                                                 advapi, "SetSecurityDescriptorDacl")
+                                           : NULL;
     SECURITY_DESCRIPTOR unsafe_descriptor;
     bool unsafe_descriptor_ok = initialize_sd && set_dacl &&
                                 initialize_sd(&unsafe_descriptor, SECURITY_DESCRIPTOR_REVISION) &&


### PR DESCRIPTION
Fixes #1225

## What does this PR do?

Makes the Windows sources compile cleanly with MinGW GCC when warnings are treated as errors.

- Removes a redundant `DWORD` range comparison that GCC reports as always false on 64-bit Windows. The existing `MAXDWORD` guard keeps the subsequent `+1` safe, while `calloc` retains allocation-overflow handling.
- Converts dynamically resolved Windows functions through GCC's generic `void (*)(void)` function-pointer type before assigning their concrete signatures.
- Applies the same conversion to the Windows IPC regression test helpers.

## Root cause

MinGW defines `FARPROC` as an unspecified-parameter function pointer. Direct casts from it to concrete Win32 function signatures trigger `-Wcast-function-type`. Separately, a `DWORD` can never exceed the 64-bit `SIZE_MAX`-based bound, so `-Wtype-limits` rejects that comparison under `-Werror`.

## Verification

- Unmodified `origin/main` reproduced both warning classes with `x86_64-w64-mingw32-gcc 16.1.0 -Wall -Wextra -Werror`.
- The affected production translation units compile cleanly with the same MinGW GCC flags after the fix.
- The Windows IPC test translation unit compiles cleanly for the affected warning class; `-Wno-stringop-overflow` was used only to isolate pre-existing unrelated diagnostics in that file.
- `make -f Makefile.cbm test` — 6776 passed, 4 skipped.
- `make -f Makefile.cbm lint-ci` — passed.
- `scripts/check-dco.sh origin/main..HEAD` — passed.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test`)
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)
