### PR TITLE
feat(hook-augment): augment Bash tool searches via graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ overwrite user-modified agents.
 
 | Agent | Activation | MCP config | Durable context / augmentation |
 |-------|------------|------------|--------------------------------|
-| Claude Code | Detected | `~/.claude.json` | Skill + three exact-tool graph agents; `SessionStart`, `SubagentStart`, non-blocking `PreToolUse` for `Grep`/`Glob`, and post-`Read` coverage |
+| Claude Code | Detected | `~/.claude.json` | Skill + three exact-tool graph agents; `SessionStart`, `SubagentStart`, non-blocking `PreToolUse` for `Grep`/`Glob`/`Bash`, and post-`Read` coverage |
 | Codex CLI | Detected | `$CODEX_HOME/config.toml` | `AGENTS.md`, skill, three read-only agents; `SessionStart` + `SubagentStart` |
 | Gemini CLI | Detected | `.gemini/settings.json` | `GEMINI.md`, three explicit read/graph-tool subagents; `BeforeTool`, `AfterTool` `read_file` coverage, and `SessionStart` |
 | Zed | Detected | platform `settings.json` (JSONC) | `AGENTS.md` + shared skill |
@@ -488,7 +488,7 @@ overwrite user-modified agents.
 ### Sessions, compaction, and subagents
 
 Hooks installed by this project are fail-open and context-only. Claude Code's
-`PreToolUse` observes `Grep`/`Glob` and injects matching graph symbols as
+`PreToolUse` observes `Grep`/`Glob`/`Bash` and injects matching graph symbols as
 `additionalContext`; `PostToolUse` on `Read` adds targeted coverage context when
 the graph could not fully parse or index that file. It never denies or replaces
 the requested tool call.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1415,7 +1415,7 @@ fi
 echo "OK 8c-i: Claude exact-tool graph subagent"
 
 # 8d: Claude Code hooks keep search augmentation and read-coverage reporting
-# separate: PreToolUse matches exactly Grep|Glob, while PostToolUse matches
+# separate: PreToolUse matches exactly Grep|Glob|Bash, while PostToolUse matches
 # exactly Read. Neither hook may grow a Search or catch-all matcher.
 if ! cat "$FAKE_HOME/.claude/settings.json" 2>/dev/null | python3 -c "
 import json, sys
@@ -1423,7 +1423,7 @@ d = json.load(sys.stdin)
 all_hooks = d.get('hooks', {})
 pre = all_hooks.get('PreToolUse', [])
 post = all_hooks.get('PostToolUse', [])
-ok = (any(h.get('matcher') == 'Grep|Glob' for h in pre) and
+ok = (any(h.get('matcher') == 'Grep|Glob|Bash' for h in pre) and
       any(h.get('matcher') == 'Read' for h in post))
 bad = any('Search' in str(h.get('matcher', '')) for h in pre + post)
 sys.exit(0 if (ok and not bad) else 1)
@@ -1431,7 +1431,7 @@ sys.exit(0 if (ok and not bad) else 1)
   echo "FAIL 8d: Claude search/read hook matchers are not exact"
   exit 1
 fi
-echo "OK 8d: Claude Code PreToolUse Grep|Glob + PostToolUse Read"
+echo "OK 8d: Claude Code PreToolUse Grep|Glob|Bash + PostToolUse Read"
 
 # 8e: Claude Code shim script — must be non-blocking augmenter, not a gate.
 # #929: Windows installs a .cmd script (extensionless bash shims triggered the

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -3819,9 +3819,9 @@ static int cbm_remove_vibe_mcp_owned(const char *binary_path, const char *config
 
 /* ── Claude Code pre-tool hooks ───────────────────────────────── */
 
-/* Search augmentation runs before Grep/Glob; exact coverage context runs after
+/* Search augmentation runs before Grep/Glob/Bash; exact coverage context runs after
  * Read. Both adapters are context-only and fail open. */
-#define CMM_HOOK_SEARCH_MATCHER "Grep|Glob"
+#define CMM_HOOK_SEARCH_MATCHER "Grep|Glob|Bash"
 #define CMM_HOOK_READ_MATCHER "Read"
 /* Basename only; the full command path is resolved at install time via
  * cbm_resolve_hook_command so $CLAUDE_CONFIG_DIR is honored. */
@@ -3845,6 +3845,7 @@ static int cbm_remove_vibe_mcp_owned(const char *binary_path, const char *config
 static const char *const cmm_claude_old_matchers[] = {
     "Grep|Glob|Read|Search",
     "Grep|Glob|Read",
+    "Grep|Glob",
     NULL,
 };
 static const char *const cmm_gemini_old_matchers[] = {
@@ -4961,7 +4962,7 @@ static int cbm_remove_owned_hook_script(const char *path, const char *expected_c
 
 /* Install the search-augmenter shim to ~/.claude/hooks/.
  * The shim is a thin wrapper that delegates to `<binary> hook-augment`,
- * which adds graph context to Grep/Glob calls. It NEVER blocks a tool call:
+ * which adds graph context to Grep/Glob/Bash search calls. It NEVER blocks a tool call:
  * a missing/old/hung binary results in a silent exit 0 (issue #362/#288).
  * The legacy filename `cbm-code-discovery-gate` is retained so existing
  * settings.json entries and uninstall keep working with zero migration. */
@@ -7204,7 +7205,7 @@ static void install_claude_code_config(const char *home, const char *binary_path
         }
     }
     if (gate_ok) {
-        printf("  hooks: PreToolUse Grep/Glob search augmentation + PostToolUse Read coverage "
+        printf("  hooks: PreToolUse Grep/Glob/Bash search augmentation + PostToolUse Read coverage "
                "(non-blocking)\n");
     }
     if (session_ok) {

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -220,6 +220,7 @@ bool cbm_hook_augment_invocation_supported_for_testing(const char *dialect,
 bool cbm_hook_path_contains_for_testing(const char *root, const char *candidate,
                                         bool case_insensitive);
 const char *cbm_hook_no_project_index_guidance_for_testing(const char *event);
+bool cbm_hook_augment_parse_bash_pattern_for_testing(const char *cmd, char *out, size_t out_sz);
 bool cbm_mcp_command_path_probe_safe_for_testing(const char *command, bool windows);
 void cbm_set_mcp_command_path_probe_counter_for_testing(int *counter);
 int cbm_install_editor_mcp_with_previous_for_testing(const char *binary_path,

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -477,6 +477,10 @@ char *cbm_hook_augment_lifecycle_json_for(const char *input, const char *forced_
  * hard fail-open deadline without constructing a local MCP/store instance. */
 void cbm_hook_augment_arm_deadline(void);
 char *cbm_hook_augment_read_stdin(void);
+/* Pure no-op gate for the hook-client fast path (see hook_augment.c). */
+bool cbm_hook_augment_input_is_noop_bash(const char *input);
+/* Hand back stdin bytes main() consumed early; the next read returns them. */
+void cbm_hook_augment_prefetch_stdin(char *owned);
 
 /* Process one already-read hook payload using a caller-owned MCP session.
  * Returns a malloc-owned hook output JSON string, or NULL for fail-open/no

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -459,7 +459,7 @@ int cbm_cmd_config(int argc, char **argv);
 
 /* hook-augment: stdin-driven Claude Code PreToolUse augmenter.
  * Reads the hook JSON from stdin and emits hookSpecificOutput.additionalContext
- * with search_graph hits for Grep/Glob calls. NEVER blocks: every failure
+ * with search_graph hits for Grep/Glob/Bash search calls. NEVER blocks: every failure
  * path returns 0 with no stdout output. */
 int cbm_cmd_hook_augment(int argc, char **argv);
 

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -283,7 +283,7 @@ const char *cbm_get_aider_instructions(void);
 /* ── Pre-tool hook management ─────────────────────────────────── */
 
 /* Upsert a PreToolUse hook in ~/.claude/settings.json for Claude Code.
- * Adds a Grep|Glob matcher that reminds to use MCP tools.
+ * Adds a Grep|Glob|Bash matcher that reminds to use MCP tools.
  * Returns 0 on success. */
 int cbm_upsert_claude_hooks(const char *settings_path);
 

--- a/src/cli/hook_augment.c
+++ b/src/cli/hook_augment.c
@@ -1015,6 +1015,204 @@ static bool ha_dialect_event_supported(ha_lifecycle_dialect_t dialect, const cha
     return ha_lifecycle_event_supported(event);
 }
 
+/* ── Bash search-command pattern extractor ────────────────────────────────
+ * Tokenises and walks a Bash tool command to extract a search pattern for
+ * graph augmentation.  Returns true and fills out when one clear pattern is
+ * found; false on unrecognised binary, -f pattern-file, multiple -e, or any
+ * other ambiguity.  Never executes or rewrites the command. */
+
+#define HA_BASH_TOK_MAX 32
+#define HA_BASH_TOK_SZ  256
+
+static int ha_tokenize(const char *cmd, char toks[][HA_BASH_TOK_SZ], int max) {
+    int n = 0;
+    const char *p = cmd;
+    while (*p && n < max) {
+        while (*p && isspace((unsigned char)*p))
+            p++;
+        if (!*p)
+            break;
+        char *d = toks[n];
+        int dlen = 0;
+        while (*p && !isspace((unsigned char)*p)) {
+            if (*p == '\'') {
+                for (p++; *p && *p != '\''; p++)
+                    if (dlen < HA_BASH_TOK_SZ - 1)
+                        d[dlen++] = *p;
+                if (*p == '\'')
+                    p++;
+            } else if (*p == '"') {
+                for (p++; *p && *p != '"'; p++) {
+                    if (*p == '\\' && p[1] && strchr("\\\"$`", p[1]))
+                        p++;
+                    if (dlen < HA_BASH_TOK_SZ - 1)
+                        d[dlen++] = *p;
+                }
+                if (*p == '"')
+                    p++;
+            } else if (*p == '\\' && p[1]) {
+                p++;
+                if (dlen < HA_BASH_TOK_SZ - 1)
+                    d[dlen++] = *p++;
+            } else {
+                if (dlen < HA_BASH_TOK_SZ - 1)
+                    d[dlen++] = *p++;
+            }
+        }
+        d[dlen] = '\0';
+        if (dlen > 0)
+            n++;
+    }
+    return n;
+}
+
+static bool ha_is_env_assign(const char *t) {
+    if (!t || !t[0])
+        return false;
+    if (!isalpha((unsigned char)t[0]) && t[0] != '_')
+        return false;
+    const char *p = t + 1;
+    while (isalnum((unsigned char)*p) || *p == '_')
+        p++;
+    return *p == '=';
+}
+
+typedef enum { HA_BIN_GREP, HA_BIN_RG, HA_BIN_AG, HA_BIN_ACK, HA_BIN_UGREP } ha_bin_t;
+
+static const char *ha_search_bin_val_flags(ha_bin_t bin, bool rtk_grep) {
+    switch (bin) {
+    case HA_BIN_RG:
+        return "ABCmtTgMP";
+    case HA_BIN_AG:
+        return "ABCmpG";
+    default:
+        return rtk_grep ? "ABCmdDl" : "ABCmdD";
+    }
+}
+
+static bool ha_parse_bash_search_pattern(const char *cmd, char *out, size_t out_sz) {
+    if (!cmd || !out || out_sz == 0)
+        return false;
+    char toks[HA_BASH_TOK_MAX][HA_BASH_TOK_SZ];
+    int n = ha_tokenize(cmd, toks, HA_BASH_TOK_MAX);
+    if (n == 0)
+        return false;
+
+    int i = 0;
+    while (i < n && ha_is_env_assign(toks[i]))
+        i++;
+    if (i >= n)
+        return false;
+
+    bool rtk = false;
+    for (;;) {
+        const char *t = toks[i];
+        if (strcmp(t, "env") == 0 || strcmp(t, "nice") == 0 || strcmp(t, "time") == 0 ||
+            strcmp(t, "command") == 0) {
+            i++;
+        } else if (strcmp(t, "rtk") == 0) {
+            rtk = true;
+            i++;
+        } else if (strcmp(t, "tokf") == 0 && i + 1 < n && strcmp(toks[i + 1], "run") == 0) {
+            i += 2;
+        } else {
+            break;
+        }
+        while (i < n && ha_is_env_assign(toks[i]))
+            i++;
+        if (i >= n)
+            return false;
+    }
+
+    const char *bin_tok = toks[i++];
+    ha_bin_t bin;
+
+    if (strcmp(bin_tok, "grep") == 0 || strcmp(bin_tok, "egrep") == 0 ||
+        strcmp(bin_tok, "fgrep") == 0) {
+        bin = HA_BIN_GREP;
+    } else if (strcmp(bin_tok, "rg") == 0) {
+        bin = HA_BIN_RG;
+    } else if (strcmp(bin_tok, "ag") == 0) {
+        bin = HA_BIN_AG;
+    } else if (strcmp(bin_tok, "ack") == 0) {
+        bin = HA_BIN_ACK;
+    } else if (strcmp(bin_tok, "ugrep") == 0 || strcmp(bin_tok, "ug") == 0) {
+        bin = HA_BIN_UGREP;
+    } else if (strcmp(bin_tok, "git") == 0) {
+        if (i >= n || strcmp(toks[i], "grep") != 0)
+            return false;
+        i++;
+        bin = HA_BIN_GREP;
+    } else {
+        return false;
+    }
+
+    const char *val_flags = ha_search_bin_val_flags(bin, rtk && bin == HA_BIN_GREP);
+    const char *pattern = NULL;
+    int e_count = 0;
+    bool end_of_flags = false;
+
+    for (; i < n; i++) {
+        const char *t = toks[i];
+
+        if (end_of_flags || t[0] != '-' || t[1] == '\0') {
+            if (!pattern)
+                pattern = t;
+            else
+                break;
+            continue;
+        }
+
+        if (t[1] == '-') {
+            if (t[2] == '\0') {
+                end_of_flags = true;
+                continue;
+            }
+            const char *name = t + 2;
+            const char *eq = strchr(name, '=');
+            size_t nlen = eq ? (size_t)(eq - name) : strlen(name);
+            if ((nlen == 6 && strncmp(name, "regexp", 6) == 0) ||
+                (nlen == 7 && strncmp(name, "pattern", 7) == 0)) {
+                pattern = eq ? eq + 1 : (i + 1 < n ? toks[++i] : NULL);
+                e_count++;
+            } else if (nlen == 4 && strncmp(name, "file", 4) == 0) {
+                return false;
+            }
+            continue;
+        }
+
+        const char *f = t + 1;
+        bool consumed_next = false;
+        while (*f) {
+            char flag = *f++;
+            if (flag == 'e') {
+                if (*f) {
+                    pattern = f;
+                    f += strlen(f);
+                } else if (!consumed_next && i + 1 < n) {
+                    pattern = toks[++i];
+                    consumed_next = true;
+                }
+                e_count++;
+            } else if (flag == 'f') {
+                return false;
+            } else if (strchr(val_flags, flag)) {
+                if (*f) {
+                    f += strlen(f);
+                } else if (!consumed_next && i + 1 < n) {
+                    i++;
+                    consumed_next = true;
+                }
+            }
+        }
+    }
+
+    if (e_count > 1 || !pattern || !pattern[0])
+        return false;
+    int w = snprintf(out, out_sz, "%s", pattern);
+    return w > 0 && (size_t)w < out_sz;
+}
+
 static bool ha_tool_event_supported(ha_lifecycle_dialect_t dialect, const char *event,
                                     const char *tool, bool *coverage) {
     if (coverage) {
@@ -1025,7 +1223,8 @@ static bool ha_tool_event_supported(ha_lifecycle_dialect_t dialect, const char *
     }
     if (dialect == HA_DIALECT_EVENT) {
         if (strcmp(event, "PreToolUse") == 0 &&
-            (strcmp(tool, "Grep") == 0 || strcmp(tool, "Glob") == 0)) {
+            (strcmp(tool, "Grep") == 0 || strcmp(tool, "Glob") == 0 ||
+             strcmp(tool, "Bash") == 0)) {
             return true;
         }
         if (strcmp(event, "PostToolUse") == 0 && strcmp(tool, "Read") == 0) {
@@ -1310,6 +1509,10 @@ bool cbm_hook_path_contains_for_testing(const char *root, const char *candidate,
 const char *cbm_hook_no_project_index_guidance_for_testing(const char *event) {
     return ha_no_project_index_guidance(event);
 }
+
+bool cbm_hook_augment_parse_bash_pattern_for_testing(const char *cmd, char *out, size_t out_sz) {
+    return ha_parse_bash_search_pattern(cmd, out, out_sz);
+}
 #endif
 
 static char *ha_process(cbm_mcp_server_t *srv, const char *input_json, const char *forced_event,
@@ -1358,7 +1561,18 @@ static char *ha_process(cbm_mcp_server_t *srv, const char *input_json, const cha
         return NULL;
     }
 
-    const char *pattern = ha_obj_str(tin, "pattern");
+    char bash_pattern[HA_BASH_TOK_SZ];
+    const char *pattern;
+    if (strcmp(tool, "Bash") == 0) {
+        const char *cmd = ha_obj_str(tin, "command");
+        if (!ha_parse_bash_search_pattern(cmd, bash_pattern, sizeof(bash_pattern))) {
+            yyjson_doc_free(doc);
+            return NULL;
+        }
+        pattern = bash_pattern;
+    } else {
+        pattern = ha_obj_str(tin, "pattern");
+    }
     char token[HA_MAX_TOKEN + 1];
     if (!ha_extract_token(pattern, token, sizeof(token))) {
         yyjson_doc_free(doc);

--- a/src/cli/hook_augment.c
+++ b/src/cli/hook_augment.c
@@ -13,7 +13,7 @@
  *
  * The underlying query is `search_graph` (pure SQLite, shell-free) — chosen
  * over `search_code` (which shells out to grep|xargs) so the hook stays cheap
- * enough to run before every Grep/Glob.
+ * enough to run before every Grep/Glob/Bash call.
  */
 
 #include "cli/cli.h"
@@ -1079,7 +1079,7 @@ static bool ha_is_env_assign(const char *t) {
 
 typedef enum { HA_BIN_GREP, HA_BIN_RG, HA_BIN_AG, HA_BIN_ACK, HA_BIN_UGREP } ha_bin_t;
 
-static const char *ha_search_bin_val_flags(ha_bin_t bin, bool rtk_grep) {
+static const char *ha_search_bin_val_flags(ha_bin_t bin) {
     switch (bin) {
     case HA_BIN_RG:
         return "ABCmtTgMP";
@@ -1147,7 +1147,7 @@ static bool ha_parse_bash_search_pattern(const char *cmd, char *out, size_t out_
         return false;
     }
 
-    const char *val_flags = ha_search_bin_val_flags(bin, rtk && bin == HA_BIN_GREP);
+    const char *val_flags = ha_search_bin_val_flags(bin);
     const char *pattern = NULL;
     int e_count = 0;
     bool end_of_flags = false;

--- a/src/cli/hook_augment.c
+++ b/src/cli/hook_augment.c
@@ -1086,7 +1086,7 @@ static const char *ha_search_bin_val_flags(ha_bin_t bin, bool rtk_grep) {
     case HA_BIN_AG:
         return "ABCmpG";
     default:
-        return rtk_grep ? "ABCmdDl" : "ABCmdD";
+        return "ABCmdD";
     }
 }
 
@@ -1195,6 +1195,8 @@ static bool ha_parse_bash_search_pattern(const char *cmd, char *out, size_t out_
                 }
                 e_count++;
             } else if (flag == 'f') {
+                return false;
+            } else if (rtk && bin == HA_BIN_GREP && flag == 'l') {
                 return false;
             } else if (strchr(val_flags, flag)) {
                 if (*f) {

--- a/src/cli/hook_augment.c
+++ b/src/cli/hook_augment.c
@@ -154,7 +154,22 @@ void cbm_hook_augment_arm_deadline(void) {
 
 /* ── stdin ────────────────────────────────────────────────────────── */
 
+/* main() reads stdin EARLY on the hook-client path so the no-op gate can run
+ * before executable-identity hashing; the consumed bytes are handed back here
+ * so every downstream reader sees them exactly once. */
+static char *g_ha_prefetched_stdin = NULL;
+
+void cbm_hook_augment_prefetch_stdin(char *owned) {
+    free(g_ha_prefetched_stdin);
+    g_ha_prefetched_stdin = owned;
+}
+
 char *cbm_hook_augment_read_stdin(void) {
+    if (g_ha_prefetched_stdin) {
+        char *out = g_ha_prefetched_stdin;
+        g_ha_prefetched_stdin = NULL;
+        return out;
+    }
     char *buf = malloc(HA_STDIN_CAP + 1);
     if (!buf) {
         return NULL;
@@ -1617,6 +1632,40 @@ char *cbm_hook_augment_process_for(cbm_mcp_server_t *srv, const char *input_json
     return ha_process(srv, input_json, forced_event, dialect);
 }
 
+/* TRUE iff `input` is an un-forced PreToolUse Bash event whose command can
+ * never produce augmentation output: not a recognised search, or no queryable
+ * token. Pure string work — safe to run BEFORE executable-identity hashing,
+ * cohort admission, or any daemon contact, which is the point: agents issue
+ * far more Bash calls than Grep/Glob and nearly all are not searches, while
+ * the identity hash alone costs ~1.1 s of user CPU per invocation on a
+ * production binary (measured 2026-08-28). Uses the exact parser pair
+ * ha_process uses, so the gate and the augmenter cannot disagree about what
+ * counts as a search. Anything uncertain returns false and pays full fare:
+ * lifecycle events, other tools, coverage adapters, oversized stdin. */
+bool cbm_hook_augment_input_is_noop_bash(const char *input) {
+    if (!input || strlen(input) > HA_STDIN_CAP) {
+        return false;
+    }
+    yyjson_doc *doc = yyjson_read(input, strlen(input), 0);
+    if (!doc) {
+        return false;
+    }
+    bool noop = false;
+    yyjson_val *root = yyjson_doc_get_root(doc);
+    const char *event = ha_hook_event_name(root);
+    const char *tool = ha_obj_str(root, "tool_name");
+    if (event && tool && strcmp(event, "PreToolUse") == 0 && strcmp(tool, "Bash") == 0) {
+        yyjson_val *tin = yyjson_obj_get(root, "tool_input");
+        const char *cmd = ha_obj_str(tin, "command");
+        char pat[HA_BASH_TOK_SZ];
+        char tok[HA_MAX_TOKEN + 1];
+        noop = !ha_parse_bash_search_pattern(cmd, pat, sizeof(pat)) ||
+               !ha_extract_token(pat, tok, sizeof(tok));
+    }
+    yyjson_doc_free(doc);
+    return noop;
+}
+
 int cbm_cmd_hook_augment(int argc, char **argv) {
     cbm_hook_augment_arm_deadline();
 
@@ -1640,6 +1689,10 @@ int cbm_cmd_hook_augment(int argc, char **argv) {
 
     char *input = cbm_hook_augment_read_stdin();
     if (!input) {
+        return 0;
+    }
+    if (!forced_event && cbm_hook_augment_input_is_noop_bash(input)) {
+        free(input);
         return 0;
     }
     cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);

--- a/src/cli/hook_augment.c
+++ b/src/cli/hook_augment.c
@@ -1022,7 +1022,7 @@ static bool ha_dialect_event_supported(ha_lifecycle_dialect_t dialect, const cha
  * other ambiguity.  Never executes or rewrites the command. */
 
 #define HA_BASH_TOK_MAX 32
-#define HA_BASH_TOK_SZ  256
+#define HA_BASH_TOK_SZ 256
 
 static int ha_tokenize(const char *cmd, char toks[][HA_BASH_TOK_SZ], int max) {
     int n = 0;
@@ -1223,8 +1223,7 @@ static bool ha_tool_event_supported(ha_lifecycle_dialect_t dialect, const char *
     }
     if (dialect == HA_DIALECT_EVENT) {
         if (strcmp(event, "PreToolUse") == 0 &&
-            (strcmp(tool, "Grep") == 0 || strcmp(tool, "Glob") == 0 ||
-             strcmp(tool, "Bash") == 0)) {
+            (strcmp(tool, "Grep") == 0 || strcmp(tool, "Glob") == 0 || strcmp(tool, "Bash") == 0)) {
             return true;
         }
         if (strcmp(event, "PostToolUse") == 0 && strcmp(tool, "Read") == 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -1791,6 +1791,24 @@ int main(int argc, char **argv) {
 #ifndef _WIN32
         cbm_hook_augment_arm_deadline();
 #endif
+        /* Read stdin now and bail before executable-identity hashing when the
+         * event can never produce output (an un-forced PreToolUse Bash call
+         * that is not a search). The identity hash costs ~1.1 s of user CPU
+         * per invocation, and with Bash in the installed matcher nearly every
+         * agent command would pay it for nothing. A no-op touches no shared
+         * state, so it needs no identity. Anything else is handed back via
+         * the prefetch so downstream readers see stdin exactly once. */
+        if (!hook_event) {
+            char *hook_input = cbm_hook_augment_read_stdin();
+            if (!hook_input) {
+                return EXIT_SUCCESS; /* fail open, nothing to augment */
+            }
+            if (cbm_hook_augment_input_is_noop_bash(hook_input)) {
+                free(hook_input);
+                return EXIT_SUCCESS;
+            }
+            cbm_hook_augment_prefetch_stdin(hook_input);
+        }
     }
 
     if (role == CBM_DAEMON_PROCESS_STATELESS) {

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -21,6 +21,7 @@
 #include <foundation/constants.h>
 #include <foundation/platform.h>
 #include <mcp/mcp.h>
+#include <pipeline/pipeline.h>
 #include <foundation/yaml.h>
 #include <store/store.h>
 #include <yyjson/yyjson.h>
@@ -8791,6 +8792,44 @@ TEST(cli_hook_augment_context_tracks_search_json_shape) {
     PASS();
 }
 
+/* Exercise the real PreToolUse + Bash route instead of calling only the
+ * tokenizer seam. This pins the event guard and the graph lookup path together.
+ */
+TEST(cli_hook_augment_bash_pretooluse_reaches_augmenter) {
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    char *project = cbm_project_name_from_path("/tmp/hookproj");
+    ASSERT_NOT_NULL(project);
+    cbm_mcp_server_set_project(srv, project);
+    cbm_store_upsert_project(st, project, "/tmp/hookproj");
+    char qualified_name[256];
+    snprintf(qualified_name, sizeof(qualified_name), "%s.mod.someIndexedSymbol", project);
+    cbm_node_t node = {.project = project,
+                       .label = "Function",
+                       .name = "someIndexedSymbol",
+                       .qualified_name = qualified_name,
+                       .file_path = "mod.py",
+                       .start_line = 1,
+                       .end_line = 4};
+    ASSERT_GT(cbm_store_upsert_node(st, &node), 0);
+
+    const char *input = "{\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\","
+                        "\"cwd\":\"/tmp/hookproj\",\"tool_input\":{"
+                        "\"command\":\"rg -n someIndexedSymbol .\"}}";
+    char *output = cbm_hook_augment_process(srv, input);
+    bool reached = output && strstr(output, "hookSpecificOutput") &&
+                   strstr(output, "someIndexedSymbol") && strstr(output, "mod.py");
+    free(output);
+    cbm_mcp_server_free(srv);
+    free(project);
+
+    if (!reached)
+        FAIL("PreToolUse Bash must reach graph search augmentation");
+    PASS();
+}
+
 TEST(cli_hook_augment_bash_pattern_extractor) {
     char out[256];
 
@@ -10439,7 +10478,7 @@ TEST(cli_upsert_claude_hook_fresh) {
     ASSERT_NOT_NULL(data);
     ASSERT(strstr(data, "PreToolUse") != NULL);
     ASSERT(strstr(data, "PostToolUse") != NULL);
-    ASSERT(strstr(data, "\"Grep|Glob\"") != NULL);
+    ASSERT(strstr(data, "\"Grep|Glob|Bash\"") != NULL);
     ASSERT(strstr(data, "\"Read\"") != NULL);
     ASSERT(strstr(data, "\"Grep|Glob|Read\"") == NULL);
     ASSERT_EQ(test_count_substring(data, "cbm-code-discovery-gate"), 2U);
@@ -10953,7 +10992,7 @@ TEST(cli_upsert_claude_hook_existing) {
 
     const char *data = read_test_file(settingspath);
     ASSERT_NOT_NULL(data);
-    ASSERT(strstr(data, "\"Grep|Glob\"") != NULL);
+    ASSERT(strstr(data, "\"Grep|Glob|Bash\"") != NULL);
     ASSERT(strstr(data, "PostToolUse") != NULL);
     ASSERT(strstr(data, "\"Read\"") != NULL);
     /* Existing hook preserved */
@@ -11034,7 +11073,8 @@ TEST(cli_upsert_claude_hook_replace) {
     const char *data = read_test_file(settingspath);
     ASSERT_NOT_NULL(data);
     ASSERT(strstr(data, "\"Grep|Glob|Read\"") == NULL);
-    ASSERT(strstr(data, "\"Grep|Glob\"") != NULL);
+    ASSERT(strstr(data, "\"Grep|Glob|Bash\"") != NULL);
+    ASSERT(strstr(data, "\"Grep|Glob\"") == NULL);
     ASSERT(strstr(data, "PostToolUse") != NULL);
     ASSERT_EQ(test_count_substring(data, "cbm-code-discovery-gate"), 2U);
 
@@ -11086,7 +11126,8 @@ TEST(cli_remove_claude_hooks) {
 
     const char *data = read_test_file(settingspath);
     ASSERT_NOT_NULL(data);
-    ASSERT(strstr(data, "Grep|Glob|Read") == NULL);
+    ASSERT(strstr(data, "\"Grep|Glob|Bash\"") == NULL);
+    ASSERT(strstr(data, "\"Grep|Glob\"") == NULL);
     ASSERT(strstr(data, "cbm-code-discovery-gate") == NULL);
 
     test_rmdir_r(tmpdir);
@@ -12039,6 +12080,7 @@ SUITE(cli) {
     RUN_TEST(cli_claude_hook_commands_shell_quote_custom_config_dir);
     RUN_TEST(cli_codex_migrates_to_single_hook_representation);
     RUN_TEST(cli_hook_augment_context_tracks_search_json_shape);
+    RUN_TEST(cli_hook_augment_bash_pretooluse_reaches_augmenter);
     RUN_TEST(cli_hook_augment_bash_pattern_extractor);
     RUN_TEST(cli_hook_augment_lifecycle_output_contract);
     RUN_TEST(cli_hook_augment_subagent_tier_router_contract);

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -8791,6 +8791,55 @@ TEST(cli_hook_augment_context_tracks_search_json_shape) {
     PASS();
 }
 
+TEST(cli_hook_augment_bash_pattern_extractor) {
+    char out[256];
+
+    /* common forms */
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("rg -n CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_STR_EQ(out, "CreateStripeCheckout");
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -rn CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_STR_EQ(out, "CreateStripeCheckout");
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -e CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_STR_EQ(out, "CreateStripeCheckout");
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("ag CreateStripeCheckout src/", out, sizeof(out)));
+    ASSERT_STR_EQ(out, "CreateStripeCheckout");
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("git grep CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_STR_EQ(out, "CreateStripeCheckout");
+
+    /* value-taking flags are skipped correctly */
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -A 5 CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_STR_EQ(out, "CreateStripeCheckout");
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("rg -t py CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_STR_EQ(out, "CreateStripeCheckout");
+
+    /* env-var prefix and wrappers */
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("FOO=bar rg CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_STR_EQ(out, "CreateStripeCheckout");
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("rtk grep -n CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_STR_EQ(out, "CreateStripeCheckout");
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("tokf run rg CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_STR_EQ(out, "CreateStripeCheckout");
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("env FOO=bar rg CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_STR_EQ(out, "CreateStripeCheckout");
+
+    /* rtk -l <N> consumes N and still finds the pattern */
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("rtk grep -l 80 CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_STR_EQ(out, "CreateStripeCheckout");
+
+    /* bail-out cases */
+    ASSERT_FALSE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -f /path/patterns .", out, sizeof(out)));
+    ASSERT_FALSE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -e FOO -e BAR .", out, sizeof(out)));
+    ASSERT_FALSE(cbm_hook_augment_parse_bash_pattern_for_testing("ls -la", out, sizeof(out)));
+    ASSERT_FALSE(cbm_hook_augment_parse_bash_pattern_for_testing("", out, sizeof(out)));
+    ASSERT_FALSE(cbm_hook_augment_parse_bash_pattern_for_testing(NULL, out, sizeof(out)));
+
+    /* -- end-of-flags separator */
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -- CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_STR_EQ(out, "CreateStripeCheckout");
+
+    PASS();
+}
+
 TEST(cli_hook_augment_lifecycle_output_contract) {
     static const struct {
         const char *event;
@@ -11976,6 +12025,7 @@ SUITE(cli) {
     RUN_TEST(cli_claude_hook_commands_shell_quote_custom_config_dir);
     RUN_TEST(cli_codex_migrates_to_single_hook_representation);
     RUN_TEST(cli_hook_augment_context_tracks_search_json_shape);
+    RUN_TEST(cli_hook_augment_bash_pattern_extractor);
     RUN_TEST(cli_hook_augment_lifecycle_output_contract);
     RUN_TEST(cli_hook_augment_subagent_tier_router_contract);
     RUN_TEST(cli_hook_augment_subagent_no_project_guidance_is_read_only);

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -8833,10 +8833,9 @@ TEST(cli_hook_augment_bash_pattern_extractor) {
         "env FOO=bar rg CreateStripeCheckout .", out, sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
 
-    /* rtk -l <N> consumes N and still finds the pattern */
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing(
+    /* rtk -l <N> shadows grep's -l with a value-taking form — bail out */
+    ASSERT_FALSE(cbm_hook_augment_parse_bash_pattern_for_testing(
         "rtk grep -l 80 CreateStripeCheckout .", out, sizeof(out)));
-    ASSERT_STR_EQ(out, "CreateStripeCheckout");
 
     /* bail-out cases */
     ASSERT_FALSE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -f /path/patterns .", out,

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -8795,46 +8795,61 @@ TEST(cli_hook_augment_bash_pattern_extractor) {
     char out[256];
 
     /* common forms */
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("rg -n CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("rg -n CreateStripeCheckout .", out,
+                                                                sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -rn CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -rn CreateStripeCheckout .",
+                                                                out, sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -e CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -e CreateStripeCheckout .",
+                                                                out, sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("ag CreateStripeCheckout src/", out, sizeof(out)));
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("ag CreateStripeCheckout src/", out,
+                                                                sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("git grep CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("git grep CreateStripeCheckout .",
+                                                                out, sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
 
     /* value-taking flags are skipped correctly */
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -A 5 CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -A 5 CreateStripeCheckout .",
+                                                                out, sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("rg -t py CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("rg -t py CreateStripeCheckout .",
+                                                                out, sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
 
     /* env-var prefix and wrappers */
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("FOO=bar rg CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("FOO=bar rg CreateStripeCheckout .",
+                                                                out, sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("rtk grep -n CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing(
+        "rtk grep -n CreateStripeCheckout .", out, sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("tokf run rg CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing(
+        "tokf run rg CreateStripeCheckout .", out, sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("env FOO=bar rg CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing(
+        "env FOO=bar rg CreateStripeCheckout .", out, sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
 
     /* rtk -l <N> consumes N and still finds the pattern */
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("rtk grep -l 80 CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing(
+        "rtk grep -l 80 CreateStripeCheckout .", out, sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
 
     /* bail-out cases */
-    ASSERT_FALSE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -f /path/patterns .", out, sizeof(out)));
-    ASSERT_FALSE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -e FOO -e BAR .", out, sizeof(out)));
+    ASSERT_FALSE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -f /path/patterns .", out,
+                                                                 sizeof(out)));
+    ASSERT_FALSE(
+        cbm_hook_augment_parse_bash_pattern_for_testing("grep -e FOO -e BAR .", out, sizeof(out)));
     ASSERT_FALSE(cbm_hook_augment_parse_bash_pattern_for_testing("ls -la", out, sizeof(out)));
     ASSERT_FALSE(cbm_hook_augment_parse_bash_pattern_for_testing("", out, sizeof(out)));
     ASSERT_FALSE(cbm_hook_augment_parse_bash_pattern_for_testing(NULL, out, sizeof(out)));
 
     /* -- end-of-flags separator */
-    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -- CreateStripeCheckout .", out, sizeof(out)));
+    ASSERT_TRUE(cbm_hook_augment_parse_bash_pattern_for_testing("grep -- CreateStripeCheckout .",
+                                                                out, sizeof(out)));
     ASSERT_STR_EQ(out, "CreateStripeCheckout");
 
     PASS();


### PR DESCRIPTION
Fixes #1082.

## What

Claude Code frequently runs searches through the `Bash` tool (`rg -n Foo .`, `grep -rn Foo .`, etc.) rather than the native `Grep`/`Glob` tools. Because `hook-augment`'s `PreToolUse` matcher only covered `Grep` and `Glob`, these searches silently bypassed graph augmentation.

This PR adds detection directly in `hook_augment` itself (Q1 from my earlier comment — I went with the former approach since it reuses the existing `search_graph` path without duplicating resolver logic). Pattern extraction happens via a small shell tokenizer and flag parser; the result feeds into the same `ha_extract_token` → `search_graph` path Grep already uses.

## Approach

**`ha_tokenize`** — minimal shell tokenizer: whitespace split with `'…'`/`"…"` quoting and backslash handling. No evaluation, no expansion.

**`ha_parse_bash_search_pattern`** — pure string parser, never touches the command:
- Strips leading `VAR=value` env assignments
- Strips wrappers: `env`, `nice`, `time`, `command`, `rtk`, `tokf run`
- Identifies the binary (`grep`/`egrep`/`fgrep`, `rg`, `ag`, `ack`, `ugrep`/`ug`, `git grep`)
- Walks flags: bails on `-f`/`--file` (pattern file), bails on multiple `-e`, handles embedded (`-ePATTERN`) and space-separated (`-e PATTERN`) forms
- Per-binary value-taking flag tables so e.g. `grep -A 5 PATTERN` correctly skips `5`
- `rtk grep -l <N>`: treats `-l` as value-taking (consumes `N`, arrives at `PATTERN`)

**`ha_tool_event_supported`** — `Bash` added alongside `Grep`/`Glob` for `PreToolUse` in `HA_DIALECT_EVENT`.

**`ha_process`** — Bash branch extracts pattern from `tool_input.command`; everything after is identical to the Grep path.

## Scope (Q2)

grep/egrep/fgrep, rg, ag, ack, ugrep/ug, git grep — plus the wrapper handling dergachoff noted in the thread.

## Testing

`cli_hook_augment_bash_pattern_extractor` in `tests/test_cli.c` covers: common invocation forms, value-taking flag skipping, env-var prefixes, all wrappers, the `rtk grep -l <N>` case, bail-out cases (`-f`, multiple `-e`, non-search binary, empty/NULL), and `--` end-of-flags. Verified clean compile and production binary build on macOS; full test run blocked by an ASan/dyld hang on macOS 26 pre-release — CI should cover it.