### PR TITLE
fix(graph-ui): rank Accept-Language by q instead of substring match

### DIFF
--- a/graph-ui/src/lib/i18n.test.ts
+++ b/graph-ui/src/lib/i18n.test.ts
@@ -7,6 +7,31 @@ describe("i18n", () => {
     expect(detectLanguage("de-DE,de;q=0.9")).toBe("en");
   });
 
+  it("ranks Accept-Language by q rather than by presence", () => {
+    // A bilingual visitor who prefers English but lists Chinese as a fallback.
+    expect(detectLanguage("en-US,en;q=0.9,zh;q=0.5")).toBe("en");
+    expect(detectLanguage("en,zh;q=0.1")).toBe("en");
+    // Chinese still wins when it is actually preferred.
+    expect(detectLanguage("zh;q=0.9,en;q=0.5")).toBe("zh");
+  });
+
+  it("treats q=0 as unacceptable", () => {
+    expect(detectLanguage("zh;q=0, en")).toBe("en");
+    expect(detectLanguage("zh;q=0")).toBe("en");
+  });
+
+  it("matches the language subtag, not a substring", () => {
+    expect(detectLanguage("en-GB")).toBe("en");
+    expect(detectLanguage("zh-Hant-TW")).toBe("zh");
+  });
+
+  it("honours the override and handles empty input", () => {
+    expect(detectLanguage("zh-CN", "en")).toBe("en");
+    expect(detectLanguage("en-US", "zh")).toBe("zh");
+    expect(detectLanguage(null)).toBe("en");
+    expect(detectLanguage("")).toBe("en");
+  });
+
   it("keeps UI chrome messages in the catalog", () => {
     expect(messages.zh.tabs.projects).toBe("项目");
     expect(messages.zh.index.newIndex).toBe("新建索引");

--- a/graph-ui/src/lib/i18n.ts
+++ b/graph-ui/src/lib/i18n.ts
@@ -152,8 +152,22 @@ export type UiMessages = (typeof messages)[UiLanguage];
 export function detectLanguage(acceptLanguage?: string | null, override?: string | null): UiLanguage {
   if (override === "zh" || override === "en") return override;
   if (!acceptLanguage) return "en";
-  const normalized = acceptLanguage.toLowerCase();
-  return normalized.includes("zh-cn") || normalized.includes("zh") ? "zh" : "en";
+
+  // Ranked by q, not by whether "zh" appears anywhere. A substring test served
+  // Chinese for "en-US,en;q=0.9,zh;q=0.5", where English is clearly preferred,
+  // and for "zh;q=0, en", where q=0 means Chinese is unacceptable.
+  const best = acceptLanguage
+    .split(",")
+    .map((part) => {
+      const [tag, ...params] = part.trim().split(";");
+      const q = params.map((p) => /^\s*q\s*=\s*([\d.]+)\s*$/i.exec(p)).find(Boolean);
+      return { tag: tag.trim().toLowerCase(), q: q ? Number(q[1]) : 1 };
+    })
+    .filter(({ tag, q }) => tag && Number.isFinite(q) && q > 0)
+    .sort((a, b) => b.q - a.q)
+    .find(({ tag }) => tag.split("-")[0] === "zh" || tag.split("-")[0] === "en");
+
+  return best?.tag.startsWith("zh") ? "zh" : "en";
 }
 
 let cachedLanguage: UiLanguage = "en";


### PR DESCRIPTION
## What does this PR do?

`detectLanguage` tested whether `"zh"` appeared anywhere in the header, so any visitor whose `Accept-Language` mentions Chinese got the Chinese UI regardless of preference.

| Header | Before | Expected |
|---|---|---|
| `en-US,en;q=0.9,zh;q=0.5` | `zh` | `en` |
| `zh;q=0, en` | `zh` | `en` |

The first is the common case: a bilingual visitor who prefers English and lists Chinese as a fallback. That is a normal Chrome language configuration, and it currently produces a Chinese interface for someone who asked for English.

The second sets `q=0`, which RFC 7231 defines as *not acceptable* — the header explicitly excludes Chinese and it was served anyway.

Now parses `q`, drops `q=0`, sorts descending, and matches the primary subtag rather than a substring. Chinese still wins whenever it is actually preferred, and the two existing assertions are unchanged and still pass.

Reproduce-first: both rows above are in the new tests and fail against the previous implementation.

## Checklist

- [x] Every commit is signed off (`git commit -s`)
- [ ] Tests pass locally (`make -f Makefile.cbm test`)
- [ ] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)

The two unticked items are the C toolchain, which this change does not touch and which I have not set up. For `graph-ui` I ran its own suite:

```
npx vitest run   9 files, 38 tests passed
npx tsc -b       clean
```

Happy to run the C targets too if you would like that before merging.