### PR TITLE
fix(stale): mark awaiting-reporter issues stale, never auto-close

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,24 @@
 name: Stale awaiting-reporter
 
+# Marks inactive `awaiting-reporter` issues as `stale`. It NEVER closes them:
+# closing an issue as "not planned" is a maintainer judgement, not an automated
+# one, so this workflow only surfaces a review queue and a human decides.
+#
 # Only touches issues that a maintainer has explicitly marked `awaiting-reporter`.
 # Never touches pull requests, and never touches issues without that label.
 # A reporter comment removes `stale` and resets the clock.
+#
+# WHY never close (2026-07-26): `awaiting-reporter` is applied by hand and means
+# "the reporter owes the next step". It was also being used to mean "we will come
+# back to this", which is a different thing. In that second case the automation was
+# closing issues the project itself owed work on — #56 was a confirmed bug with an
+# in-tree reproduction (tests/repro/repro_issue56.c, landed via #667) queued to close
+# as `not_planned` purely because a maintainer had the last word. A mislabel should
+# cost a stale tag, never a silently discarded bug.
+#
+# The `stale` label is therefore a review queue, not a countdown. Sweep it during
+# triage: clear the label where we owe the next step, and close by hand where the
+# thread is genuinely dead.
 
 on:
   schedule:
@@ -23,22 +39,23 @@ jobs:
           only-labels: 'awaiting-reporter'
           stale-issue-label: 'stale'
           days-before-issue-stale: 21
-          days-before-issue-close: 14
+          # -1 disables automated closing entirely. Marking stale is the whole job.
+          days-before-issue-close: -1
           # Never act on pull requests with this workflow.
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          # Belt-and-braces: these categories must never be auto-flagged even if
+          # `awaiting-reporter` is applied to them by mistake. `task` covers the
+          # umbrella/epic issues (incl. the pinned roadmap index #595), and
+          # `maintainer-notes` is the explicit "we owe the next step" escape hatch.
+          exempt-issue-labels: 'security,task,maintainer-notes'
           remove-stale-when-updated: true
-          close-issue-reason: not_planned
           operations-per-run: 60
           ascending: true
           stale-issue-message: >
             This issue has been waiting on more information for 21 days (a
             version, exact steps, or a public repro), so it's now marked
-            `stale`. It will be closed in 14 days if there's no update — just
-            add a comment to keep it open. We're happy to pick it back up the
-            moment we can reproduce it.
-          close-issue-message: >
-            Closing because we haven't received the requested details and can't
-            reproduce it as-is. This isn't a "won't fix" — please comment with
-            the info (version + a public repro) and we'll reopen and dig in.
-            Thanks for the report.
+            `stale`. **It will not be closed automatically** — a maintainer
+            reviews stale issues by hand. Adding a comment with the details
+            clears the label and puts it straight back in the queue. We're happy
+            to pick it back up the moment we can reproduce it.


### PR DESCRIPTION
## Problem

The stale workflow closed `awaiting-reporter` issues as `not_planned` after 35 days (21 to stale + 14 to close). That label is applied by hand and is meant to signal "the reporter owes the next step" — but it was also being used to mean "we will come back to this", and in that second case the automation closed issues the project itself owed work on.

**#56 is the concrete case.** Its last comment was a maintainer commitment, not a request: the promised reproduction landed via #667 (`36d83280`) and lives in-tree as `tests/repro/repro_issue56.c`. The bug is confirmed, reproduced, guarded against regression — and unfixed. It was three days from closing as `not planned` purely because a maintainer had the last word.

That was 1 mislabel in a sample of 9. **13 of the 22** currently labelled issues are `priority/high`.

## Change

- `days-before-issue-close: -1` — closing is disabled entirely. Closing as "not planned" is a maintainer judgement, so the bot no longer makes it. The `stale` label becomes a review queue swept by hand during triage.
- `exempt-issue-labels: security,task,maintainer-notes` — belt-and-braces so these are never flagged even if `awaiting-reporter` is applied by mistake. `task` covers the umbrella/epic issues including the pinned roadmap index #595; `maintainer-notes` is the explicit "we owe the next step" escape hatch.
- Removed `close-issue-message` and `close-issue-reason`, now unreachable.
- Rewrote the stale notice, which promised a closure that no longer happens.
- Documented the reasoning in a header comment so the next person does not restore the countdown without knowing why it went.

Unchanged: trigger (daily cron + dispatch), `only-labels`, `remove-stale-when-updated`, PRs still never touched, `permissions`, `operations-per-run`.

## Scope / risk

Non-gating — scheduled workflow, blocks nothing. No build-cost or flake-surface change; same single job on the same schedule. Permissions unchanged (`issues: write`, still needed to apply the label). Behavioural change is strictly *less* destructive: the bot can now only add a label.

Trade-off worth stating: the backlog no longer self-clears, so the `stale` set needs a periodic sweep. That is the intended exchange — a mislabel now costs a stale tag instead of a silently discarded bug.

## Follow-up

#56 has already been de-armed by hand (label removed, `maintainer-notes` applied, reporter told the next step is ours). The remaining 21 labelled issues stay flagged but are no longer on a countdown.