### PR TITLE
fix(security): audit shared agent skills

### DIFF
--- a/scripts/security-install.sh
+++ b/scripts/security-install.sh
@@ -49,6 +49,7 @@ find "$HOME" -type f > "$TMPDIR/created_files.txt" 2>/dev/null || true
 # Expected path patterns (relative to HOME):
 #   .config/*/mcp.json (or .mcp.json variants)
 #   .claude/skills/*
+#   .agents/skills/*
 #   .claude/settings.json
 #   .continue/config.yaml
 #   .codeium/config.json
@@ -56,6 +57,7 @@ find "$HOME" -type f > "$TMPDIR/created_files.txt" 2>/dev/null || true
 #   Various agent config dirs
 
 EXPECTED_PATTERNS=(
+    ".agents/"
     ".claude/"
     ".cursor/"
     ".config/"
@@ -121,10 +123,18 @@ fi
 echo ""
 echo "--- Auditing skill file content ---"
 
-SKILLS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills"
-if [[ -d "$SKILLS_DIR" ]]; then
-    SKILL_ISSUES=0
+SKILL_DIRS=(
+    "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills"
+    "$HOME/.agents/skills"
+)
+SKILL_ISSUES=0
+SKILL_DIRS_FOUND=0
 
+for SKILLS_DIR in "${SKILL_DIRS[@]}"; do
+    if [[ ! -d "$SKILLS_DIR" ]]; then
+        continue
+    fi
+    SKILL_DIRS_FOUND=1
     while IFS= read -r skill_file; do
         basename=$(basename "$skill_file")
 
@@ -138,11 +148,11 @@ if [[ -d "$SKILLS_DIR" ]]; then
         done
 
         # Check for unexpected URLs
-        if grep -oE 'https?://[^\s"'"'"']+' "$skill_file" 2>/dev/null | grep -v 'github.com/DeusData' | grep -v 'localhost' | grep -v '127.0.0.1' > /tmp/sec_skill_urls 2>/dev/null; then
+        if grep -oE 'https?://[^\s"'"'"']+' "$skill_file" 2>/dev/null | grep -v 'github.com/DeusData' | grep -v 'localhost' | grep -v '127.0.0.1' > "$TMPDIR/sec_skill_urls" 2>/dev/null; then
             while IFS= read -r url; do
                 echo "REVIEW: Skill '$basename' contains URL: $url"
-            done < /tmp/sec_skill_urls
-            rm -f /tmp/sec_skill_urls
+            done < "$TMPDIR/sec_skill_urls"
+            rm -f "$TMPDIR/sec_skill_urls"
         fi
 
         # Check for encoded strings (base64-like blocks > 50 chars)
@@ -150,12 +160,14 @@ if [[ -d "$SKILLS_DIR" ]]; then
             echo "REVIEW: Skill '$basename' contains potential encoded content"
         fi
     done < <(find "$SKILLS_DIR" -type f -name '*.md')
+done
 
+if [[ $SKILL_DIRS_FOUND -eq 0 ]]; then
+    echo "SKIP: No skills directory created."
+else
     if [[ $SKILL_ISSUES -eq 0 ]]; then
         echo "OK: Skill files contain no dangerous patterns."
     fi
-else
-    echo "SKIP: No skills directory created."
 fi
 
 # ── Summary ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- include `.agents/` in the install-audit expected path set for shared skill writes
- audit both Claude skills and `$HOME/.agents/skills` for dangerous patterns
- keep the temporary URL scratch file under the script `mktemp` directory instead of predictable `/tmp/sec_skill_urls`

## Testing

- `bash -n scripts/security-install.sh`
- `make -f Makefile.cbm cbm`
- `bash scripts/security-install.sh build/c/codebase-memory-mcp`

## Context

Extracted from #977 after Codex skill support landed in main. This addresses the two remaining `scripts/security-install.sh` hardening items identified in the maintainer review thread.