### PR TITLE
fix(extract): Nix definitions are dropped in any file whose root expression is a function

### DIFF
--- a/internal/cbm/extract_defs.c
+++ b/internal/cbm/extract_defs.c
@@ -6758,10 +6758,16 @@ static void walk_defs(CBMExtractCtx *ctx, TSNode root, const CBMLangSpec *spec, 
                 // Ada subprograms nest (a procedure body's declarative part can
                 // contain inner subprogram bodies); descend so the nested defs
                 // are captured and same-file calls to them resolve to a CALLS edge.
+                // Nix: a library/module file's ROOT expression is normally itself a
+                // function_expression (`{ pkgs, lib, ... }: <body>`), so stopping here
+                // abandons the entire file — every binding in it is lost. Descend so
+                // the body's `name = args: ...` bindings are reached. Inner curried
+                // lambdas (`f = a: b: ...`) resolve no name and mint nothing, so the
+                // extra descent adds defs without adding noise.
                 bool descend_into_func =
                     (ctx->language == CBM_LANG_WOLFRAM || ctx->language == CBM_LANG_TYPESCRIPT ||
                      ctx->language == CBM_LANG_JAVASCRIPT || ctx->language == CBM_LANG_TSX ||
-                     ctx->language == CBM_LANG_ADA);
+                     ctx->language == CBM_LANG_ADA || ctx->language == CBM_LANG_NIX);
                 if (!descend_into_func) {
                     continue;
                 }

--- a/tests/test_extraction.c
+++ b/tests/test_extraction.c
@@ -1145,6 +1145,97 @@ TEST(nix_function) {
     PASS();
 }
 
+/* A Nix file's root expression is normally itself a function (`{ pkgs, lib, ... }:`)
+ * — the near-universal library/module header. Definitions must survive that header.
+ * Each shape below is asserted separately so a regression names the shape it broke.
+ * `nix_function` above deliberately stays as-is: its binding is an application, not
+ * a function, so it pins the "parses, no def" case and cannot cover this. */
+TEST(nix_defs_in_let_rooted_file) {
+    CBMFileResult *r = extract("let\n  alpha = x: x + 1;\n  beta = { a, b }: a + b;\nin\n"
+                               "{ inherit alpha beta; }\n",
+                               CBM_LANG_NIX, "t", "bare.nix");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+    ASSERT(has_def(r, "Function", "alpha"));
+    ASSERT(has_def(r, "Function", "beta"));
+    cbm_free_result(r);
+    PASS();
+}
+
+TEST(nix_defs_in_attrset_rooted_file) {
+    CBMFileResult *r = extract("{\n  epsilon = x: x + 1;\n  zeta = { a, b }: a + b;\n}\n",
+                               CBM_LANG_NIX, "t", "attrset.nix");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+    ASSERT(has_def(r, "Function", "epsilon"));
+    ASSERT(has_def(r, "Function", "zeta"));
+    cbm_free_result(r);
+    PASS();
+}
+
+TEST(nix_defs_in_nested_let) {
+    CBMFileResult *r = extract("let\n  outer =\n    let theta = x: x + 1;\n    in theta;\n"
+                               "in\n{ inherit outer; }\n",
+                               CBM_LANG_NIX, "t", "nested.nix");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+    ASSERT(has_def(r, "Function", "theta"));
+    cbm_free_result(r);
+    PASS();
+}
+
+/* The regression this suite previously could not see: the root `{ prelude }:` matches
+ * nix_func_types, resolves no name of its own, and — before the fix — terminated the
+ * walk, so nothing below the header was ever visited. */
+TEST(nix_defs_survive_function_header_let) {
+    CBMFileResult *r = extract("{ prelude }:\nlet\n  gamma = x: x + 1;\n"
+                               "  delta = { a, b }: a + b;\nin\n{ inherit gamma delta; }\n",
+                               CBM_LANG_NIX, "t", "wrapped.nix");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+    ASSERT(has_def(r, "Function", "gamma"));
+    ASSERT(has_def(r, "Function", "delta"));
+    cbm_free_result(r);
+    PASS();
+}
+
+TEST(nix_defs_survive_function_header_attrset) {
+    CBMFileResult *r = extract("{ prelude }:\n{\n  eta = x: x + 1;\n}\n", CBM_LANG_NIX, "t",
+                               "wrapped_attrset.nix");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+    ASSERT(has_def(r, "Function", "eta"));
+    cbm_free_result(r);
+    PASS();
+}
+
+/* A curried header — `final: prev: { … }` is the standard nixpkgs overlay signature, and
+ * the most common multi-arm header in the ecosystem. Two nested function_expressions sit
+ * between the file root and the body. */
+TEST(nix_defs_survive_curried_header) {
+    CBMFileResult *r =
+        extract("final: prev: {\n  kappa = x: x + 1;\n}\n", CBM_LANG_NIX, "t", "overlay.nix");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+    ASSERT(has_def(r, "Function", "kappa"));
+    cbm_free_result(r);
+    PASS();
+}
+
+/* Descending past the header must not mint a second def from a curried lambda's inner
+ * arm: `iota = a: b: ...` is one named function, not two. The inner `b:` has a
+ * function_expression parent, resolves no name, and must stay out. */
+TEST(nix_curried_lambda_mints_one_def) {
+    CBMFileResult *r = extract("{ prelude }:\nlet\n  iota = a: b: a + b;\nin\n{ inherit iota; }\n",
+                               CBM_LANG_NIX, "t", "curried.nix");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+    ASSERT(has_def(r, "Function", "iota"));
+    ASSERT(count_defs_with_label(r, "Function") == 1);
+    cbm_free_result(r);
+    PASS();
+}
+
 /* --- Fortran --- */
 TEST(fortran_function) {
     /* Fortran subroutine name extraction is incomplete — just verify no crash */
@@ -4802,6 +4893,13 @@ SUITE(extraction) {
     RUN_TEST(julia_function);
     RUN_TEST(elm_function);
     RUN_TEST(nix_function);
+    RUN_TEST(nix_defs_in_let_rooted_file);
+    RUN_TEST(nix_defs_in_attrset_rooted_file);
+    RUN_TEST(nix_defs_in_nested_let);
+    RUN_TEST(nix_defs_survive_function_header_let);
+    RUN_TEST(nix_defs_survive_function_header_attrset);
+    RUN_TEST(nix_defs_survive_curried_header);
+    RUN_TEST(nix_curried_lambda_mints_one_def);
     RUN_TEST(fortran_function);
 
     /* OOP/Systems variants */


### PR DESCRIPTION
## What does this PR do?

Fixes total definition loss for Nix files whose root expression is a function — `{ pkgs, lib, ... }: <body>` — and rewrites the Nix extraction test so the suite can actually fail for it.

Filing without a prior issue under the CONTRIBUTING carve-out for focused bug fixes and test additions. Happy to open one first if you'd rather.

### The bug

A Nix library or module file almost always opens with a function pattern. That root node is a `function_expression`, so it matches `nix_func_types`. `walk_defs` hands it to `extract_func_def`, which resolves no name for it — the Nix resolver at `internal/cbm/extract_defs.c:827` requires the function's parent to be a `binding`, and the root lambda's parent is the file root `source_code` — so nothing is minted. Control then reaches:

```c
if (!descend_into_func) {
    continue;
}
```

Nix is not in `descend_into_func`, so the walk abandons the subtree. **No binding below the header is ever visited.**

Files opening with a bare `let` or an attrset are walked normally, which is why the language looked supported: some files produced definitions, so the failure read as sparse coverage rather than a structural miss.

Minimal reproduction — the last two shapes yield nothing on `main`:

| file root | shape | defs on `main` |
| --- | --- | --- |
| `let … in` | `alpha = x: x + 1;` | found |
| `{ … }` | `epsilon = x: x + 1;` | found |
| `let` inside `let` | `theta = x: x + 1;` | found |
| `{ prelude }:` then `let … in` | `gamma`, `delta` | **none** |
| `{ prelude }:` then `{ … }` | `eta` | **none** |

Nesting depth is not the trigger — `nested_let` is fine. The trigger is solely whether the file's root expression is a function.

### Why the suite didn't catch it

`TEST(nix_function)` was the only Nix extraction test, and it could not fail for this, for three independent reasons:

- its fixture is function-headed — the exact broken shape;
- its binding, `hello = pkgs.writeShellScriptBin "hello" ''…''`, is an application rather than a function, so no `Function` def is expected from it either way;
- it asserts only `ASSERT_NOT_NULL` and `ASSERT_FALSE(r->has_error)`, omitting the `has_def` check that every adjacent language test makes.

So the suite reported green while definitions were dropped for the dominant file shape in the ecosystem. I've left `nix_function` as-is — it usefully pins the "parses, yields no def" case — and added coverage around it.

### The fix

One line: add `CBM_LANG_NIX` to `descend_into_func`.

Descending does not over-mint from curried lambdas. In `f = a: b: …` the inner `b:` has a `function_expression` parent, resolves no name, and stays out. `nix_curried_lambda_mints_one_def` pins that with a counter assertion so a future change that starts minting the inner arm is caught.

The change is gated on `ctx->language`, so no other language's walk is affected.

### Tests

Seven cases, one per root shape, each asserting its own definitions so a regression names the shape it broke:

```
nix_defs_in_let_rooted_file                 let … in
nix_defs_in_attrset_rooted_file             { … }
nix_defs_in_nested_let                      let inside let
nix_defs_survive_function_header_let        { prelude }: let … in
nix_defs_survive_function_header_attrset    { prelude }: { … }
nix_defs_survive_curried_header             final: prev: { … }  (nixpkgs overlay)
nix_curried_lambda_mints_one_def            guards the other direction
```

Verified as a negative control: with the one-line change reverted, exactly the three new function-header tests fail, each on its own assertion (`gamma`, `eta`, `iota`), while the three pre-existing shapes stay green. That is what makes them real tests rather than tautologies.

### Impact

Twelve real Nix repositories, same binary and `mode=full` on both sides, so the delta is the fix alone. `Function` / `CALLS` / files-with-definitions:

| repo | .nix | before | after |
| --- | --- | --- | --- |
| library A | 6 | 27 / 5 / 3 | 34 / 7 / 4 |
| library B | 76 | 36 / 24 / 14 | 390 / 287 / 59 |
| library C | 146 | 12 / 11 / 5 | 141 / 272 / 55 |
| library D | 31 | 10 / 17 / 7 | 113 / 114 / 28 |
| library E | 29 | 9 / 9 / 4 | 156 / 191 / 22 |
| library F | 27 | 2 / 0 / 2 | 87 / 149 / 22 |
| library G | 58 | 6 / 4 / 4 | 135 / 118 / 34 |
| library H | 37 | 2 / 0 / 2 | 163 / 309 / 32 |
| library I | 29 | 2 / 0 / 2 | 48 / 31 / 22 |
| library J | 34 | 24 / 5 / 10 | 140 / 75 / 30 |
| framework | 320 | 48 / 56 / 8 | 1900 / 1443 / 258 |
| system config | 499 | 293 / 204 / 181 | 654 / 325 / 320 |

The size of the gain tracks how much of a repository uses the function header, which is what you would expect if the diagnosis is right. Library A barely moves — its entry point opens with a bare attrset, so it was already being walked. The framework repository, where 253 of 320 files carry a header, moves 39-fold. Nothing here regresses.

Checked for quality, not just volume:

- One file's extracted definitions match exactly what `nil`'s `textDocument/documentSymbol` reports for the same file.
- Sampled names from a second repository are all real public API — `nameValuePair`, `hasInfix`, `reverseList`, `listDfs`, `toposort`, `findFirstIndex` — plus `outputs` from `flake.nix`, which is correct since `outputs = inputs@{ … }: …` is genuinely a function binding.
- No anonymous or empty names appear among the 1900 definitions in the largest repository, so descending past the header does not mint defs for unnamed lambdas.

Incidental finding while confirming node names: `nix_module_types` in `lang_specs.c` declares `"source_expression"`, which does not exist in the vendored grammar (the root node is `source_code`). `module_node_types` is not consumed anywhere, so it is inert today — but it is misleading, and it is where I first took the wrong name from. Left alone here as out of scope.

Constructs checked for over-minting and clean: `map`/`foldl'` arguments, `with` bodies, `inherit`, parenthesized lambdas. Correctly minted: `rec` attrsets, nested attrsets, `let` inside a function body, factory-returned attrsets.

The `{ pkgs, lib, ... }:` header is the near-universal idiom for Nix libraries, NixOS modules, home-manager modules, and package definitions, so the shape this fixes is the common case rather than an edge case.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test`) — see the note below
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)

The extraction suite is 260 passed, 0 failed. The full `make test` target exits
non-zero for me, but it does so on `main` as well, identically: LeakSanitizer
reports `3679 byte(s) leaked in 5 allocation(s)` from `strdup` in
`cbm_project_name_from_path` (src/pipeline/fqn.c:511), reached from the test
harness itself — `ei_index_files` (tests/test_edge_imports.c:108) and
`lrp_open_indexed` (tests/test_lsp_resolution_probe.c:125). I checked this out at
d587deab and ran it untouched to be sure: same byte count, same allocation count,
same frames. Nothing here contributes to it. Mentioning it in case it is news —
happy to send a separate PR freeing those if you want one.

### Pre-existing limitations this fix makes visible

None of these are introduced here — they live in the name resolver, which this PR does not touch. But they were previously unreachable for most files, so this change raises their exposure by roughly the same factor as the coverage gain. Flagging them rather than letting you discover them as a regression. Happy to open issues, or follow-up PRs, for whichever you want.

**1. Attrpath names are the first `attr` child only, so leaf names collide.** A definition's qualified name is `<project>.<module>.<leaf attr>` with no attrpath prefix. Two bindings with the same leaf name in different attrsets in one file collapse to a single node — the second definition, and any `CALLS` edge sourced from it, is silently dropped. Minimal case, four function bindings yielding three nodes:

```nix
{
  setA = { dupName = x: x + 1; };   # }- one node, one def lost
  setB = { dupName = y: y + 2; };   # }
  dotted.path.fn = z: z + 3;        # minted as `dotted`
  "kebab-case" = a: a;              # minted as `"kebab-case"`, quotes included
}
```

`dotted.path.fn` mints `dotted` because the resolver returns the first `attr` child of the attrpath. Quoted and interpolated attrpaths keep their delimiters, so `"then" = vals: …` mints a name of `"then"` with the quote characters in it. On the 320-file framework repository above, a conservative regex scan finds at least 54 files containing colliding leaf names, at least 275 bindings collapsed, and 73 dotted attrpaths. Attrpath-qualified names would address all three at once.

**2. Nix bindings mint no `Variable` nodes.** `nix_var_types = {"binding"}` is declared in `lang_specs.c`, but there is no Nix name resolver for a plain `binding`, so a non-function binding produces nothing. The `Variable` count was unchanged across this fix. A fix would mirror the existing function resolver — `child_by_field_name(node, "attrpath")`, then its `attr` — and would inherit the same collision caveat as (1).
