### PR TITLE
ci(release): correct channel semantics for semver prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,8 @@ jobs:
         with:
           tag_name: ${{ inputs.version }}
           draft: true
+          # Semver prerelease (v0.9.1-rc.1): never the "latest" release on GitHub.
+          prerelease: ${{ contains(inputs.version, '-') }}
           files: |
             *.tar.gz
             *.zip
@@ -303,7 +305,16 @@ jobs:
         working-directory: pkg/npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance
+          RELEASE_VERSION: ${{ inputs.version }}
+        # A prerelease must never become npm `latest` — plain `npm install`
+        # would serve the RC to everyone. Publish prereleases under the
+        # `next` dist-tag; testers opt in via `npm i codebase-memory-mcp@next`.
+        run: |
+          if [[ "$RELEASE_VERSION" == *-* ]]; then
+            npm publish --access public --provenance --tag next
+          else
+            npm publish --access public --provenance
+          fi
 
       # ── PyPI ─────────────────────────────────────────────────
       - name: Setup Python
@@ -340,7 +351,9 @@ jobs:
   # not touch npm/PyPI, so retries are safe.
   publish-mcp-registry:
     needs: [publish-registries]
-    if: ${{ !cancelled() && !failure() && needs.publish-registries.result == 'success' }}
+    # Skipped for prereleases: the MCP Registry has no channel concept, so an
+    # RC would present itself as the current version to every registry consumer.
+    if: ${{ !cancelled() && !failure() && needs.publish-registries.result == 'success' && !contains(inputs.version, '-') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write   # GitHub OIDC auth to the MCP Registry


### PR DESCRIPTION
A version containing a prerelease suffix (`v0.9.1-rc.1`) now publishes as an RC on every channel instead of masquerading as stable:

- **GitHub release** is created with `prerelease: true` (never marked *Latest*)
- **npm** publishes under the `next` dist-tag — plain `npm install` keeps serving the last stable; testers opt in via `codebase-memory-mcp@next`
- **MCP Registry** sync is skipped (the registry has no channel concept)
- **PyPI** needs no change: PEP 440 already treats `rc` versions as pre-releases pip only installs with `--pre`

Stable releases (no dash in the version) are byte-identical in behavior. Workflows-only change; product code untouched relative to the green dry-run SHA `d587dea` (run 30244476878). Unblocks the `v0.9.1-rc.1` dispatch.