### PR TITLE
fix: default indexing to crash-free sequential extraction

### DIFF
--- a/src/pipeline/pipeline.c
+++ b/src/pipeline/pipeline.c
@@ -401,7 +401,19 @@ static int effective_worker_count(bool initial) {
     if (st && st[0] == '1') {
         return 1;
     }
-    return cbm_default_worker_count(initial);
+    /* Keep the explicit override available for parallel regression tests and
+     * deliberate diagnostics. It is opt-in; the production default below stays
+     * on the crash-free sequential path. */
+    if (getenv("CBM_WORKERS")) {
+        return cbm_default_worker_count(initial);
+    }
+    (void)initial;
+    /* Parallel extraction currently corrupts heap state on real mixed-language
+     * repositories (reproduced with two or more workers on Serena). Keep the
+     * production indexing path deterministic and crash-free until the shared
+     * parser/allocator race is fixed. Correctness is more important than the
+     * parallel speedup. */
+    return 1;
 }
 
 /* Resolve the DB path for this pipeline. Caller must free(). */

--- a/tests/test_pipeline.c
+++ b/tests/test_pipeline.c
@@ -7192,6 +7192,9 @@ TEST(pipeline_backpressure_futile_nap_disengages) {
     ASSERT_TRUE(cbm_mem_over_budget());
 
     cbm_pp_bp_nap_cycles_reset();
+    char *old_workers = getenv("CBM_WORKERS");
+    char *saved_workers = old_workers ? strdup(old_workers) : NULL;
+    cbm_setenv("CBM_WORKERS", "4", 1);
     char db_path[512];
     snprintf(db_path, sizeof(db_path), "%s/backpressure.db", g_tmpdir);
     cbm_pipeline_t *p = cbm_pipeline_new(g_tmpdir, db_path, CBM_MODE_FULL);
@@ -7201,6 +7204,12 @@ TEST(pipeline_backpressure_futile_nap_disengages) {
 
     /* Restore the caller-visible budget BEFORE asserting. */
     cbm_mem_set_budget_for_tests(saved_budget);
+    if (saved_workers) {
+        cbm_setenv("CBM_WORKERS", saved_workers, 1);
+        free(saved_workers);
+    } else {
+        cbm_unsetenv("CBM_WORKERS");
+    }
     cbm_pipeline_free(p);
     teardown_test_repo();
 


### PR DESCRIPTION
## Summary

- default production indexing to the deterministic sequential extraction path
- retain `CBM_WORKERS` as an explicit opt-in for parallel regression tests and diagnostics
- make the back-pressure regression test explicitly request parallel extraction

## Why

Parallel extraction corrupts heap state on a real mixed-language repository. The failure was reproduced on Serena with the default worker count and with `CBM_WORKERS=2` and `CBM_WORKERS=4`; glibc aborted with allocator-corruption errors. The same 770-file workload completes cleanly with one worker.

This is a stability containment, not a claim that the underlying shared parser/allocator race has been repaired. It trades default indexing throughput for correctness while preserving an explicit route for debugging and testing the parallel implementation.

## Verification

- sanitizer `sqlite_writer`: 12 passed
- sanitizer `mcp`: passed
- sanitizer `pipeline`: 226 passed
- `make -f Makefile.cbm lint-format CLANG_FORMAT=clang-format`
- `git diff --check`
- clean upstream production build: `make -f Makefile.cbm cbm`
- Serena clean-cache index: 10,171 nodes, 50,959 edges, zero skipped files
