### PR TITLE
fix(installer): stop PS 5.1 stderr wrapping from aborting version probes

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -262,7 +262,17 @@ if (($launcherItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -o
 # Verify the complete launcher/payload path before it asks all coordinated CBM
 # processes to stop.
 try {
-    $candidateVersion = & $DownloadedLauncher --version 2>&1
+    # Windows PowerShell 5.1 wraps redirected native stderr in ErrorRecords, so
+    # under $ErrorActionPreference = "Stop" a healthy candidate that prints any
+    # warning would abort here. Probe with EAP relaxed; failure detection stays
+    # on $LASTEXITCODE.
+    $PrevErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $candidateVersion = & $DownloadedLauncher --version 2>&1
+    } finally {
+        $ErrorActionPreference = $PrevErrorActionPreference
+    }
     if ($LASTEXITCODE -ne 0) { throw "candidate exited with $LASTEXITCODE" }
     Write-Host "Verified candidate: $candidateVersion"
 } catch {
@@ -285,7 +295,14 @@ if ($LASTEXITCODE -ne 0) {
 
 # Verify
 try {
-    $ver = & $Dest --version 2>&1
+    # Same PS 5.1 stderr-wrapping hazard as the candidate probe above.
+    $PrevErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $ver = & $Dest --version 2>&1
+    } finally {
+        $ErrorActionPreference = $PrevErrorActionPreference
+    }
     if ($LASTEXITCODE -ne 0) { throw "installed binary exited with $LASTEXITCODE" }
     Write-Host "Installed: $ver"
 } catch {


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows PowerShell 5.1 failure mode in `install.ps1`: the script sets `$ErrorActionPreference = "Stop"` globally, and PS 5.1 (the default `powershell.exe` the README instructs users to run) wraps redirected native stderr in ErrorRecords. The two `--version 2>&1` probes (candidate at ~L265, installed binary at ~L288) therefore abort the whole install for any healthy binary that prints a single warning line to stderr while exiting 0 — reporting `error: downloaded binary failed to run`.

The fix relaxes EAP to `Continue` only around the two native probe calls, restoring it in a `finally` block. Failure detection is unchanged: it stays on `$LASTEXITCODE`.

**Reproduction** (PS 5.1.26100.8875, `powershell.exe -File`): stub binary printing a version to stdout + one warning to stderr, exit 0 → previous pattern aborts with the stderr text as the exception; new pattern captures the version output and still detects a nonzero exit (tested with exit 3). EAP is restored to `Stop` afterwards.

The literal invariants checked by `tests/test_windows_bundle_contract.sh` (`& $DownloadedLauncher --version`, launcher-only invocation) are preserved — that contract test passes locally.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Tests pass locally (`make -f Makefile.cbm test`) — not run: no C toolchain on this machine; the change touches only `install.ps1`. `tests/test_windows_bundle_contract.sh` (the suite that asserts installer invariants) passes locally.
- [x] Lint passes (`make -f Makefile.cbm lint-ci`) — C linters not applicable to this script-only change; `install.ps1` parses clean (PSParser, 0 errors).
- [x] New behavior is covered by a test (reproduce-first for bug fixes) — reproduced first with a stderr-writing stub as described above; the existing bundle contract test still guards the probe invariants. Happy to add a harness test if you point me at the preferred place for installer regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)