### PR TITLE
fix(hooks): scope pre-commit clang-tidy to staged changes (#1264)

### DIFF
--- a/Makefile.cbm
+++ b/Makefile.cbm
@@ -651,7 +651,7 @@ PP_OBJ_TSAN = $(BUILD_DIR)/tsan_preprocessor.o
 
 # ── Targets ──────────────────────────────────────────────────────
 
-.PHONY: test test-par test-repro test-foundation test-tsan test-daemon-smoke cbm cbm-with-ui frontend embed clean-c lint lint-tidy lint-cppcheck lint-format security
+.PHONY: test test-par test-repro test-foundation test-tsan test-daemon-smoke cbm cbm-with-ui frontend embed clean-c lint lint-tidy lint-tidy-diff lint-cppcheck lint-format security
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
@@ -980,6 +980,12 @@ LINT_TEST_SRCS = $(ALL_TEST_SRCS)
 lint-tidy:
 	@echo "=== clang-tidy ==="
 	@$(CLANG_TIDY) --quiet $(LINT_SRCS) -- $(CFLAGS_COMMON) $(SYSROOT_FLAG)
+
+# clang-tidy, scoped to this commit's staged changes only (scripts/lint-tidy-diff.sh).
+# The pre-commit hook runs this instead of the full lint-tidy sweep above, so a
+# clean commit is not blocked by pre-existing findings elsewhere in the tree.
+lint-tidy-diff:
+	@scripts/lint-tidy-diff.sh "$(CLANG_TIDY)" $(LINT_SRCS) -- $(CFLAGS_COMMON) $(SYSROOT_FLAG)
 
 # cppcheck: complementary analysis (config in .cppcheck)
 lint-cppcheck:

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -7,7 +7,11 @@ set -euo pipefail
 #   git config core.hooksPath scripts/hooks
 
 echo "pre-commit: running all linters in parallel..."
-make -j3 -f Makefile.cbm lint
+# clang-tidy runs diff-scoped (lint-tidy-diff, see scripts/lint-tidy-diff.sh):
+# the full lint-tidy sweep surfaces thousands of pre-existing findings that
+# have nothing to do with this commit and would block every contributor who
+# has clang-tidy on PATH. `make lint-tidy` remains available for a full audit.
+make -j3 -f Makefile.cbm lint-ci lint-tidy-diff
 
 echo "pre-commit: security audit (source-level)..."
 scripts/security-audit.sh

--- a/scripts/lint-tidy-diff.sh
+++ b/scripts/lint-tidy-diff.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# lint-tidy-diff.sh — clang-tidy scoped to the lines this commit changes.
+#
+# `make lint-tidy` (the full sweep) checks the entire LINT_SRCS tree, which
+# currently surfaces ~5,100 pre-existing findings unrelated to any given
+# commit (see Makefile.cbm's `lint-tidy` target). That is fine for a manual
+# deep audit but makes the pre-commit hook unusable: it blocks every commit,
+# including ones that touch files with zero findings on the touched lines.
+#
+# This script runs the same clang-tidy binary/config against the SAME staged
+# .c files, but passes clang-tidy's own `-line-filter` so only lines the
+# commit actually added/modified can produce a diagnostic. Pre-existing
+# findings on untouched lines — in the same file or elsewhere — are not
+# reported.
+#
+# Invoked by `make lint-tidy-diff` (scripts/hooks/pre-commit), which supplies
+# the resolved clang-tidy binary, then LINT_SRCS, then `--`, then the
+# compiler flags — the same argv shape as the `lint-tidy` target itself.
+#
+# Known limitation: only staged *.c files that are members of LINT_SRCS are
+# checked (matching the full sweep's own scope: vendored code and tests/ are
+# never clang-tidy'd). clang-tidy reports a header's diagnostics under
+# whatever path it was #include-d with, which is not reliably the same
+# string as its path in the working tree, so a commit that touches only a
+# header is not covered here even if a .c file including it also changed;
+# run `make lint-tidy` for a full pass in that case.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: lint-tidy-diff.sh <clang-tidy-bin> [LINT_SRCS...] -- [CFLAGS...]" >&2
+    exit 2
+fi
+
+CLANG_TIDY="$1"
+shift
+
+LINT_SRCS=()
+while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do
+    LINT_SRCS+=("$1")
+    shift
+done
+[ "$#" -gt 0 ] && shift # drop the `--` separator
+CFLAGS=("$@")
+
+# bash 3.2 (macOS default, see scripts/check-lsp-originality.sh) has neither
+# `mapfile` nor associative arrays — read loop + linear membership check.
+is_lint_src() {
+    local needle="$1" f
+    [ "${#LINT_SRCS[@]}" -eq 0 ] && return 1
+    for f in "${LINT_SRCS[@]}"; do
+        [ "$f" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+# Staged .c files this commit actually changed (added/copied/modified/
+# renamed — a delete has no new lines to check) that are members of
+# LINT_SRCS.
+CHANGED=()
+while IFS= read -r f; do
+    [ -n "$f" ] && is_lint_src "$f" && CHANGED+=("$f")
+done < <(git diff --cached --name-only --diff-filter=ACMR -- '*.c')
+
+if [ "${#CHANGED[@]}" -eq 0 ]; then
+    echo "lint-tidy-diff: no staged changes to a linted .c file, skipping clang-tidy"
+    exit 0
+fi
+
+# For each changed file, turn its staged hunks into a clang-tidy line-filter
+# range: `@@ -a,b +c,d @@` -> lines [c, c+d-1]. Zero-context (-U0) so a range
+# never includes untouched, pre-existing lines. Pure-deletion hunks (d == 0)
+# add no new lines and are skipped.
+LINE_FILTER='['
+FILTER_SEP=''
+TARGETS=()
+for f in "${CHANGED[@]}"; do
+    [ -f "$f" ] || continue # renamed away / not present in the working tree
+    ranges=''
+    range_sep=''
+    while IFS= read -r hunk; do
+        if [[ "$hunk" =~ ^@@\ -[0-9]+(,[0-9]+)?\ \+([0-9]+)(,([0-9]+))?\ @@ ]]; then
+            new_start="${BASH_REMATCH[2]}"
+            new_count="${BASH_REMATCH[4]:-1}"
+            [ "$new_count" -eq 0 ] && continue
+            new_end=$((new_start + new_count - 1))
+            ranges+="${range_sep}[${new_start},${new_end}]"
+            range_sep=','
+        fi
+    done < <(git diff --cached -U0 --diff-filter=ACMR -- "$f" | grep -E '^@@ ')
+    [ -z "$ranges" ] && continue
+
+    LINE_FILTER+="${FILTER_SEP}{\"name\":\"${f}\",\"lines\":[${ranges}]}"
+    FILTER_SEP=','
+    TARGETS+=("$f")
+done
+LINE_FILTER+=']'
+
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+    echo "lint-tidy-diff: staged .c changes are deletion-only, skipping clang-tidy"
+    exit 0
+fi
+
+echo "lint-tidy-diff: ${#TARGETS[@]} changed file(s), diff-scoped clang-tidy"
+"$CLANG_TIDY" --quiet "-line-filter=${LINE_FILTER}" "${TARGETS[@]}" -- "${CFLAGS[@]}"


### PR DESCRIPTION
Fixes #1264

## Problem

`scripts/hooks/pre-commit` runs `make -j3 -f Makefile.cbm lint`
unconditionally on every commit. `lint` includes `lint-tidy`, which runs
clang-tidy over the whole `LINT_SRCS` tree. On a clean `main` checkout
that surfaces ~5,100 pre-existing `error:`-level findings across 113
files (mostly `readability-magic-numbers`), unrelated to whatever the
commit touches. The hook blocks every commit for every contributor with
clang-tidy on `PATH` — reproduced on a clean checkout, one-line non-C
change.

## Fix

Add `lint-tidy-diff` (`scripts/lint-tidy-diff.sh`), a Makefile target
running the same clang-tidy binary/config, but passing clang-tidy's own
`-line-filter` so a diagnostic can only fire on lines the commit actually
added or modified (parsed from `git diff --cached -U0` hunk headers).
Pre-existing findings on untouched lines are never reported, whether in
an untouched file or an untouched line of a touched file — baseline-aware
at the line level, not just the file level.

The hook now runs `lint-ci` (unchanged: cppcheck + clang-format +
no-suppress, already CI's contract) plus `lint-tidy-diff` instead of the
full `lint` target. `make lint`, `make lint-tidy`, and `scripts/lint.sh`
are untouched, still the full-tree audit; CI (`_lint.yml` →
`scripts/lint.sh --ci`) never ran clang-tidy and is unaffected. This
follows the scoping the issue itself suggested (remediation option 2), at
line rather than file granularity.

## Verification

- Reproduced: clean checkout, `git commit -s` on a one-line
  `CONTRIBUTING.md` change, clang-tidy on `PATH` → blocked, 5,190
  pre-existing findings, commit did not happen.
- After the fix, same clang-tidy binary/config:
  - No staged `.c` changes → skipped, exit 0.
  - Clean addition to `internal/cbm/cbm.c` (one of the dirtiest files, 57
    pre-existing findings on a full-file run of the same edit) → exit 0,
    nothing reported.
  - A deliberate new finding (`return 424242;`) added to the same file →
    exit 2, reports only that one finding.
  - Header-only change (no paired `.c` change) → skipped, exit 0 (see
    Known limitation).
- `scripts/lint.sh` (cppcheck + clang-format + no-suppress) unaffected,
  still clean.

## Known limitation

clang-tidy reports a header's diagnostics under whatever path it was
`#include`-d with, not reliably its working-tree path (verified:
absolute vs. search-path-relative, depending on include style). So
`lint-tidy-diff` scopes `.c` files only; a header-only commit isn't
covered and needs `make lint-tidy`. A proper diff-to-header mapping would
be a natural follow-up, left for the maintainer to size.
