### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/io-github-deusdata-codebase-memory-mcp)](https://mcpindex.ai/server/io-github-deusdata-codebase-memory-mcp)
+
 # codebase-memory-mcp
 
 [![GitHub Release](https://img.shields.io/github/v/release/DeusData/codebase-memory-mcp?style=flat&color=blue)](https://github.com/DeusData/codebase-memory-mcp/releases/latest)


### PR DESCRIPTION
Hey, Codebase Memory's registered MCP server came back clean on mcpindex's semantic screen (injection/manipulation check on the tool description, nothing deeper). Added the badge to your README in case it's useful. Advisory signal, not a security certification. Feel free to close if not a fit.