### PR TITLE
Cycle-5: soak .exe resolution (root cause of both Windows runner soak reds) + preflight cleanup race

### DIFF
--- a/.github/workflows/_smoke.yml
+++ b/.github/workflows/_smoke.yml
@@ -201,7 +201,10 @@ jobs:
           # runner workspace is deliberately not a valid launcher bundle root.
           PROFILE_ROOT="$(cygpath -u "$USERPROFILE")"
           LAUNCH_DIR="$(mktemp -d "$PROFILE_ROOT/cbm-release-version.XXXXXX")"
-          trap 'rm -rf "$LAUNCH_DIR"' EXIT
+          # Best-effort cleanup with one retry: Windows holds the just-exited
+          # image's file busy for ~100ms (section teardown / first-touch AV),
+          # and a temp dir on an ephemeral runner must never fail the job.
+          trap 'rm -rf "$LAUNCH_DIR" 2>/dev/null || { sleep 2; rm -rf "$LAUNCH_DIR" 2>/dev/null || true; }' EXIT
           cp "$ARTIFACT_DIR/codebase-memory-mcp.exe" \
             "$ARTIFACT_DIR/codebase-memory-mcp.payload.exe" "$LAUNCH_DIR/"
           "$LAUNCH_DIR/codebase-memory-mcp.payload.exe" --version
@@ -231,7 +234,8 @@ jobs:
           scripts/security-strings.sh "$ARTIFACT_DIR/codebase-memory-mcp.payload.exe"
           PROFILE_ROOT="$(cygpath -u "$USERPROFILE")"
           SECURITY_DIR="$(mktemp -d "$PROFILE_ROOT/cbm-release-security.XXXXXX")"
-          trap 'rm -rf "$SECURITY_DIR"' EXIT
+          # Best-effort cleanup with one retry (see the version preflight).
+          trap 'rm -rf "$SECURITY_DIR" 2>/dev/null || { sleep 2; rm -rf "$SECURITY_DIR" 2>/dev/null || true; }' EXIT
           cp "$ARTIFACT_DIR/codebase-memory-mcp.exe" \
             "$ARTIFACT_DIR/codebase-memory-mcp.payload.exe" "$SECURITY_DIR/"
           TMPDIR="$SECURITY_DIR" \

--- a/scripts/soak-legs.sh
+++ b/scripts/soak-legs.sh
@@ -67,7 +67,14 @@ esac
 [ "$DURATION" -gt 0 ] || { echo "soak-legs: duration must be positive" >&2; exit 2; }
 # Windows builds produce <name>.exe; resolve it here so every venue passes the
 # same plain path and carries no per-platform binary-name logic of its own.
-if [ ! -x "$BINARY" ] && [ -x "${BINARY}.exe" ]; then
+# Resolve whenever the .exe EXISTS, not only when the plain name fails -x:
+# msys resolves the suffix-less name transparently (it IS -x), but soak-test
+# keys its native-Windows handling — cygpath'd CBM_CACHE_DIR, coproc stdio —
+# off the literal .exe suffix. A suffix-less native binary therefore received
+# a POSIX-form cache path, mis-rooting the daemon logs and silently disabling
+# diagnostics (both hosted-runner Windows soak legs; reproduced on the VM's
+# CLANG64 environment with a suffix-less invocation).
+if [[ "$BINARY" != *.exe ]] && [ -x "${BINARY}.exe" ]; then
     BINARY="${BINARY}.exe"
 fi
 [ -x "$BINARY" ] || { echo "soak-legs: binary '$BINARY' missing or not executable — build first" >&2; exit 2; }


### PR DESCRIPTION
soak-legs now resolves the .exe whenever it exists: workflows pass suffix-less paths, msys executes them transparently, and soak-test keys its native-Windows cache-path/coproc gates off the literal suffix — suffix-less native binaries got POSIX cache paths (mis-rooted daemon logs, silent frontend death). Reproduced and red->green proven on the VM CLANG64 rig. Plus best-effort retry on the Windows version/security preflight cleanup traps (image-teardown busy race that failed a job whose work was green).