### PR TITLE
fix(build): force LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Shell scripts must stay LF: with git's Windows default (core.autocrlf=true)
+# they check out as CRLF and bash inside the build containers rejects them.
+*.sh text eol=lf
+
 # Vendored tree-sitter grammars — machine-generated, hide from stats and diffs
 internal/cbm/vendored/grammars/**/parser.c  linguist-generated=true diff=false
 internal/cbm/vendored/grammars/**/scanner.c linguist-generated=true diff=false


### PR DESCRIPTION
On Windows, git's default `core.autocrlf=true` checks out every `.sh` with CRLF endings. The Docker cross-build then fails at `clean-c`: bash cannot source `scripts/path-safety.sh` (`$'\r': command not found`), and the same applies to every script under `scripts/` and `tests/`.

Declaring `*.sh text eol=lf` in `.gitattributes` keeps checkouts LF on all platforms regardless of local git config. One-line fix, no renormalization needed — the index already stores LF.

Hit today on a fresh Windows clone while building from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)