### PR TITLE
fix(contract): 0h VM-soak needle onto the canonical soak entry (dry-run test-wave red)

### DIFF
--- a/tests/test_smoke_fixture_contract.sh
+++ b/tests/test_smoke_fixture_contract.sh
@@ -272,12 +272,20 @@ require(
     and "vm-run-tests.sh --soak '$duration'" in windows_vm,
     "the Windows VM driver must route the native daemon soak through its protected-temp harness",
 )
+# The soak sequence and its completion guards moved into the ONE canonical
+# entry scripts/soak-legs.sh (venue parity: _soak.yml, compose and the VM all
+# run the same file); the VM wrapper supplies the protected temp root and
+# routes into it.
+soak_legs = read("scripts/soak-legs.sh")
 require(
     'if [ "$1" = "--soak" ]' in windows_vm_runner
-    and 'scripts/soak-test.sh "$binary" "$duration"' in windows_vm_runner
-    and "=== soak-test: PASSED ===" in windows_vm_runner,
-    "the Windows VM harness must run and completion-guard the native daemon soak under its "
-    "protected temp root",
+    and 'scripts/soak-legs.sh "$binary" "$duration"' in windows_vm_runner,
+    "the Windows VM harness must route the native daemon soak through the canonical soak "
+    "entry under its protected temp root",
+)
+require(
+    "grep -Fq '=== soak-test: PASSED ==='" in soak_legs,
+    "the canonical soak entry must completion-guard every leg on the soak summary",
 )
 require(
     pr_workflow.count("scripts/smoke-local.sh") >= 2,


### PR DESCRIPTION
Fix-forward for dry run 30224804737: all 20 test-wave reds share one cause — Step 0h still pinned the pre-unification direct soak-test.sh call. Chain-masking (0e failed first; --suites skips contracts) hid it until the 0e fix landed. All contract steps 0a–0j now verified green standalone. Invariant kept: canonical-entry routing + completion guard, anchors moved to where the behavior lives.