### PR TITLE
fix(extract): derive unique names for GoogleTest macros to prevent same-file node collisions (#1266)

### DIFF
--- a/internal/cbm/extract_defs.c
+++ b/internal/cbm/extract_defs.c
@@ -3196,6 +3196,54 @@ static char *go_receiver_type_name(CBMArena *a, TSNode recv, const char *source)
     return NULL;
 }
 
+/* C++/CUDA: true when name is a GoogleTest test-definition macro whose
+ * invocations parse as function definitions with bare-identifier parameters.
+ * Multiple such macros in one file all share the extracted name (e.g. "TEST"),
+ * causing qualified-name collisions and node loss (#1266). */
+static bool is_cpp_test_macro(const char *name) {
+    return strcmp(name, "TEST") == 0 || strcmp(name, "TEST_F") == 0 ||
+           strcmp(name, "TEST_P") == 0 || strcmp(name, "TYPED_TEST") == 0 ||
+           strcmp(name, "TYPED_TEST_P") == 0;
+}
+
+/* Compose a unique name from a GoogleTest-style macro invocation by appending
+ * the macro arguments: TEST(Suite, Case) -> "TEST_Suite_Case".
+ * Returns an arena-allocated string, or NULL when the parameters cannot be
+ * resolved (caller keeps the original name in that case). */
+static char *resolve_cpp_test_macro_name(CBMArena *a, const char *macro, TSNode node,
+                                         const char *source) {
+    TSNode params = ts_node_child_by_field_name(node, TS_FIELD("parameters"));
+    if (ts_node_is_null(params)) {
+        params = find_c_params(node);
+    }
+    if (ts_node_is_null(params)) {
+        return NULL;
+    }
+
+    const char *args[2] = {NULL, NULL};
+    int count = 0;
+    uint32_t nc = ts_node_named_child_count(params);
+    for (uint32_t i = 0; i < nc && count < 2; i++) {
+        TSNode child = ts_node_named_child(params, i);
+        if (ts_node_is_null(child)) {
+            continue;
+        }
+        TSNode type_node = ts_node_child_by_field_name(child, TS_FIELD("type"));
+        char *text = cbm_node_text(a, ts_node_is_null(type_node) ? child : type_node, source);
+        if (text && text[0]) {
+            args[count++] = text;
+        }
+    }
+
+    if (count == 2) {
+        return cbm_arena_sprintf(a, "%s_%s_%s", macro, args[0], args[1]);
+    }
+    if (count == 1) {
+        return cbm_arena_sprintf(a, "%s_%s", macro, args[0]);
+    }
+    return NULL;
+}
+
 static void extract_func_def(CBMExtractCtx *ctx, TSNode node, const CBMLangSpec *spec) {
     CBMArena *a = ctx->arena;
 
@@ -3215,6 +3263,20 @@ static void extract_func_def(CBMExtractCtx *ctx, TSNode node, const CBMLangSpec 
     // any dot-prefixed Make target.
     if (ctx->language == CBM_LANG_MAKEFILE && name[0] == '.') {
         return;
+    }
+
+    /* C++/CUDA: GoogleTest macros (TEST, TEST_F, TEST_P, ...) parse as
+     * function definitions whose name resolves to the bare macro identifier.
+     * Multiple test cases per file collide on qualified name; derive a unique
+     * name from the macro arguments so each gets its own graph node (#1266). */
+    bool is_gtest = false;
+    if ((ctx->language == CBM_LANG_CPP || ctx->language == CBM_LANG_CUDA) &&
+        is_cpp_test_macro(name)) {
+        char *gtest_name = resolve_cpp_test_macro_name(a, name, node, ctx->source);
+        if (gtest_name) {
+            name = gtest_name;
+            is_gtest = true;
+        }
     }
 
     TSNode func_node = unwrap_template_inner(node, ctx->language);
@@ -3342,6 +3404,11 @@ static void extract_func_def(CBMExtractCtx *ctx, TSNode node, const CBMLangSpec 
     if (ctx->language == CBM_LANG_RUST) {
         def.qualified_name = rust_cfg_qualified_name(a, def.qualified_name, def.decorators);
         def.is_test = rust_def_is_test(def.decorators);
+    }
+
+    // C++/CUDA: GoogleTest macros are test functions (#1266).
+    if (is_gtest) {
+        def.is_test = true;
     }
 
     // Docstring

--- a/tests/test_extraction.c
+++ b/tests/test_extraction.c
@@ -1285,6 +1285,41 @@ TEST(cpp_function) {
     PASS();
 }
 
+/* #1266: GoogleTest TEST() macros with the same name collapse into a single
+ * node when multiple tests share a file. Each must mint a distinct Function
+ * node whose name encodes the suite and case arguments. */
+TEST(cpp_gtest_same_name_collision_issue1266) {
+    CBMFileResult *r = extract(
+        "namespace demo { int assembleWidget(int s) { return s * 2; } }\n"
+        "TEST(WidgetSuite, DoublesSmallSize) { demo::assembleWidget(1); }\n"
+        "TEST(WidgetSuite, DoublesZero) { demo::assembleWidget(0); }\n"
+        "TEST(WidgetSuite, DoublesLargeSize) {\n"
+        "  demo::assembleWidget(1000);\n"
+        "}\n",
+        CBM_LANG_CPP, "t", "direct_test.cpp");
+    ASSERT_NOT_NULL(r);
+    ASSERT(has_def(r, "Function", "TEST_WidgetSuite_DoublesSmallSize"));
+    ASSERT(has_def(r, "Function", "TEST_WidgetSuite_DoublesZero"));
+    ASSERT(has_def(r, "Function", "TEST_WidgetSuite_DoublesLargeSize"));
+    ASSERT(!has_def(r, "Function", "TEST"));
+    cbm_free_result(r);
+    PASS();
+}
+
+/* #1266: TEST_F fixture macro also produces unique names. */
+TEST(cpp_gtest_f_unique_name_issue1266) {
+    CBMFileResult *r = extract(
+        "TEST_F(MyFixture, FirstTest) { doStuff(); }\n"
+        "TEST_F(MyFixture, SecondTest) { doOtherStuff(); }\n",
+        CBM_LANG_CPP, "t", "fixture_test.cpp");
+    ASSERT_NOT_NULL(r);
+    ASSERT(has_def(r, "Function", "TEST_F_MyFixture_FirstTest"));
+    ASSERT(has_def(r, "Function", "TEST_F_MyFixture_SecondTest"));
+    ASSERT(!has_def(r, "Function", "TEST_F"));
+    cbm_free_result(r);
+    PASS();
+}
+
 /* --- C++ out-of-line method definitions (#428) ---
  * A .cpp defining methods of a class declared elsewhere (not in this TU).
  * Pre-fix these were recorded as free Functions (label "Function", no
@@ -4816,6 +4851,8 @@ SUITE(extraction) {
     RUN_TEST(rust_enum);
     RUN_TEST(zig_struct);
     RUN_TEST(cpp_function);
+    RUN_TEST(cpp_gtest_same_name_collision_issue1266);
+    RUN_TEST(cpp_gtest_f_unique_name_issue1266);
     RUN_TEST(cpp_out_of_line_method_issue428);
     RUN_TEST(cobol_paragraph);
     RUN_TEST(verilog_module);


### PR DESCRIPTION
## What does this PR do?

Fixes #1266

Multiple GoogleTest `TEST(...)` cases defined in the same file collapse into a single graph node because `cbm_resolve_func_name` returns the bare macro name `TEST` with no argument-derived identity. Every test case in the file maps to the same qualified name (e.g. `proj.file.TEST`), so the graph upsert keeps only the last one and the call edges of all previous test cases are dropped.

This PR adds a GoogleTest macro detection step in `extract_func_def` that composes a unique name from the two macro arguments: `TEST(WidgetSuite, DoublesSmallSize)` becomes `TEST_WidgetSuite_DoublesSmallSize`. This gives each test case its own qualified name, preventing node collisions. The fix covers `TEST`, `TEST_F`, `TEST_P`, `TYPED_TEST`, and `TYPED_TEST_P`. It also sets `is_test = true` for these nodes so test exclusion queries work correctly.

**Changes:**
- `internal/cbm/extract_defs.c`: Add `is_cpp_test_macro()` and `resolve_cpp_test_macro_name()` helpers; call them in `extract_func_def` before QN computation; set `is_test` flag
- `tests/test_extraction.c`: Two regression tests using the exact fixture from the issue (`TEST()` three-case collision and `TEST_F()` two-case collision)

## Checklist

- [x] Every commit is signed off (`git commit -s`) -- required, CI rejects unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Tests pass locally (`make -f Makefile.cbm test`)
  _ASan test-runner hangs on startup on macOS Tahoe (Apple Clang 17), a pre-existing environment issue unrelated to this change._
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)

Note: the local test checkbox is unchecked because the ASan test-runner hangs on startup for all suites locally (pre-existing environment issue unrelated to this change). The production build compiles cleanly with `-Werror` and clang-format passes on all changed files. CI will run the full test suite.
