### PR TITLE
fix(build): preserve LF for shell entrypoints

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 # Vendored tree-sitter grammars — machine-generated, hide from stats and diffs
 internal/cbm/vendored/grammars/**/parser.c  linguist-generated=true diff=false
 internal/cbm/vendored/grammars/**/scanner.c linguist-generated=true diff=false
+
+# Shell entrypoints must stay executable from Windows checkouts mounted in WSL.
+*.sh                           text eol=lf
+scripts/git-hooks/commit-msg   text eol=lf
+scripts/hooks/pre-commit       text eol=lf

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -85,6 +85,9 @@ bash "$ROOT/tests/test_makefile_ts_runtime_dependencies.sh"
 echo "=== Step 0g: security fuzz harness self-test ==="
 bash "$ROOT/tests/test_security_fuzz_harness.sh"
 
+echo "=== Step 0h: shell line-ending contract ==="
+bash "$ROOT/tests/test_shell_line_endings.sh"
+
 # Verify compiler supports target arch
 verify_compiler "$CC"
 

--- a/tests/test_shell_line_endings.sh
+++ b/tests/test_shell_line_endings.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Regression guard: shell entrypoints must remain LF in Windows checkouts so
+# they can run directly from WSL and MSYS without a `bash\r` shebang failure.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+failures=0
+checked=0
+while IFS= read -r -d '' path &&
+    IFS= read -r -d '' attribute &&
+    IFS= read -r -d '' eol; do
+    checked=$((checked + 1))
+    if [[ "$eol" != "lf" ]]; then
+        echo "FAIL: $path must declare eol=lf (got ${eol:-unset})" >&2
+        failures=$((failures + 1))
+    fi
+done < <(
+    git ls-files -z '*.sh' 'scripts/git-hooks/*' 'scripts/hooks/*' |
+        git check-attr -z --stdin eol
+)
+
+if (( failures > 0 )); then
+    echo "FAIL: $failures shell entrypoint(s) lack an LF checkout contract" >&2
+    exit 1
+fi
+
+echo "Shell line-ending contract passed ($checked files)"


### PR DESCRIPTION
## What does this PR do?

Preserve LF checkout semantics for shell entrypoints so Windows clones with `core.autocrlf=true` can run repository scripts directly from WSL or MSYS. Without this rule, the shebang can be checked out as CRLF and fail with `env: $'bash\r': No such file or directory`.

This adds a shell line-ending contract test and runs it before the compiler-heavy suite. The test checks all tracked `*.sh` files and shell hook entrypoints with `git check-attr`.

## Validation

- `bash tests/test_shell_line_endings.sh`: 60/60 entrypoints passed
- `bash scripts/build.sh`: passed
- Version smoke test: `codebase-memory-mcp dev`
- `git diff --check`: passed
- Full suite: 6,614 passed / 6 failed / 4 skipped. The six failures are unrelated WSL/DrvFs/test-infrastructure failures, so this does not claim a fully green local suite.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Tests pass locally (`make -f Makefile.cbm test`)
- [ ] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)