### PR TITLE
Local-ladder green: BSD mktemp soak fix (CI-mac-gating) + 0h port-poll tolerance + Alpine curl

### DIFF
--- a/scripts/soak-legs.sh
+++ b/scripts/soak-legs.sh
@@ -77,7 +77,10 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 run_leg() {
     local leg="$1"
     local log
-    log="$(mktemp "${TMPDIR:-/tmp}/cbm-soak-leg-XXXXXX.log")"
+    # No suffix after the X run: BSD mktemp substitutes only TRAILING X's, so
+    # a template like ...XXXXXX.log creates a near-literal file on macOS and
+    # every second run collides with the first run's leftover ("File exists").
+    log="$(mktemp "${TMPDIR:-/tmp}/cbm-soak-leg-XXXXXX")"
     echo "=== soak-legs: leg=${leg} binary=${BINARY} duration=${DURATION}m ==="
     local rc=0
     case "$leg" in

--- a/test-infrastructure/Dockerfile.alpine
+++ b/test-infrastructure/Dockerfile.alpine
@@ -14,6 +14,7 @@ RUN apk add --no-cache \
     zlib-dev \
     zlib-static \
     bash \
+    curl \
     git \
     python3 \
     nodejs \

--- a/tests/test_smoke_fixture_contract.sh
+++ b/tests/test_smoke_fixture_contract.sh
@@ -381,7 +381,13 @@ if helper.is_file():
                 deadline = time.monotonic() + 30
                 while time.monotonic() < deadline:
                     if port_file.is_file():
-                        text = port_file.read_text(encoding="ascii").strip()
+                        try:
+                            text = port_file.read_text(encoding="ascii").strip()
+                        except OSError:
+                            # Windows: the atomic replace publishing the port
+                            # (or a first-touch AV scan of the fresh file)
+                            # briefly denies the read — not ready yet.
+                            text = ""
                         if text:
                             port = int(text)
                             break
@@ -474,7 +480,12 @@ if helper.is_file():
             dns_deadline = time.monotonic() + 20
             while time.monotonic() < dns_deadline:
                 if dns_port_file.is_file():
-                    dns_text = dns_port_file.read_text(encoding="ascii").strip()
+                    try:
+                        dns_text = dns_port_file.read_text(encoding="ascii").strip()
+                    except OSError:
+                        # Windows: replace-in-flight / first-touch AV scan —
+                        # not ready yet (see the port poll above).
+                        dns_text = ""
                     if dns_text:
                         dns_port = int(dns_text)
                         break


### PR DESCRIPTION
Three harness fixes from driving the full local ladder to green on merged main. The mktemp one is REMOTE-gating: CI's macos soak jobs run two legs per job on BSD mktemp and collide on the near-literal leftover exactly like the local repro. The other two are local-venue-only (Windows/Defender port-publish race in the 0h self-test; curl missing from the Alpine smoke image). Local ladder is fully green with these: mac 6621/0 + TSan + smoke + artifact + soak×2 · linux test/perf/TSan/smoke/portable/artifact/glibc-floor/soak×2 · windows test-par 6681/0 solo + guards + smoke-install + smoke-artifact + soak×2.