### PR TITLE
fix(install): accept flat Windows release archives without payload wrapper (#1257)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -220,12 +220,21 @@ try {
             }
             $archiveCounts[$entryName] = $archiveCounts[$entryName] + 1
         }
-        foreach ($archiveName in $WindowsArchiveNames) {
+        $RequiredArchiveNames = @(
+            $BinName,
+            "LICENSE",
+            "install.ps1",
+            "THIRD_PARTY_NOTICES.md"
+        )
+        foreach ($archiveName in $RequiredArchiveNames) {
             if ($archiveCounts[$archiveName] -ne 1) {
                 throw "archive must contain exactly one $archiveName"
             }
         }
-        if ($seen.Count -ne $WindowsArchiveNames.Count) {
+        if ($archiveCounts[$PayloadName] -gt 1) {
+            throw "archive contains duplicate $PayloadName"
+        }
+        if ($seen.Count -lt $RequiredArchiveNames.Count -or $seen.Count -gt $WindowsArchiveNames.Count) {
             throw "archive does not match the exact Windows release allowlist"
         }
     } finally {
@@ -244,6 +253,10 @@ Expand-Archive -Path "$TmpDir\$Archive" -DestinationPath $TmpDir -Force
 
 $DownloadedLauncher = Join-Path $TmpDir $BinName
 $DownloadedPayload = Join-Path $TmpDir $PayloadName
+if (-not (Test-Path -LiteralPath $DownloadedPayload -PathType Leaf) -and
+    (Test-Path -LiteralPath $DownloadedLauncher -PathType Leaf)) {
+    Copy-Item -LiteralPath $DownloadedLauncher -Destination $DownloadedPayload
+}
 if (-not (Test-Path -LiteralPath $DownloadedLauncher -PathType Leaf) -or
     -not (Test-Path -LiteralPath $DownloadedPayload -PathType Leaf)) {
     Write-Host "error: launcher or payload not found after extraction" -ForegroundColor Red

--- a/tests/test_windows_bundle_contract.sh
+++ b/tests/test_windows_bundle_contract.sh
@@ -367,7 +367,7 @@ require(
 # attacker-controlled sixth member.
 exact_archive_guards = {
     "install.ps1": (
-        "$seen.Count -ne $WindowsArchiveNames.Count",
+        "$seen.Count -gt $WindowsArchiveNames.Count",
         '"LICENSE"',
         '"install.ps1"',
         "THIRD_PARTY_NOTICES.md",


### PR DESCRIPTION
Fixes #1257

### Problem
install.ps1's archive namespace check strictly required codebase-memory-mcp.payload.exe to exist as a separate entry in the release zip. In release builds where codebase-memory-mcp.exe is packaged as a flat standalone binary without a separate *.payload.exe entry (such as the v0.9.0 windows-arm64 and windows-amd64 UI archives), install.ps1 aborted with:
\rror: unsafe or incomplete release archive: archive must contain exactly one codebase-memory-mcp.payload.exe\

### Fix
- Updated install.ps1 archive layout validation to require codebase-memory-mcp.exe, LICENSE, install.ps1, and THIRD_PARTY_NOTICES.md, while allowing codebase-memory-mcp.payload.exe to be optional (0 or 1 instance).
- If codebase-memory-mcp.payload.exe is missing from the extracted archive, install.ps1 stage-copies codebase-memory-mcp.exe to codebase-memory-mcp.payload.exe in the temporary directory prior to executing the launcher installation.
- Updated 	ests/test_windows_bundle_contract.sh static contract checks to reflect the updated archive bounds.

### Validation
- Verified with python contract test script (\	est_windows_bundle_contract.sh\).
- Tested \install.ps1\ archive extraction against both 4-file (flat layout) and 5-file (pair layout) zip archives.