### PR TITLE
feat(mcp): surface edge resolution provenance behind include_evidence

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -510,7 +510,11 @@ static const tool_def_t TOOLS[] = {
      "filtered out. When true, test nodes are included with a test column/marker.\"},"
      "\"format\":{\"type\":\"string\",\"enum\":[\"tree\",\"json\"],\"default\":\"tree\","
      "\"description\":\"Response encoding. tree (default): prefix-grouped text rows. "
-     "json: the SAME tree model as structured JSON (groups + column-ordered row arrays).\"}},"
+     "json: the SAME tree model as structured JSON (groups + column-ordered row arrays).\"},"
+     "\"include_evidence\":{\"type\":\"boolean\",\"default\":false,"
+     "\"description\":\"Add how each hop was resolved: a strategy class (lsp | language_rule | "
+     "heuristic | unresolved) and the resolver's confidence. Off by default — it adds two "
+     "columns per row. Use it to judge whether an edge is trustworthy, not to find edges.\"}},"
      "\"required\":[\"function_name\",\"project\"]}"},
 
     {"get_code_snippet", "Get code snippet",
@@ -5648,6 +5652,96 @@ static const char *bfs_edge_args_for_hop(cbm_traverse_result_t *tr, int64_t hop_
     return NULL;
 }
 
+/* Classify a resolver strategy into the CLOSED public vocabulary.
+ *
+ * The indexer records ~20 internal strategy names on CALLS edges
+ * (lsp_trait_dispatch, php_self_static, callee_suffix, ...) and the set grows
+ * with every language. Publishing those verbatim would make each internal
+ * resolver name public API by accident, so a rename would silently change a
+ * user-visible field. We publish the CLASS instead: adding lsp_foo_dispatch
+ * maps automatically, while a genuinely new KIND of resolution fails the
+ * pinning test in tests/test_mcp.c and forces a deliberate decision.
+ *
+ * Returns NULL only for a NULL/empty strategy — every non-empty value lands in
+ * a class, so an unmapped strategy can never silently vanish from output. */
+const char *cbm_mcp_edge_strategy_class(const char *strategy) {
+    if (!strategy || !strategy[0]) {
+        return NULL;
+    }
+    /* Order matters: lsp_unresolved is an LSP strategy that failed, and the
+     * caller cares that it did NOT resolve — so it classifies as unresolved. */
+    if (strcmp(strategy, "lsp_unresolved") == 0 || strcmp(strategy, "unknown") == 0) {
+        return "unresolved";
+    }
+    if (strncmp(strategy, "lsp_", 4) == 0) {
+        return "lsp";
+    }
+    if (strncmp(strategy, "php_", 4) == 0 || strncmp(strategy, "perl_", 5) == 0) {
+        return "language_rule";
+    }
+    /* Everything else is a name/shape heuristic: callee_suffix,
+     * field_type_hint, service_pattern, fastapi_depends, unique_name, ... */
+    return "heuristic";
+}
+
+/* Find the resolution evidence on the edge that leads to the given hop node —
+ * the same endpoint-matching rule as bfs_edge_args_for_hop (target for an
+ * outbound trace, source for inbound, so both directions surface it).
+ *
+ * Reads only from tr->edges, and callers pass the PAGINATED view, so evidence
+ * is emitted for the rows on this page and nothing else.
+ *
+ * Returns false when the edge carries no strategy (non-CALLS edges do not). */
+static bool bfs_edge_evidence_for_hop(cbm_traverse_result_t *tr, int64_t hop_node_id,
+                                      const char **class_out, double *confidence_out) {
+    for (int e = 0; e < tr->edge_count; e++) {
+        if (tr->edges[e].target_id != hop_node_id && tr->edges[e].source_id != hop_node_id) {
+            continue;
+        }
+        const char *pj = tr->edges[e].properties_json;
+        if (!pj) {
+            continue;
+        }
+        const char *key = strstr(pj, "\"strategy\"");
+        if (!key) {
+            continue;
+        }
+        const char *open = strchr(key + 10, '"');
+        if (!open) {
+            continue;
+        }
+        open++;
+        const char *close = strchr(open, '"');
+        if (!close || close == open) {
+            continue;
+        }
+        char raw[CBM_SZ_64];
+        size_t len = (size_t)(close - open);
+        if (len >= sizeof(raw)) {
+            len = sizeof(raw) - 1;
+        }
+        memcpy(raw, open, len);
+        raw[len] = '\0';
+        const char *cls = cbm_mcp_edge_strategy_class(raw);
+        if (!cls) {
+            continue;
+        }
+        *class_out = cls;
+        /* Confidence rides on the same edge; absent is reported as -1 so a
+         * genuine 0.0 stays distinguishable from "not recorded". */
+        *confidence_out = -1.0;
+        const char *conf = strstr(pj, "\"confidence\"");
+        if (conf) {
+            const char *colon = strchr(conf, ':');
+            if (colon) {
+                *confidence_out = strtod(colon + 1, NULL);
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
 /* TOON table for one trace direction: callees[N]{qn,hop,...} with optional
  * risk / test / args columns. `name` is omitted (it is the qn's last
  * segment); the per-item JSON key envelope was 84% of the legacy payload. */
@@ -6061,7 +6155,7 @@ static int tree_hop_cmp_qn(const void *pa, const void *pb) {
 }
 
 static void bfs_to_tree_table(cbm_sb_t *sb, const char *key, cbm_traverse_result_t *tr,
-                              bool include_tests) {
+                              bool include_tests, bool include_evidence) {
     int visible = 0;
     for (int i = 0; i < tr->visited_count; i++) {
         if (!include_tests && is_test_file(tr->visited[i].node.file_path)) {
@@ -6070,8 +6164,12 @@ static void bfs_to_tree_table(cbm_sb_t *sb, const char *key, cbm_traverse_result
         visible++;
     }
     char buf[CBM_SZ_256];
-    snprintf(buf, sizeof(buf), "%s: %d  (rows: name hop; qn = group prefix + \".\" + name)\n", key,
-             visible);
+    snprintf(buf, sizeof(buf),
+             include_evidence
+                 ? "%s: %d  (rows: name hop strategy confidence; qn = group prefix + \".\" + "
+                   "name)\n"
+                 : "%s: %d  (rows: name hop; qn = group prefix + \".\" + name)\n",
+             key, visible);
     cbm_sb_append(sb, buf);
     if (tr->visited_count > 1) {
         qsort(tr->visited, (size_t)tr->visited_count, sizeof(cbm_node_hop_t), tree_hop_cmp_qn);
@@ -6093,7 +6191,26 @@ static void bfs_to_tree_table(cbm_sb_t *sb, const char *key, cbm_traverse_result
             cbm_sb_append(sb, ":\n");
         }
         char row[CBM_SZ_512];
-        snprintf(row, sizeof(row), "  %s %d\n", plen ? qn + plen + 1 : qn, tr->visited[i].hop);
+        const char *ev_class = NULL;
+        double ev_conf = -1.0;
+        if (include_evidence &&
+            bfs_edge_evidence_for_hop(tr, tr->visited[i].node.id, &ev_class, &ev_conf)) {
+            if (ev_conf >= 0.0) {
+                snprintf(row, sizeof(row), "  %s %d %s %.2f\n", plen ? qn + plen + 1 : qn,
+                         tr->visited[i].hop, ev_class, ev_conf);
+            } else {
+                snprintf(row, sizeof(row), "  %s %d %s -\n", plen ? qn + plen + 1 : qn,
+                         tr->visited[i].hop, ev_class);
+            }
+        } else if (include_evidence) {
+            /* The root hop has no inbound edge, and non-CALLS edges record no
+             * strategy. Emit placeholders so the column count stays fixed —
+             * a ragged table is worse to parse than an explicit "-". */
+            snprintf(row, sizeof(row), "  %s %d - -\n", plen ? qn + plen + 1 : qn,
+                     tr->visited[i].hop);
+        } else {
+            snprintf(row, sizeof(row), "  %s %d\n", plen ? qn + plen + 1 : qn, tr->visited[i].hop);
+        }
         cbm_sb_append(sb, row);
     }
 }
@@ -6137,6 +6254,10 @@ static char *handle_trace_call_path(cbm_mcp_server_t *srv, const char *args) {
     }
     bool risk_labels = cbm_mcp_get_bool_arg(args, "risk_labels");
     bool include_tests = cbm_mcp_get_bool_arg(args, "include_tests");
+    /* Off by default: two extra columns on every row is exactly the kind of
+     * inflation the tree format exists to avoid. Opt in when you need to judge
+     * whether an edge is trustworthy. */
+    bool include_evidence = cbm_mcp_get_bool_arg(args, "include_evidence");
 
     if (!func_name) {
         free(project);
@@ -6424,7 +6545,7 @@ static char *handle_trace_call_path(cbm_mcp_server_t *srv, const char *args) {
             if (flat_trace) {
                 bfs_to_toon_table(&sb, "callees", &view_out, risk_labels, include_tests, data_flow);
             } else {
-                bfs_to_tree_table(&sb, "callees", &view_out, include_tests);
+                bfs_to_tree_table(&sb, "callees", &view_out, include_tests, include_evidence);
             }
         }
         if (do_inbound) {
@@ -6432,7 +6553,7 @@ static char *handle_trace_call_path(cbm_mcp_server_t *srv, const char *args) {
             if (flat_trace) {
                 bfs_to_toon_table(&sb, "callers", &view_in, risk_labels, include_tests, data_flow);
             } else {
-                bfs_to_tree_table(&sb, "callers", &view_in, include_tests);
+                bfs_to_tree_table(&sb, "callers", &view_in, include_tests, include_evidence);
             }
         }
         if (more_rows) {

--- a/src/mcp/mcp_internal.h
+++ b/src/mcp/mcp_internal.h
@@ -28,6 +28,16 @@ enum { CBM_MCP_DEFAULT_AUTO_INDEX_LIMIT = 50000 };
  * without retaining per-file results. A false result means the count exceeded
  * file_limit or could not be established before the bounded deadline; every
  * such failure is fail-closed because this is the memory-admission guard. */
+/* Map an internal resolver strategy (as recorded on a CALLS edge by
+ * pass_calls.c) to the CLOSED public class published by trace_path's
+ * include_evidence output: "lsp" | "language_rule" | "heuristic" |
+ * "unresolved". NULL only for a NULL/empty strategy.
+ *
+ * Exposed so tests/test_mcp.c can pin every strategy production can emit to a
+ * known class — a new resolver KIND must fail there rather than leaking an
+ * unmapped internal name into a user-visible field. */
+const char *cbm_mcp_edge_strategy_class(const char *strategy);
+
 bool cbm_mcp_auto_index_within_file_limit(const char *root_path, int file_limit,
                                           int *file_count_out);
 

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -2850,6 +2850,133 @@ TEST(tool_trace_call_path_prefers_definition) {
     PASS();
 }
 
+/* CONTRACT PIN for the closed strategy vocabulary published by
+ * trace_path(include_evidence:true).
+ *
+ * The indexer records ~20 internal strategy names on CALLS edges and the set
+ * grows with every language added. We publish a CLASS, not the raw name, so a
+ * resolver rename cannot silently change a user-visible field. This test is
+ * what keeps that promise honest: every strategy production can emit must land
+ * in a known class. Adding lsp_foo_dispatch passes automatically; introducing a
+ * genuinely new KIND of resolution fails HERE and forces a deliberate decision
+ * about the public contract instead of leaking an internal name. */
+TEST(trace_evidence_strategy_class_vocabulary_is_closed) {
+    /* Every strategy string assigned anywhere in src/ + internal/ as of this
+     * commit, plus the two literals pass_calls.c writes directly. */
+    static const char *const lsp[] = {"lsp_direct",         "lsp_base_dispatch",
+                                      "lsp_embed_dispatch", "lsp_implicit_this",
+                                      "lsp_inherited_dispatch", "lsp_method_dispatch",
+                                      "lsp_proc_macro",     "lsp_smart_ptr_dispatch",
+                                      "lsp_strategy_cross_file", "lsp_trait_dispatch",
+                                      "lsp_type_dispatch",  "lsp_virtual_dispatch"};
+    for (size_t i = 0; i < sizeof(lsp) / sizeof(lsp[0]); i++) {
+        const char *cls = cbm_mcp_edge_strategy_class(lsp[i]);
+        ASSERT_NOT_NULL(cls);
+        ASSERT_STR_EQ(cls, "lsp");
+    }
+    static const char *const lang[] = {"php_self_static", "php_static_resolved",
+                                       "perl_method_static", "perl_method_typed"};
+    for (size_t i = 0; i < sizeof(lang) / sizeof(lang[0]); i++) {
+        const char *cls = cbm_mcp_edge_strategy_class(lang[i]);
+        ASSERT_NOT_NULL(cls);
+        ASSERT_STR_EQ(cls, "language_rule");
+    }
+    static const char *const heur[] = {"callee_suffix", "field_type_hint", "service_pattern",
+                                       "fastapi_depends"};
+    for (size_t i = 0; i < sizeof(heur) / sizeof(heur[0]); i++) {
+        const char *cls = cbm_mcp_edge_strategy_class(heur[i]);
+        ASSERT_NOT_NULL(cls);
+        ASSERT_STR_EQ(cls, "heuristic");
+    }
+    /* A failed LSP resolution is reported as unresolved, not as "lsp" — the
+     * caller's question is whether the edge is trustworthy, and "we tried LSP
+     * and it did not resolve" answers no. */
+    ASSERT_STR_EQ(cbm_mcp_edge_strategy_class("lsp_unresolved"), "unresolved");
+    ASSERT_STR_EQ(cbm_mcp_edge_strategy_class("unknown"), "unresolved");
+    /* Only a NULL/empty strategy is unclassified — an unmapped non-empty value
+     * must never silently disappear from the output. */
+    ASSERT_NULL(cbm_mcp_edge_strategy_class(NULL));
+    ASSERT_NULL(cbm_mcp_edge_strategy_class(""));
+    ASSERT_STR_EQ(cbm_mcp_edge_strategy_class("some_future_resolver"), "heuristic");
+    PASS();
+}
+
+/* Distilled from #559 (@vvenegasv). The indexer already records
+ * {strategy, confidence} on every CALLS edge (pass_calls.c:355) and the store
+ * reads it back, but no tool ever surfaced it — an agent could see THAT A->B
+ * exists, never HOW it was resolved.
+ *
+ * Binds two things at once: the evidence columns appear only when asked for
+ * (default stays lean), and the published value is the CLASS, not the raw
+ * internal strategy name. Fails without the production change in both
+ * directions — no columns at all before, and "lsp_trait_dispatch" would leak
+ * verbatim if the classifier were bypassed. */
+TEST(tool_trace_path_evidence_is_opt_in_and_class_mapped) {
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    const char *proj = "ev-proj";
+    cbm_mcp_server_set_project(srv, proj);
+    cbm_store_upsert_project(st, proj, "/tmp/ev");
+    cbm_node_t caller = {.project = proj,
+                         .label = "Function",
+                         .name = "caller",
+                         .qualified_name = "ev-proj.src.caller",
+                         .file_path = "src/a.c",
+                         .start_line = 1,
+                         .end_line = 5};
+    cbm_node_t callee = {.project = proj,
+                         .label = "Function",
+                         .name = "target",
+                         .qualified_name = "ev-proj.src.target",
+                         .file_path = "src/a.c",
+                         .start_line = 10,
+                         .end_line = 20};
+    int64_t id_caller = cbm_store_upsert_node(st, &caller);
+    int64_t id_callee = cbm_store_upsert_node(st, &callee);
+    ASSERT_GT(id_caller, 0);
+    ASSERT_GT(id_callee, 0);
+    /* Exactly the shape pass_calls.c:355 writes in production. */
+    cbm_edge_t e = {.project = proj,
+                    .source_id = id_caller,
+                    .target_id = id_callee,
+                    .type = "CALLS",
+                    .properties_json = "{\"callee\":\"target\",\"confidence\":0.95,"
+                                       "\"strategy\":\"lsp_trait_dispatch\",\"candidates\":1}"};
+    ASSERT_GT(cbm_store_insert_edge(st, &e), 0);
+
+    /* Default: lean. No evidence columns, no strategy anywhere. */
+    char *plain = cbm_mcp_server_handle(
+        srv, "{\"jsonrpc\":\"2.0\",\"id\":91,\"method\":\"tools/call\","
+             "\"params\":{\"name\":\"trace_path\",\"arguments\":{\"function_name\":\"caller\","
+             "\"project\":\"ev-proj\",\"direction\":\"outbound\"}}}");
+    ASSERT_NOT_NULL(plain);
+    char *plain_txt = extract_text_content(plain);
+    ASSERT_NOT_NULL(plain_txt);
+    ASSERT_NOT_NULL(strstr(plain_txt, "target")); /* positive control: the hop IS there */
+    ASSERT_NULL(strstr(plain_txt, "lsp"));
+    ASSERT_NULL(strstr(plain_txt, "0.95"));
+    free(plain_txt);
+    free(plain);
+
+    /* Opted in: the class and the confidence appear, the raw name does not. */
+    char *ev = cbm_mcp_server_handle(
+        srv, "{\"jsonrpc\":\"2.0\",\"id\":92,\"method\":\"tools/call\","
+             "\"params\":{\"name\":\"trace_path\",\"arguments\":{\"function_name\":\"caller\","
+             "\"project\":\"ev-proj\",\"direction\":\"outbound\",\"include_evidence\":true}}}");
+    ASSERT_NOT_NULL(ev);
+    char *ev_txt = extract_text_content(ev);
+    ASSERT_NOT_NULL(ev_txt);
+    ASSERT_NOT_NULL(strstr(ev_txt, "target"));
+    ASSERT_NOT_NULL(strstr(ev_txt, "lsp"));
+    ASSERT_NOT_NULL(strstr(ev_txt, "0.95"));
+    /* The internal resolver name must NOT reach the client. */
+    ASSERT_NULL(strstr(ev_txt, "lsp_trait_dispatch"));
+    free(ev_txt);
+    free(ev);
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
 /* Reproduce-first (#887): the client-supplied `depth` on trace_call_path must be
  * clamped to the MCP ceiling (cbm_mcp_max_depth(), default 15). On origin/main
  * an MCP_MAX_DEPTH=15 constant was defined but never applied — `depth` flowed
@@ -9800,6 +9927,8 @@ SUITE(mcp) {
     RUN_TEST(tool_trace_union_records_min_hop_across_seeds);
     RUN_TEST(tool_trace_pagination_exactly_once);
     RUN_TEST(tool_trace_call_path_prefers_definition);
+    RUN_TEST(trace_evidence_strategy_class_vocabulary_is_closed);
+    RUN_TEST(tool_trace_path_evidence_is_opt_in_and_class_mapped);
     RUN_TEST(tool_trace_call_path_depth_clamped);
     RUN_TEST(tool_trace_call_path_distinct_defs_not_over_unioned);
     RUN_TEST(tool_trace_call_path_dts_stub_unions_with_impl);


### PR DESCRIPTION
Distilled from #559 by @vvenegasv, with credit on the commit.

## The gap

The indexer already records how every `CALLS` edge was resolved — `pass_calls.c:355` writes `{callee, confidence, strategy, candidates}` into the edge properties, and `cbm_store_traverse` reads it back into `cbm_edge_info_t`. **No tool ever surfaced it.** `grep -n confidence src/mcp/mcp.c` on main returns nothing.

So an agent could see *that* `A` calls `B`, but never how confident the resolver was, or whether the edge came from an LSP or from a name-shape heuristic. Those are very different claims, and the difference matters when deciding whether to trust a trace.

Surfacing it costs **zero added storage and zero added indexing work** — the indexer is already paying to compute and persist it.

## What this adds

`trace_path` and `trace_call_path` gain `include_evidence` (default `false`). When set, each row carries two extra columns:

```
callees: 2  (rows: name hop strategy confidence; qn = group prefix + "." + name)
ev-proj.src:
  target 1 lsp 0.95
  helper 2 heuristic 0.60
```

## Two decisions worth stating

**Opt-in, not default.** Two extra columns on every row is exactly the inflation the tree format exists to avoid — the default response is byte-identical to before this change.

**A closed class, not the raw strategy.** Production emits ~20 internal strategy names (`lsp_trait_dispatch`, `php_self_static`, `callee_suffix`, `service_pattern`, …) and the set grows with every language added. Publishing them verbatim would make each internal resolver name public API by accident, so a rename would silently change a user-visible field.

`cbm_mcp_edge_strategy_class()` maps them to a fixed vocabulary:

| class | covers |
|---|---|
| `lsp` | every `lsp_*` strategy that resolved |
| `language_rule` | `php_*`, `perl_*` — language-specific static resolution |
| `heuristic` | `callee_suffix`, `field_type_hint`, `service_pattern`, `fastapi_depends`, … |
| `unresolved` | `lsp_unresolved`, `unknown` |

Adding `lsp_foo_dispatch` maps automatically; a genuinely new **kind** of resolution fails the pinning test and forces a deliberate decision about the public contract.

`lsp_unresolved` classifies as `unresolved`, not `lsp` — the caller's question is whether the edge is trustworthy, and "we tried LSP and it did not resolve" answers no.

## Pagination

Evidence is looked up against the **paginated view**, so it is emitted only for the rows on the current page. It does not bypass `limit`, the cursor, or the `MCP_BFS_LIMIT_MAX` guard. (The original PR called its emitter with the full traversal result, which would have regressed the tree format's token win.)

## Tests

Both fail without the production change:

- **`trace_evidence_strategy_class_vocabulary_is_closed`** — pins every strategy production can emit to a known class, so an unmapped resolver kind fails here rather than leaking an internal name into a user-visible field.
- **`tool_trace_path_evidence_is_opt_in_and_class_mapped`** — end-to-end through the real MCP server: absent by default (with a positive control proving the hop *is* in the response), present when asked for, and `lsp_trait_dispatch` never reaching the client.

## Verification

- `mcp`, `mcp_mutation_guard`, `store_nodes`, `pipeline` — **504 passed, 2 skipped**
- `make -f Makefile.cbm lint-ci` — clean
- **Revert-checks, both directions:** neutering `include_evidence` fails the e2e test at the `lsp` assertion; bypassing the classifier to pass the raw strategy through trips **ASan with a stack-use-after-return** (`raw` is a stack local), which incidentally confirms the classifier returning static literals is load-bearing rather than cosmetic.

## Not included from #559

The freshness half. It is non-functional in production — both pipelines persist through the direct SQLite writer, where `build_project_record` records a hardcoded NULL — and its `ALTER TABLE` migration never runs for the read-only opens the MCP server uses, so it would make every project indexed by an older binary report itself unindexed. That is written up on #559 and recorded as a design question rather than dropped.
