### PR TITLE
fix(security): declare the printed install-script URL on the allow-list

### DIFF
--- a/scripts/security-allowlist.txt
+++ b/scripts/security-allowlist.txt
@@ -66,6 +66,7 @@ src/ui/http_server.c:execl:exec indexing binary in child process
 URL:https://api.github.com/repos/DeusData/codebase-memory-mcp/releases/latest:update check
 URL:https://github.com/DeusData/codebase-memory-mcp/releases/latest/download:binary download + checksums
 URL:https://github.com/DeusData/codebase-memory-mcp/releases/latest:version check via redirect header
+URL:https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh:printed by `update` as the install-script command when install.sh is not beside the binary (a string in the message, not a network call - the binary no longer downloads anything)
 URL:http://127.0.0.1:UI server binding (localhost only)
 URL:https://www.sqlite.org/c3ref/c_checkpoint_full.html:sqlite WAL checkpoint API doc reference (comment only, not a network call)
 URL:https://github.com/DeusData/codebase-memory-mcp:project repository self-reference in update/star notice (src/mcp/mcp.c)

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -11168,6 +11168,12 @@ static bool check_already_latest(void) {
 
 #endif /* CBM_CLI_ENABLE_TEST_API */
 
+/* One token on purpose: the security audit extracts URLs literally, so a URL
+ * split across string-literal continuations cannot be matched against the
+ * allow-list. Printed for the user to paste; never fetched by this binary. */
+#define CBM_INSTALL_SH_URL \
+    "https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh"
+
 int cbm_cmd_update(int argc, char **argv) {
     parse_auto_answer(argc, argv);
 
@@ -11257,8 +11263,7 @@ int cbm_cmd_update(int argc, char **argv) {
         if (have_dir) {
             printf("  bash \"%s/install.sh\"\n\n", self_dir);
         } else {
-            printf("  curl -fsSL https://raw.githubusercontent.com/DeusData/"
-                   "codebase-memory-mcp/main/install.sh | bash\n\n");
+            printf("  curl -fsSL " CBM_INSTALL_SH_URL " | bash\n\n");
         }
         printf("It downloads the latest release, verifies its checksum, and replaces\n"
                "this binary in place. install.sh is idempotent, so re-running it IS\n"


### PR DESCRIPTION
Release run 30435312575 was blocked by `security-static`:

```
BLOCKED: src/cli/cli.c: URL not on allow-list: https://raw.githubusercontent.com/DeusData/
```

Two problems, both fixed:

1. **Undeclared.** The `update` handoff prints a curl one-liner when `install.sh` isn't beside the binary. It's the same URL as our documented one-liner install, and it's *printed for the user to paste* — the binary no longer downloads anything.
2. **Unmatchable.** The URL was split across string-literal continuations, so the audit extracted only `https://raw.githubusercontent.com/DeusData/`. An allow-list entry for the real URL could never have matched. Hoisted to a single `CBM_INSTALL_SH_URL` token so the declaration means what it says.

Note the counter-intuitive detail in that job: it also reports `mcp.c has 16 file read operations (expected max 15)`. That is **pre-existing** — the same tree at `560ad40` reports **17** and passed CI, because that check is advisory. This change *reduced* it by removing the update-check `fread`.

## Verification
| Check | Result |
|---|---|
| `scripts/security-audit.sh` | `OK: All URLs are on the allow-list.` |
| `cli` + `mcp` suites | 436 passed, 2 skipped |
| Contracts (smoke fixture, windows bundle, venue parity, security strings) | pass |
| `lint-ci` | clean |
| Release binary contains `releases/latest/download` | **0** |

Follow-up queued: have `install.sh` copy itself next to the binary so `update` always references a local file and the URL can be dropped entirely.