### PR TITLE
fix(similarity): skip empty fingerprint sort

### DIFF
--- a/src/pipeline/pass_similarity.c
+++ b/src/pipeline/pass_similarity.c
@@ -148,8 +148,12 @@ static int collect_fp_entries(cbm_gbuf_t *gbuf, fp_entry_t **out_entries) {
             };
         }
     }
-    /* Canonicalize (determinism) — see cmp_fp_entry_by_qn. */
-    qsort(entries, (size_t)count, sizeof(fp_entry_t), cmp_fp_entry_by_qn);
+    /* Canonicalize (determinism) — see cmp_fp_entry_by_qn. Avoid passing the
+     * NULL empty-set buffer to qsort: libc treats zero elements as a no-op,
+     * but the standard function contract still requires a valid base pointer. */
+    if (count > 1) {
+        qsort(entries, (size_t)count, sizeof(fp_entry_t), cmp_fp_entry_by_qn);
+    }
     *out_entries = entries;
     return count;
 }


### PR DESCRIPTION
## What changed

`collect_fp_entries()` now calls `qsort` only when at least two fingerprint
entries were collected.

## Why

The empty path leaves `entries == NULL`. Calling `qsort(NULL, 0, ...)` relies on
library behavior outside the portable array-pointer contract, while the
one-entry path needs no sorting at all. Guarding with `count > 1` avoids both
unnecessary cases without changing deterministic ordering.

Fixes #1367.

## Validation

- `scripts/build.sh` — passed
- `scripts/test.sh --suites simhash` — passed, 24 sanitizer-backed tests
- `git diff --check` — passed

## Checklist

- [x] Commit is signed off (DCO)
- [x] Change is focused on one tracked bug
- [x] Existing focused tests pass
