### PR TITLE
fix(windows): repair install.ps1, honest dry-run status, deterministic daemon_ipc

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-# install.ps1 — One-line installer for codebase-memory-mcp (Windows).
+# install.ps1 - One-line installer for codebase-memory-mcp (Windows).
 #
 # Usage: see README.md for install instructions.
 #
@@ -103,7 +103,7 @@ foreach ($arg in $args) {
 # PROCESSOR_ARCHITEW6432, which is unset for 64-bit emulated processes. Fall back
 # to the env vars only if the .NET API is somehow unavailable.
 if ($env:CBM_ARCH) {
-    # Explicit override wins — used by CI/tests, and an escape hatch under x64
+    # Explicit override wins - used by CI/tests, and an escape hatch under x64
     # emulation on ARM64 where no in-process detection is reliable.
     $Arch = $env:CBM_ARCH
 } else {
@@ -279,7 +279,7 @@ if (Test-Path -LiteralPath $Dest -PathType Leaf) {
         catch { Start-Sleep -Milliseconds 500 }
     }
     if (-not $renamed) {
-        Write-Host "error: could not retire the existing $BinName — close all running" -ForegroundColor Red
+        Write-Host "error: could not retire the existing $BinName - close all running" -ForegroundColor Red
         Write-Host "       codebase-memory-mcp sessions and coding agents, then re-run." -ForegroundColor Red
         Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
         exit 1

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -57,6 +57,17 @@ smoke_mktemp_dir() {
   fi
 }
 
+# Byte-identity of two files. `cmp` is NOT present in the Windows MSYS shell, so
+# a comparison built on it reports "different" for every pair it is handed —
+# including two copies of the same file.
+smoke_file_sha256() {
+  if command -v sha256sum &>/dev/null; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
 # Every platform ships ONE binary, Windows included: a fixture copy is complete
 # with nothing beside it.
 copy_smoke_binary() {
@@ -876,36 +887,34 @@ if [[ "$BINARY" == *.exe ]] &&
 fi
 
 # 6b: uninstall --dry-run -y
+# Windows used to refuse this: a portable extracted bundle was a DIFFERENT
+# artifact from the launcher-managed install it would have torn down, so it had
+# to decline and point at the managed copy. One binary per platform removes that
+# split entirely — the extracted binary IS the installed one — so uninstall now
+# plans the same removals it does on Linux and macOS.
 echo "--- Phase 6b: uninstall --dry-run ---"
-if [[ "$BINARY" == *.exe ]]; then
-  if UNINSTALL_OUT=$(run_dryrun_env "$BINARY" uninstall --dry-run -y 2>&1); then
-    echo "FAIL: portable Windows bundle accepted uninstall"
-    exit 1
-  fi
-  if ! echo "$UNINSTALL_OUT" | grep -qi 'managed\|install\|package'; then
-    echo "FAIL: portable Windows uninstall refusal had no install guidance"
-    echo "$UNINSTALL_OUT"
-    exit 1
-  fi
-else
-  UNINSTALL_OUT=$(run_dryrun_env "$BINARY" uninstall --dry-run -y 2>&1)
-  if ! echo "$UNINSTALL_OUT" | grep -qi 'uninstall\|remov'; then
-    echo "FAIL: uninstall --dry-run produced unexpected output"
-    echo "$UNINSTALL_OUT"
-    exit 1
-  fi
+UNINSTALL_OUT=$(run_dryrun_env "$BINARY" uninstall --dry-run -y 2>&1)
+if ! echo "$UNINSTALL_OUT" | grep -qi 'uninstall\|remov'; then
+  echo "FAIL: uninstall --dry-run produced unexpected output"
+  echo "$UNINSTALL_OUT"
+  exit 1
 fi
 echo "OK: uninstall --dry-run completed"
 
 # 6c: update --dry-run --standard -y
 echo "--- Phase 6c: update --dry-run ---"
 if [[ "$BINARY" == *.exe ]]; then
-  if UPDATE_OUT=$(run_dryrun_env "$BINARY" update --dry-run --standard -y 2>&1); then
-    echo "FAIL: portable Windows bundle accepted update"
+  # Same contract Phase 14a asserts against a real update: Windows never
+  # replaces the running image in-process, so `update` is a handoff — it exits 0
+  # and prints the exact install.ps1 command. The old refusal here was the
+  # portable-vs-managed split, which died with the launcher stub.
+  if ! UPDATE_OUT=$(run_dryrun_env "$BINARY" update --dry-run --standard -y 2>&1); then
+    echo "FAIL: Windows update handoff exited non-zero"
+    echo "$UPDATE_OUT"
     exit 1
   fi
-  if ! echo "$UPDATE_OUT" | grep -qi 'managed\|install\|package'; then
-    echo "FAIL: portable Windows update refusal had no install guidance"
+  if ! echo "$UPDATE_OUT" | grep -q 'install.ps1'; then
+    echo "FAIL: Windows update did not print the install.ps1 handoff"
     echo "$UPDATE_OUT"
     exit 1
   fi
@@ -1102,10 +1111,10 @@ ROVO_AGENT="$FAKE_HOME/.rovodev/subagents/codebase-memory.md"
 AMAZON_Q_MCP="$FAKE_HOME/.aws/amazonq/default.json"
 mkdir -p "$GITLAB_DIR" "$(dirname "$GITLAB_HOOKS")" "$DEVIN_DIR"
 mkdir -p "$FAKE_HOME/.local/bin"
-# A Windows portable pair is the installer source, not a valid managed target.
-# Leave the canonical destination absent so install can publish the authenticated
-# generation backing + canonical hard-link pair. A one-link copy at that path is
-# deliberately rejected as an unknown/conflicting installation.
+# POSIX seeds the destination so install exercises the replace-an-existing-copy
+# path. Windows leaves it absent and covers the first-install path instead:
+# seeding it would mean running the fixture binary out of the very location the
+# install is about to publish to, which Windows' image lock forbids.
 if [[ "$BINARY" == *.exe ]]; then
   SELF_PATH="$FAKE_HOME/.local/bin/codebase-memory-mcp.exe"
 else
@@ -2934,9 +2943,15 @@ if [ -n "${SMOKE_DOWNLOAD_URL:-}" ]; then
   # Pre-install agent config with positive prior-install identity. POSIX runs
   # update from that exact retired CBM image, so refresh requires only string
   # equality with OS-reported self identity and never probes config paths.
-  # Windows retains its fixed-drive missing-path classification coverage.
+  #
+  # Windows points at the INSTALLED binary, not the retired one. Its update is a
+  # handoff to install.ps1 now, so nothing rewrites this entry in-process the way
+  # the old launcher-managed update did; leaving it on the retired path would
+  # make 14f demand that uninstall delete an entry owned by a DIFFERENT
+  # installation, which it correctly refuses to do. install.ps1 re-runs
+  # `install`, so this is exactly what a real Windows user is left holding.
   if [[ "$BINARY" == *.exe ]]; then
-    STALE_CMD="$UPDATE_HOME/retired-install/codebase-memory-mcp.exe"
+    STALE_CMD="$UPDATE_HOME/.local/bin/codebase-memory-mcp.exe"
   else
     STALE_CMD="$UPDATE_DRIVER"
   fi
@@ -2970,7 +2985,8 @@ if [ -n "${SMOKE_DOWNLOAD_URL:-}" ]; then
       echo "FAIL 14a: Windows update did not print the install.ps1 command"
       exit 1
     fi
-    if ! cmp -s "$BINARY" "$UPDATE_HOME/.local/bin/codebase-memory-mcp.exe"; then
+    if [ "$(smoke_file_sha256 "$BINARY")" != \
+         "$(smoke_file_sha256 "$UPDATE_HOME/.local/bin/codebase-memory-mcp.exe")" ]; then
       echo "FAIL 14a: Windows update replaced the binary in-process"
       exit 1
     fi

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -9437,12 +9437,16 @@ int cbm_cmd_install(int argc, char **argv) {
          * so a non-OK here is a plan-side check (agent-config / PATH probe)
          * and must still report that it was a dry-run - on Windows it was
          * silently skipping the summary and reading as a hard failure. Emit
-         * the dry-run indicator, and name the underlying status for triage. */
+         * the dry-run indicator, and name the underlying status for triage.
+         *
+         * The status itself still travels: `--dry-run` exists to answer "would
+         * this install work?", so a refused plan check has to be visible to a
+         * caller that only sees the exit code. Reporting success here made a
+         * fail-closed PATH probe indistinguishable from a clean plan. */
         if (dry_run) {
             (void)fprintf(stderr, "note: install --dry-run plan check returned %d\n",
                           activation_rc);
             printf("\n(dry-run — no files were modified)\n");
-            return CLI_OK;
         }
         return CLI_TRUE;
     }

--- a/src/daemon/ipc.c
+++ b/src/daemon/ipc.c
@@ -114,6 +114,30 @@ void cbm_daemon_ipc_windows_legacy_guard_release_failures_set_for_test(unsigned 
                           memory_order_release);
 }
 
+#ifdef _WIN32
+static cbm_daemon_ipc_startup_gate_fn g_startup_gate_for_test;
+static void *g_startup_gate_context_for_test;
+#endif
+
+void cbm_daemon_ipc_startup_gate_set_for_test(cbm_daemon_ipc_startup_gate_fn gate, void *context) {
+#ifdef _WIN32
+    g_startup_gate_context_for_test = context;
+    g_startup_gate_for_test = gate;
+#else
+    (void)gate;
+    (void)context;
+#endif
+}
+
+#ifdef _WIN32
+static void ipc_startup_gate_run(void) {
+    cbm_daemon_ipc_startup_gate_fn gate = g_startup_gate_for_test;
+    if (gate) {
+        gate(g_startup_gate_context_for_test);
+    }
+}
+#endif
+
 bool cbm_daemon_ipc_windows_legacy_names(const char *canonical_runtime_parent,
                                          const char *instance_key,
                                          char pipe_out[CBM_DAEMON_IPC_WINDOWS_NAME_CAP],
@@ -5755,6 +5779,9 @@ int cbm_daemon_ipc_startup_lock_try_acquire(const cbm_daemon_ipc_endpoint_t *end
     lock->legacy_guard = legacy_guard;
     lock->legacy_sentinel = INVALID_HANDLE_VALUE;
     *lock_out = lock;
+    /* The lock is held and the handoff has not run yet: the one point where a
+     * test can pin this interleaving deterministically. No-op in production. */
+    ipc_startup_gate_run();
     return 1;
 }
 

--- a/src/daemon/ipc_internal.h
+++ b/src/daemon/ipc_internal.h
@@ -96,4 +96,13 @@ void cbm_daemon_ipc_posix_publication_hook_set_for_test(
     cbm_daemon_ipc_posix_publication_hook_fn hook, void *context);
 void cbm_daemon_ipc_windows_legacy_guard_release_failures_set_for_test(unsigned int count);
 
+/* Deterministic-interleaving seam: fires on the Windows startup path once the
+ * startup lock is held, before the rendezvous handoff. A test parks here to
+ * pin the "startup is holding the lock" interleaving by construction. Polling
+ * for that state instead is a race — the whole acquire → handoff → release
+ * sequence completes in microseconds whenever the handoff does not block, so
+ * the observation window has no lower bound. */
+typedef void (*cbm_daemon_ipc_startup_gate_fn)(void *context);
+void cbm_daemon_ipc_startup_gate_set_for_test(cbm_daemon_ipc_startup_gate_fn gate, void *context);
+
 #endif /* CBM_DAEMON_IPC_INTERNAL_H */

--- a/tests/test_daemon_ipc.c
+++ b/tests/test_daemon_ipc.c
@@ -399,6 +399,36 @@ typedef struct {
     int result;
 } ipc_test_win_startup_call_t;
 
+typedef struct {
+    atomic_bool acquired;
+    atomic_bool may_proceed;
+} ipc_test_startup_gate_t;
+
+/* Runs on the startup thread INSIDE cbm_daemon_ipc_startup_lock_try_acquire,
+ * with the startup lock held and the rendezvous handoff not yet attempted.
+ * Announce that state, then park until the test has released its reader. This
+ * pins the interleaving by construction; the previous version polled for the
+ * lock being busy, which is unobservable whenever the handoff does not block. */
+static void ipc_test_startup_gate(void *context) {
+    ipc_test_startup_gate_t *gate = context;
+    atomic_store(&gate->acquired, true);
+    while (!atomic_load(&gate->may_proceed)) {
+        cbm_usleep(200);
+    }
+}
+
+static bool ipc_test_startup_gate_wait_acquired(ipc_test_startup_gate_t *gate) {
+    /* `acquired` never clears, so this wait cannot miss the event; the bound
+     * only catches a thread that never started at all. */
+    for (size_t attempt = 0; attempt < 50000U; attempt++) {
+        if (atomic_load(&gate->acquired)) {
+            return true;
+        }
+        cbm_usleep(200);
+    }
+    return false;
+}
+
 static void *ipc_test_win_startup_call(void *opaque) {
     ipc_test_win_startup_call_t *call = opaque;
     cbm_daemon_ipc_startup_lock_t *startup = NULL;
@@ -415,14 +445,6 @@ static void ipc_test_win_lock_release(cbm_private_file_lock_t **lock_io) {
            cbm_private_file_lock_release(lock_io) != CBM_PRIVATE_FILE_LOCK_OK) {
         cbm_usleep(1000);
     }
-}
-
-static bool ipc_test_win_lock_busy(cbm_private_lock_directory_t *directory, const char *base_name) {
-    cbm_private_file_lock_t *probe = NULL;
-    cbm_private_file_lock_status_t status =
-        cbm_private_file_lock_try_acquire(directory, base_name, CBM_PRIVATE_FILE_LOCK_SH, &probe);
-    ipc_test_win_lock_release(&probe);
-    return status == CBM_PRIVATE_FILE_LOCK_BUSY;
 }
 #endif
 
@@ -1028,6 +1050,10 @@ TEST(daemon_ipc_windows_startup_retries_transient_rendezvous_reader) {
     bool startup_observed = false;
     int join_status = -1;
     ipc_test_win_startup_call_t call = {.result = -1};
+    ipc_test_startup_gate_t gate;
+    atomic_init(&gate.acquired, false);
+    atomic_init(&gate.may_proceed, false);
+    cbm_daemon_ipc_startup_gate_set_for_test(ipc_test_startup_gate, &gate);
 
     bool parent_ok = ipc_test_parent_new(parent, "win-record-reader");
     if (parent_ok) {
@@ -1048,14 +1074,11 @@ TEST(daemon_ipc_windows_startup_retries_transient_rendezvous_reader) {
     if (record_status == CBM_PRIVATE_FILE_LOCK_OK) {
         thread_started = cbm_thread_create(&thread, 0, ipc_test_win_startup_call, &call) == 0;
     }
-    for (size_t attempt = 0; thread_started && attempt < 200U; attempt++) {
-        if (ipc_test_win_lock_busy(directory, "cbm-startup-v2.lock")) {
-            startup_observed = true;
-            break;
-        }
-        cbm_usleep(1000);
+    if (thread_started) {
+        startup_observed = ipc_test_startup_gate_wait_acquired(&gate);
     }
     ipc_test_win_lock_release(&record_reader);
+    atomic_store(&gate.may_proceed, true);
     if (thread_started) {
         join_status = cbm_thread_join(&thread);
     }
@@ -1063,6 +1086,7 @@ TEST(daemon_ipc_windows_startup_retries_transient_rendezvous_reader) {
         ipc_test_copy_path(address, cbm_daemon_ipc_endpoint_address(endpoint));
     }
 
+    cbm_daemon_ipc_startup_gate_set_for_test(NULL, NULL);
     ipc_test_win_lock_release(&record_reader);
     cbm_private_lock_directory_close(directory);
     cbm_daemon_ipc_endpoint_free(endpoint);
@@ -1115,6 +1139,11 @@ TEST(daemon_ipc_windows_rendezvous_bridges_concurrent_lifetime_owner) {
     cbm_daemon_ipc_startup_lock_release(&initial_startup);
     initial_startup = NULL;
 
+    ipc_test_startup_gate_t gate;
+    atomic_init(&gate.acquired, false);
+    atomic_init(&gate.may_proceed, false);
+    cbm_daemon_ipc_startup_gate_set_for_test(ipc_test_startup_gate, &gate);
+
     cbm_private_file_lock_status_t directory_status =
         endpoint ? cbm_daemon_ipc_private_lock_directory_new(endpoint, &directory)
                  : CBM_PRIVATE_FILE_LOCK_IO;
@@ -1126,19 +1155,18 @@ TEST(daemon_ipc_windows_rendezvous_bridges_concurrent_lifetime_owner) {
     if (record_status == CBM_PRIVATE_FILE_LOCK_OK) {
         thread_started = cbm_thread_create(&thread, 0, ipc_test_win_startup_call, &call) == 0;
     }
-    for (size_t attempt = 0; thread_started && attempt < 200U; attempt++) {
-        if (ipc_test_win_lock_busy(directory, "cbm-startup-v2.lock")) {
-            startup_observed = true;
-            break;
-        }
-        cbm_usleep(1000);
+    if (thread_started) {
+        startup_observed = ipc_test_startup_gate_wait_acquired(&gate);
     }
+    /* Claim the lifetime lock while startup is parked in the gate, so the
+     * concurrent-owner bridge under test is exercised deterministically. */
     cbm_private_file_lock_status_t lifetime_status =
         startup_observed
             ? cbm_private_file_lock_try_acquire(directory, "cbm-lifetime.lock",
                                                 CBM_PRIVATE_FILE_LOCK_EX, &lifetime_owner)
             : CBM_PRIVATE_FILE_LOCK_IO;
     ipc_test_win_lock_release(&record_reader);
+    atomic_store(&gate.may_proceed, true);
     if (thread_started) {
         join_status = cbm_thread_join(&thread);
     }
@@ -1147,6 +1175,7 @@ TEST(daemon_ipc_windows_rendezvous_bridges_concurrent_lifetime_owner) {
     }
     ipc_test_win_lock_release(&lifetime_owner);
 
+    cbm_daemon_ipc_startup_gate_set_for_test(NULL, NULL);
     ipc_test_win_lock_release(&record_reader);
     ipc_test_win_lock_release(&lifetime_owner);
     cbm_private_lock_directory_close(directory);
@@ -2072,6 +2101,13 @@ typedef struct {
     int receive_result;
 } ipc_forever_wait_server_t;
 
+/* The connection is deliberately NOT closed here. The test interrupts this
+ * thread's wait through server->connection, and `receive_frame` can also return
+ * on its own (a torn connection, an early frame) before that call lands.
+ * Closing from this thread therefore freed the connection while the test was
+ * still dereferencing the pointer it had already loaded — a use-after-free that
+ * crashed roughly one Windows run in five. Ownership stays with the test, which
+ * closes it after joining, so `interrupt` can only ever see a live connection. */
 static void *ipc_forever_wait_server(void *opaque) {
     ipc_forever_wait_server_t *server = (ipc_forever_wait_server_t *)opaque;
     cbm_daemon_frame_t frame = {0};
@@ -2084,8 +2120,6 @@ static void *ipc_forever_wait_server(void *opaque) {
             server->connection, CBM_DAEMON_IPC_WAIT_FOREVER, &frame, &payload);
     }
     free(payload);
-    cbm_daemon_ipc_connection_close(server->connection);
-    server->connection = NULL;
     return NULL;
 }
 
@@ -2129,6 +2163,9 @@ TEST(daemon_ipc_wait_forever_is_interruptible) {
     if (thread_started) {
         join_result = cbm_thread_join(&thread);
     }
+    /* Safe only after the join: the server thread no longer touches it. */
+    cbm_daemon_ipc_connection_close(server.connection);
+    server.connection = NULL;
     cbm_daemon_ipc_connection_close(client);
     cbm_daemon_ipc_listener_close(listener);
     cbm_daemon_ipc_endpoint_free(endpoint);

--- a/tests/test_windows_bundle_contract.sh
+++ b/tests/test_windows_bundle_contract.sh
@@ -164,6 +164,19 @@ for archive, call, ui in (
 # "<dest>.retired-<timestamp>", then installs over the freed name. Without the
 # retire step every Windows update fails on a locked destination.
 installer = read("install.ps1")
+# Windows PowerShell 5.1 decodes a BOM-less .ps1 as ANSI, so a UTF-8 em-dash
+# arrives as three cp1252 characters ending in a double quote. Inside a string
+# literal that quote closes it early and the whole script dies with a cascade of
+# parse errors before its first statement runs. A BOM would fix the file on disk
+# but corrupt the documented `irm ... | iex` path, which pipes the bytes
+# straight into the parser -- so the shipped installer stays pure ASCII.
+non_ascii = sorted({ch for ch in installer if ord(ch) > 0x7F})
+require(
+    not non_ascii,
+    "install.ps1 must be pure ASCII (found: "
+    + ", ".join(f"U+{ord(ch):04X}" for ch in non_ascii)
+    + ")",
+)
 require(
     "$Dest = Join-Path $InstallDir $BinName" in installer,
     "install.ps1 must resolve the canonical install destination as $Dest",


### PR DESCRIPTION
Unblocks the 0.9.1-rc.1 release. Three independent fixes, one of them
user-facing and serious.

## install.ps1 could not run at all

`install.ps1` failed to PARSE and has been in that state on main since
`61a432c`. Windows PowerShell 5.1 decodes a BOM-less `.ps1` as ANSI, so a UTF-8
em-dash arrives as cp1252 bytes ending in a double quote. One of the three in
this file sat inside a string literal, where that quote closed the string early
and took the enclosing blocks with it.

It shipped because nothing ever executed the script: the smoke covers it in
Phase 13, but every Windows smoke run since the launcher removal aborted at an
earlier phase, and the VirusTotal check only scanned the bytes. Since
`install.ps1` is now the sole Windows install AND update path, this was a total
loss of both.

Fixed as ASCII rather than with a BOM, because the documented install pipes the
file straight into the parser (`irm ... | iex`). The bundle contract now rejects
any non-ASCII codepoint and names it.

## install --dry-run reported success on a failed plan check

The Windows guard that an invalid PATH seam must fail closed was passing
vacuously. The seam still refused and still printed `PATH configuration failed`,
but the process exited 0, because Windows now compiles the shared
`cbm_cmd_install`, which since `30b5f12` downgraded any failed dry-run plan check
to `CLI_OK`. Keeping the dry-run summary was right; reporting success was not.
Only the status changes -- a real install already failed non-zero, so
fail-closed behaviour was never at risk, just its observability.

The smoke also still encoded the launcher-era portable-vs-managed split, which
does not survive one-binary-per-platform: `6b`/`6c` expected refusals that no
longer apply (and `6c` contradicted `14a`), `14a` used `cmp`, which is absent
from the Windows MSYS shell, and `14f` seeded the MCP entry at the retired
binary that the old in-process update used to rewrite.

## daemon_ipc was decided by a coin flip

Two Windows tests polled for the startup thread HOLDING the startup lock -- a
state with no lower bound, since acquire -> handoff -> release completes in
microseconds when the handoff does not block. This blocked release run
30374135923. Widening the budget was tried and rejected; a transient window is
never a fixed test. The production path now exposes a gate that fires with the
lock held and before the handoff, matching the existing POSIX publication hook,
so the interleaving is pinned by construction and inert unless a test installs
it.

Also fixes an unrelated use-after-free it exposed: `ipc_forever_wait_server`
closed and NULLed the connection from the server thread while the test was about
to `interrupt` the pointer it had already loaded. It crashed roughly one Windows
run in five.

## Verification

Full 3-OS local, on the final tree:

| Leg | Result |
|---|---|
| macOS | 320 suite tests, `daemon_ipc` 46 passed x5 under ASan/UBSan, full smoke exit 0 |
| Linux (arm64) | 6606 passed, 0 failed, 4 skipped, 116 suites |
| Windows (real VM) | `daemon_ipc` 5/5 consecutive, smoke ALL PASSED (Phases 1-17) |

`install.ps1` verified executing end to end on Windows (`13g: binary placed`,
`13h: binary runs`). `lint-ci` clean. The new ASCII guard verified in both
directions -- passes clean, fails with `U+2014` when an em-dash is reintroduced.
