### PR TITLE
test(daemon-app): yield in the terminal-job wait like every sibling helper

### DIFF
--- a/tests/test_daemon_application.c
+++ b/tests/test_daemon_application.c
@@ -1471,6 +1471,10 @@ static bool app_wait_for_terminal_job_with_subscribers(cbm_daemon_application_t 
             cbm_daemon_application_job_subscribers(application, project) >= minimum_subscribers) {
             return true;
         }
+        /* Yield like every sibling wait helper: a sleepless spin pins a core
+         * and can starve the daemon threads it polls on scarce-CPU runners
+         * (windows-11-arm release leg, run 30305464193). */
+        cbm_usleep(1000);
     }
     return false;
 }


### PR DESCRIPTION
Release run 30305464193 failed on windows-11-arm 1/2 with `test_daemon_application.c:2671 ASSERT(terminal_with_prior_subscribers)`. Root cause: `app_wait_for_terminal_job_with_subscribers` is the only one of the eight `app_wait_for_*` helpers that busy-spins without `cbm_usleep(1000)` — the spin pins a core for up to 10s and can starve the daemon threads it polls on the 4-vCPU ARM runners. One-line fix matching the suite's own idiom; 47/47 locally. Unblocks v0.9.1-rc.1.