### PR TITLE
test(smoke): retire the Windows Phase 14 missing-executable requirement

### DIFF
--- a/tests/test_smoke_fixture_contract.sh
+++ b/tests/test_smoke_fixture_contract.sh
@@ -334,9 +334,23 @@ require(
     and 'STALE_CMD="$UPDATE_DRIVER"' in smoke_test,
     "POSIX Phase 14 must refresh from positive running-image identity without probing config paths",
 )
+# This used to pin the retired path so Windows Phase 14 carried a config entry
+# naming a missing executable. Two things retired that intent. The fixture now
+# COPIES a binary to the retired path, so it stopped being missing regardless of
+# what this string says -- the requirement was only ever checking the string,
+# never the property. And Windows update is a handoff to install.ps1 now, so
+# nothing rewrites this entry in-process the way the launcher-managed update
+# did: an entry naming a foreign path simply survives to uninstall, which
+# correctly refuses to remove a config entry owned by a DIFFERENT installation,
+# and 14f would then be demanding the one thing uninstall must never do.
+#
+# The missing-executable classification lives on in named unit tests instead of
+# here: cli_editor_mcp_preserves_unrecorded_posix_absolute_entries_without_probe
+# and cli_editor_mcp_preserves_unsafe_windows_drive_probe (tests/test_cli.c),
+# the latter covering the Windows missing-drive case specifically.
 require(
-    'STALE_CMD="$UPDATE_HOME/retired-install/codebase-memory-mcp.exe"' in smoke_test,
-    "Windows Phase 14 must test a literal missing executable, not an ambiguous extensionless command",
+    'STALE_CMD="$UPDATE_HOME/.local/bin/codebase-memory-mcp.exe"' in smoke_test,
+    "Windows Phase 14 must seed the MCP command at the binary uninstall will own",
 )
 for changed_path in (
     "install\\.(sh|ps1)",


### PR DESCRIPTION
Release run 30384603265 failed **all 30 test jobs** -- Windows, macOS and Linux
alike -- from a single stale contract requirement. `test_smoke_fixture_contract.sh`
runs as step zero of every test leg, so one violation reddens the whole matrix.

The contract pinned a literal string so Windows Phase 14 would carry an MCP entry
naming a missing executable. Because it matched only the STRING and never the
property, it kept passing after the property was gone -- twice over:

* the fixture now **copies a binary** to the retired path (added with the
  launcher removal), so that path stopped being missing regardless of the string
* Windows update is a **handoff to install.ps1**, so nothing rewrites the entry
  in-process the way the launcher-managed update did

An entry naming a foreign path therefore survives to uninstall, which correctly
refuses to remove a config entry owned by a *different* installation -- making
Phase 14f assert precisely the removal uninstall must never perform.

The requirement now pins the installed binary, which is what `install.ps1`
leaves a real Windows user holding.

**No coverage is dropped.** The missing-executable classification moves to named
unit tests rather than this fixture:
`cli_editor_mcp_preserves_unrecorded_posix_absolute_entries_without_probe` and
`cli_editor_mcp_preserves_unsafe_windows_drive_probe` (the latter covering the
Windows missing-drive case specifically).

## Verification

All 10 shell contract tests `scripts/test.sh` runs pass locally:

```
test_build_dir_safety                 PASS   test_soak_daemon_recovery_contract  PASS
test_makefile_ts_runtime_dependencies PASS   test_ui_dev_proxy_security          PASS
test_parallel_harness_contract        PASS   test_venue_parity_contract          PASS
test_security_strings_allowlist       PASS   test_vm_worktree_manifest           PASS
test_smoke_fixture_contract           PASS   test_windows_bundle_contract        PASS
```

Root cause confirmed identical on a macOS job and a Linux job from the failed
run, not inferred from the Linux one alone.
