### PR TITLE
feat(ci): acknowledge new pull requests automatically

### DIFF
--- a/.github/pr-acknowledgement.md
+++ b/.github/pr-acknowledgement.md
@@ -14,13 +14,13 @@ Thanks for opening this — it has been seen, and it is queued.
 
 This note is automated, but it is not a brush-off: it exists so you know where your PR stands instead of having to guess from silence.
 
-**Current review status: reviews are running behind.** We are finishing release-critical work for `0.9.1-rc.1` — a coordination daemon that changed how the whole system runs, and the root-cause fix for a severe Windows memory leak ([#581](https://github.com/DeusData/codebase-memory-mcp/issues/581)) that could exhaust a machine's commit charge over hours. Those changes cross the memory allocator, thread lifecycle, and the store-resolution path that every tool call runs through, so merging other work on top of them while they settle would leave neither change trustworthy. The full explanation is in [discussion #1144](https://github.com/DeusData/codebase-memory-mcp/discussions/1144).
+**Current review status: working through a backlog.** `0.9.1-rc.1` is out, so the release freeze that held reviews is over — but it left a large queue of open pull requests behind it, and we are reading through them oldest-first. The background is in [discussion #1144](https://github.com/DeusData/codebase-memory-mcp/discussions/1144).
 
 What that means for this PR, concretely:
 
 - **It will not be closed for inactivity.** No stale bot touches pull requests here.
-- It may sit longer than it should before a human reads it. That is on us, not on you.
-- Review resumes once the release path is clear.
+- It may still sit a while before a human reads it. That is on us, not on you.
+- Older PRs are read first, so a recent one is not being skipped — it is behind a queue.
 
 Things that will genuinely speed it up whenever review does happen:
 

--- a/.github/pr-acknowledgement.md
+++ b/.github/pr-acknowledgement.md
@@ -1,0 +1,34 @@
+<!--
+  Posted automatically on every newly opened pull request by
+  .github/workflows/pr-acknowledgement.yml
+
+  EDIT THIS FILE to change what contributors are told. Blank it out to stop
+  posting acknowledgements entirely — no workflow change needed.
+
+  Keep it short, and keep it honest about what happens next. A promise of a
+  timeline you will not meet is worse than no acknowledgement at all.
+  Remove the review-status section below the moment it stops being true.
+-->
+
+Thanks for opening this — it has been seen, and it is queued.
+
+This note is automated, but it is not a brush-off: it exists so you know where your PR stands instead of having to guess from silence.
+
+**Current review status: reviews are running behind.** We are finishing release-critical work for `0.9.1-rc.1` — a coordination daemon that changed how the whole system runs, and the root-cause fix for a severe Windows memory leak ([#581](https://github.com/DeusData/codebase-memory-mcp/issues/581)) that could exhaust a machine's commit charge over hours. Those changes cross the memory allocator, thread lifecycle, and the store-resolution path that every tool call runs through, so merging other work on top of them while they settle would leave neither change trustworthy. The full explanation is in [discussion #1144](https://github.com/DeusData/codebase-memory-mcp/discussions/1144).
+
+What that means for this PR, concretely:
+
+- **It will not be closed for inactivity.** No stale bot touches pull requests here.
+- It may sit longer than it should before a human reads it. That is on us, not on you.
+- Review resumes once the release path is clear.
+
+Things that will genuinely speed it up whenever review does happen:
+
+- **Keep it rebased** on `main` — the tree is moving quickly right now, and a conflicting branch cannot be reviewed as the diff you intended.
+- **Get CI green**, or say which failures you believe are pre-existing.
+- **Keep the change to one claim.** Bundled features and refactors get split before they get merged, which costs you a round trip.
+- Every commit needs a sign-off (`git commit -s`) — CI enforces DCO.
+
+If this fixes a bug, a reproduction we can run is worth more than a description of the symptom.
+
+Thanks for contributing, and sorry in advance for the wait.

--- a/.github/workflows/pr-acknowledgement.yml
+++ b/.github/workflows/pr-acknowledgement.yml
@@ -1,0 +1,67 @@
+name: PR acknowledgement
+
+# Posts one acknowledgement comment when a pull request is opened, so a
+# contributor learns the current review status immediately instead of inferring
+# it from silence.
+#
+# The message text lives in `.github/pr-acknowledgement.md`. Edit that file to
+# change what is said; blank it (or delete it) to turn acknowledgements off
+# without touching this workflow. No code change is needed to switch it.
+#
+# SECURITY — this uses `pull_request_target`, which runs against the BASE repo
+# with a token that can write. That is required: a `pull_request` trigger gives
+# fork PRs a read-only token, so commenting on exactly the contributions we most
+# want to acknowledge would fail.
+#
+# The safety rule that makes it sound: this job NEVER checks out, builds, or
+# executes pull-request code. `actions/checkout` here resolves to the base
+# commit (the default under `pull_request_target`), and it is used only to read
+# the message file out of our own tree. Do not add a `ref:` pointing at the PR
+# head, and do not add a build step. Nothing from the PR is interpolated into a
+# shell command either — the body comes from a file, and the PR number is passed
+# through the environment rather than expanded inline.
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  acknowledge:
+    runs-on: ubuntu-latest
+    # Bots do not read comments, and acknowledging our own PRs is noise.
+    if: >-
+      github.event.pull_request.user.type != 'Bot' &&
+      github.event.pull_request.author_association != 'OWNER'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Base commit only — never the PR head. See the security note above.
+          persist-credentials: false
+
+      - name: Post acknowledgement
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          MESSAGE_FILE=.github/pr-acknowledgement.md
+
+          if [ ! -f "$MESSAGE_FILE" ]; then
+            echo "No $MESSAGE_FILE in the base tree — acknowledgements are off."
+            exit 0
+          fi
+
+          # An empty or whitespace-only file is the documented off switch.
+          if [ -z "$(tr -d '[:space:]' < "$MESSAGE_FILE")" ]; then
+            echo "$MESSAGE_FILE is blank — acknowledgements are off."
+            exit 0
+          fi
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$MESSAGE_FILE"
+          echo "Acknowledged PR #${PR_NUMBER}."


### PR DESCRIPTION
## Problem

Contributors cannot tell **blocked** from **ignored**. Several PRs sat over a week on green, mergeable work with no maintainer comment while release-critical work absorbed capacity — and nothing on the PR page said so.

GitHub offers no repo-scoped information bar for pull requests. The org announcement banner renders only for organization members, and pinned issues and discussions never appear on the PR tab. [Discussion #1144](https://github.com/DeusData/codebase-memory-mcp/discussions/1144) explains the current situation well and is effectively invisible to someone opening a PR. A comment on open is the only surface that reaches an external contributor at the moment they contribute.

## Change

Posts one comment when a PR is opened: it is queued, it will **not** be closed for inactivity, and here is what genuinely speeds up review (rebased branch, green CI, one claim per PR, signed-off commits).

**The message text lives in `.github/pr-acknowledgement.md`, not in the workflow.** Edit that file to change what is said; blank it to switch acknowledgements off. No workflow change needed either way — a missing, empty, or whitespace-only file is the documented off switch (all three cases tested).

## Security note — `pull_request_target`

This is the repo’s first use of that trigger, so the reasoning is explicit.

It is required: a `pull_request` trigger gives fork PRs a **read-only** token, so commenting would fail on exactly the contributions most worth acknowledging.

What makes it safe is that the job **never checks out, builds, or executes pull-request code**:

- `actions/checkout` carries **no `ref:`**, so it resolves to the base commit (the default under `pull_request_target`), and is used only to read our own message file.
- `persist-credentials: false`.
- No build, install, or test step — nothing from the PR is executed.
- No PR-controlled value is interpolated into a shell command. The body comes from a file; the PR number is passed via the environment.
- Permissions are minimal: `contents: read` at top level, `pull-requests: write` only on the job.

The workflow header states these constraints so a future edit does not quietly break them.

## Behaviour

- Fires on `opened` only — one comment per PR, no repeat noise.
- Skips bots (`user.type == Bot`) and owner-authored PRs.
- Does not touch existing open PRs. Those 85 were acknowledged by hand during the triage sweep.

## Scope / risk

Non-gating; blocks no merge. One short job per opened PR. Worst case if the message file is malformed is a skipped comment, not a failed PR.

**The standing obligation this creates:** the review-status section is a public promise. It must be edited when the release path clears and removed when it stops being true — a stale freeze notice trains contributors to ignore status messages, which is worse than posting nothing.