### PR TITLE
fix(python): suppress weak same-name CALLS for get/run/execute

### DIFF
--- a/internal/cbm/extract_calls.c
+++ b/internal/cbm/extract_calls.c
@@ -2244,6 +2244,17 @@ void handle_calls(CBMExtractCtx *ctx, TSNode node, const CBMLangSpec *spec, Walk
                     }
                 }
             }
+            /* Python attribute calls (prior_cp.get(...)): flag as method so weak
+             * short-name resolution can be suppressed (G2 / WP-B C2), mirroring
+             * the TS/JS receiver-aware guard above. Bare calls stay false. */
+            if (ctx->language == CBM_LANG_PYTHON &&
+                strcmp(ts_node_type(node), "call") == 0) {
+                TSNode fn = ts_node_child_by_field_name(node, TS_FIELD("function"));
+                if (!ts_node_is_null(fn) &&
+                    (strcmp(ts_node_type(fn), "attribute") == 0)) {
+                    call.is_method = true;
+                }
+            }
 
             TSNode args = ts_node_child_by_field_name(node, TS_FIELD("arguments"));
             // ObjectScript stores args under oref_method/method_args, not the

--- a/src/pipeline/pass_calls.c
+++ b/src/pipeline/pass_calls.c
@@ -421,7 +421,7 @@ static void emit_classified_edge(cbm_pipeline_ctx_t *ctx, const CBMCall *call,
         return;
     }
     if (suppress_plain_calls) {
-        return; /* weak TS/JS member-call match with an unresolved receiver (#606) */
+        return; /* weak TS/JS or Python same-name match (#606 / G2) */
     }
     char esc_c2[CBM_SZ_256];
     cbm_json_escape(esc_c2, sizeof(esc_c2), call->callee_name);
@@ -585,6 +585,10 @@ static int resolve_single_call(cbm_pipeline_ctx_t *ctx, CBMCall *call,
         lang == CBM_LANG_JAVASCRIPT || lang == CBM_LANG_TYPESCRIPT || lang == CBM_LANG_TSX;
     bool tsjs_drop_plain_call =
         cbm_tsjs_suppress_weak_method_match(is_tsjs, call->is_method, res.strategy);
+    /* Python weak same-name suppression (G2): member calls + bare get/run/execute. */
+    bool py_drop_plain_call = cbm_python_suppress_weak_generic_call(
+        lang == CBM_LANG_PYTHON, call->is_method, call->callee_name, res.strategy);
+    bool drop_plain_call = tsjs_drop_plain_call || py_drop_plain_call;
 
     /* Service-pattern HTTP/ASYNC calls to an EXTERNAL client library (e.g.
      * `requests.get("/api/orders/{id}")`) resolve to a QN containing the library
@@ -611,7 +615,7 @@ static int resolve_single_call(cbm_pipeline_ctx_t *ctx, CBMCall *call,
         return 0;
     }
     emit_classified_edge(ctx, call, source_node, target_node, &res, module_qn, imp_keys, imp_vals,
-                         imp_count, tsjs_drop_plain_call);
+                         imp_count, drop_plain_call);
     return SKIP_ONE;
 }
 

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -2335,6 +2335,9 @@ static void resolve_file_calls(resolve_ctx_t *rc, resolve_worker_state_t *ws, CB
             lang == CBM_LANG_JAVASCRIPT || lang == CBM_LANG_TYPESCRIPT || lang == CBM_LANG_TSX;
         bool tsjs_drop_plain_call =
             cbm_tsjs_suppress_weak_method_match(is_tsjs, call->is_method, res.strategy);
+        bool py_drop_plain_call = cbm_python_suppress_weak_generic_call(
+            lang == CBM_LANG_PYTHON, call->is_method, call->callee_name, res.strategy);
+        bool drop_plain_call = tsjs_drop_plain_call || py_drop_plain_call;
 
         /* Service-pattern HTTP/ASYNC client call (`requests.get(url)`): the
          * service signal lives in the callee_name. The registry can mis-resolve
@@ -2423,7 +2426,7 @@ static void resolve_file_calls(resolve_ctx_t *rc, resolve_worker_state_t *ws, CB
         _rc_t0 = extract_now_ns();
         emit_service_edge(ws->local_edge_buf, source_node, target_node, call, &res, module_qn,
                           rc->registry, rc->main_gbuf, imp_keys, imp_vals, imp_count,
-                          tsjs_drop_plain_call);
+                          drop_plain_call);
         atomic_fetch_add_explicit(&rc->time_ns_rc_emit, extract_now_ns() - _rc_t0,
                                   memory_order_relaxed);
         ws->calls_resolved++;

--- a/src/pipeline/pipeline.h
+++ b/src/pipeline/pipeline.h
@@ -256,6 +256,16 @@ bool cbm_perl_suppress_generic_match(bool is_perl, bool is_method, const char *c
  * Pure; unit-tested in test_registry.c. */
 bool cbm_tsjs_suppress_weak_method_match(bool is_tsjs, bool is_method, const char *strategy);
 
+/* Decide whether a resolved Python call edge is weak-strategy same-name noise to
+ * drop (Yui WP-B C2 / G2): true only for Python, only for weak short-name
+ * strategies (suffix_match / unique_name / field_type_hint / fuzzy), and only when
+ * (a) the call is a member call (x.get / prior_cp.get), OR (b) the bare callee is
+ * a high-fan-in generic name (get / run / execute) — e.g. a Callable parameter
+ * named `run` invoked as run(). Keeps import_map / same_module / lsp_* / etc.
+ * Pure; unit-tested in test_registry.c. */
+bool cbm_python_suppress_weak_generic_call(bool is_python, bool is_method, const char *callee_name,
+                                           const char *strategy);
+
 /* Get the label of a qualified name, or NULL if not found. */
 const char *cbm_registry_label_of(const cbm_registry_t *r, const char *qn);
 

--- a/src/pipeline/registry.c
+++ b/src/pipeline/registry.c
@@ -455,6 +455,37 @@ bool cbm_tsjs_suppress_weak_method_match(bool is_tsjs, bool is_method, const cha
            strcmp(strategy, "field_type_hint") == 0 || strcmp(strategy, "fuzzy") == 0;
 }
 
+/* High-fan-in Python basenames that frequently collide across modules (G2).
+ * Bare calls like a Callable parameter `run()` must not suffix_match onto an
+ * unrelated Method/Function with the same name. Member calls (is_method) are
+ * handled regardless of name — mirror TS/JS #592/#606. */
+static bool cbm_python_is_generic_callee_name(const char *callee_name) {
+    if (!callee_name || !callee_name[0]) {
+        return false;
+    }
+    return strcmp(callee_name, "get") == 0 || strcmp(callee_name, "run") == 0 ||
+           strcmp(callee_name, "execute") == 0;
+}
+
+static bool cbm_python_is_weak_short_name_strategy(const char *strategy) {
+    if (!strategy || !strategy[0]) {
+        return false;
+    }
+    return strcmp(strategy, "suffix_match") == 0 || strcmp(strategy, "unique_name") == 0 ||
+           strcmp(strategy, "field_type_hint") == 0 || strcmp(strategy, "fuzzy") == 0;
+}
+
+bool cbm_python_suppress_weak_generic_call(bool is_python, bool is_method, const char *callee_name,
+                                           const char *strategy) {
+    if (!is_python || !cbm_python_is_weak_short_name_strategy(strategy)) {
+        return false;
+    }
+    if (is_method) {
+        return true; /* prior_cp.get → unrelated SessionRegistry.get, etc. */
+    }
+    return cbm_python_is_generic_callee_name(callee_name); /* bare run()/get()/execute() */
+}
+
 /* ── Lifecycle ──────────────────────────────────────────────────── */
 
 cbm_registry_t *cbm_registry_new(void) {

--- a/tests/test_pipeline.c
+++ b/tests/test_pipeline.c
@@ -964,6 +964,58 @@ TEST(pipeline_incremental_preserves_cross_file_calls) {
     PASS();
 }
 
+/* Python weak same-name suppression (G2 / WP-B C2). Dict `.get` and a Callable
+ * parameter `run()` must not suffix_match onto unrelated project Methods.
+ * Same-module bare helpers remain. < 50 files → sequential path. */
+static void write_temp_file(const char *dir, const char *name, const char *content);
+TEST(pipeline_python_suppresses_weak_generic_edges) {
+    char tmp[256];
+    snprintf(tmp, sizeof(tmp), "/tmp/cbm_py_g2_XXXXXX");
+    if (!cbm_mkdtemp(tmp)) {
+        FAIL("tmpdir");
+    }
+
+    write_temp_file(tmp, "browser.py",
+                    "class SessionRegistry:\n"
+                    "    def get(self, name):\n"
+                    "        return name\n");
+    write_temp_file(tmp, "live.py",
+                    "class SatoriLive:\n"
+                    "    def run(self):\n"
+                    "        return 1\n");
+    write_temp_file(tmp, "router.py",
+                    "def submit_task(prior_cp):\n"
+                    "    return prior_cp.get(\"runtime_decision_id\")\n");
+    write_temp_file(tmp, "gate.py",
+                    "def _run_with_heavy_slot(run):\n"
+                    "    return run()\n"
+                    "\n"
+                    "def local_helper():\n"
+                    "    return 2\n"
+                    "\n"
+                    "def calls_local():\n"
+                    "    return local_helper()\n");
+
+    char db_path[512];
+    snprintf(db_path, sizeof(db_path), "%s/py_g2.db", tmp);
+    cbm_pipeline_t *p = cbm_pipeline_new(tmp, db_path, CBM_MODE_FULL);
+    ASSERT_NOT_NULL(p);
+    ASSERT_EQ(cbm_pipeline_run(p), 0);
+    const char *project = cbm_pipeline_project_name(p);
+
+    cbm_store_t *s = cbm_store_open_path(db_path);
+    ASSERT_NOT_NULL(s);
+
+    ASSERT_FALSE(cross_file_call_exists(s, project, "submit_task", "get"));
+    ASSERT_FALSE(cross_file_call_exists(s, project, "_run_with_heavy_slot", "run"));
+    ASSERT_TRUE(cross_file_call_exists(s, project, "calls_local", "local_helper"));
+
+    cbm_store_close(s);
+    cbm_pipeline_free(p);
+    th_rmtree(tmp);
+    PASS();
+}
+
 /* TS/JS receiver-aware weak-strategy suppression (#592/#606 direction; Perl
  * precedent #477). A member call x.foo() whose receiver TYPE the TS-LSP cannot
  * resolve (a regex literal `re.test()`) must NOT be bound to a same-named
@@ -7788,6 +7840,7 @@ SUITE(pipeline) {
     RUN_TEST(pipeline_calls_resolution);
     RUN_TEST(pipeline_nix_scoped_binding_calls_resolve);
     RUN_TEST(pipeline_incremental_preserves_cross_file_calls);
+    RUN_TEST(pipeline_python_suppresses_weak_generic_edges);
     RUN_TEST(pipeline_tsjs_receiver_suppresses_weak_method_edge);
     RUN_TEST(pipeline_tsjs_receiver_parallel_keeps_service_edges);
     RUN_TEST(pipeline_native_fetch_classified_as_http_calls);

--- a/tests/test_registry.c
+++ b/tests/test_registry.c
@@ -803,6 +803,35 @@ TEST(tsjs_suppress_keeps_high_confidence_and_non_methods) {
     PASS();
 }
 
+
+TEST(python_suppress_drops_weak_member_and_generic_bare) {
+    /* G2: Python prior_cp.get / bare run() must not keep weak short-name edges. */
+    ASSERT_TRUE(cbm_python_suppress_weak_generic_call(true, true, "get", "suffix_match"));
+    ASSERT_TRUE(cbm_python_suppress_weak_generic_call(true, true, "anything", "unique_name"));
+    ASSERT_TRUE(cbm_python_suppress_weak_generic_call(true, true, "foo", "field_type_hint"));
+    ASSERT_TRUE(cbm_python_suppress_weak_generic_call(true, true, "bar", "fuzzy"));
+    ASSERT_TRUE(cbm_python_suppress_weak_generic_call(true, false, "get", "suffix_match"));
+    ASSERT_TRUE(cbm_python_suppress_weak_generic_call(true, false, "run", "unique_name"));
+    ASSERT_TRUE(cbm_python_suppress_weak_generic_call(true, false, "execute", "suffix_match"));
+    PASS();
+}
+
+TEST(python_suppress_keeps_strong_strategies_and_non_generic_bare) {
+    ASSERT_FALSE(cbm_python_suppress_weak_generic_call(true, true, "get", "same_module"));
+    ASSERT_FALSE(cbm_python_suppress_weak_generic_call(true, true, "get", "import_map"));
+    ASSERT_FALSE(cbm_python_suppress_weak_generic_call(true, true, "get", "import_map_suffix"));
+    ASSERT_FALSE(cbm_python_suppress_weak_generic_call(true, true, "get", "lsp_generic_method"));
+    ASSERT_FALSE(cbm_python_suppress_weak_generic_call(true, true, "get", "lsp_direct"));
+    /* Bare non-generic helper must not be suppressed (unique_name often correct). */
+    ASSERT_FALSE(cbm_python_suppress_weak_generic_call(true, false, "local_helper", "unique_name"));
+    ASSERT_FALSE(cbm_python_suppress_weak_generic_call(true, false, "helper", "suffix_match"));
+    /* Non-Python unaffected. */
+    ASSERT_FALSE(cbm_python_suppress_weak_generic_call(false, true, "get", "suffix_match"));
+    ASSERT_FALSE(cbm_python_suppress_weak_generic_call(true, false, "run", NULL));
+    ASSERT_FALSE(cbm_python_suppress_weak_generic_call(true, true, "get", ""));
+    PASS();
+}
+
 /* ── Suite ─────────────────────────────────────────────────────── */
 
 /* Method call THROUGH an imported symbol that is itself an indexed node
@@ -895,4 +924,6 @@ SUITE(registry) {
     RUN_TEST(perl_suppress_keeps_high_confidence_and_genuine_calls);
     RUN_TEST(tsjs_suppress_drops_weak_method_matches);
     RUN_TEST(tsjs_suppress_keeps_high_confidence_and_non_methods);
+    RUN_TEST(python_suppress_drops_weak_member_and_generic_bare);
+    RUN_TEST(python_suppress_keeps_strong_strategies_and_non_generic_bare);
 }


### PR DESCRIPTION
## Summary
- Suppress weak short-name CALLS resolution for Python attribute calls and bare generic callees (`get` / `run` / `execute`), mirroring the existing TS/JS weak-method guard.
- Flag Python `attribute` calls as `is_method` during extraction so `prior_cp.get(...)` cannot `suffix_match` onto unrelated Methods (e.g. `_SessionRegistry.get`).
- Same guard drops bare `run()` Callable-parameter calls from binding to unrelated Methods (e.g. `SatoriLive.run`).

## Motivation (Yui WP-B C2 / G2)
On a large Python repo, `trace_path` hop-1 showed fabricated CALLS:
- `router.submit_task` → `_SessionRegistry.get` via `strategy=suffix_match` / `callee=prior_cp.get` / conf `0.28`
- `gate._run_with_heavy_slot` → `SatoriLive.run` via `suffix_match` / bare `run()` / conf `0.28`

Strong strategies (`import_map`, `same_module`, `lsp_*`) are kept.

## Test plan
- [x] `./build/c/test-runner registry` (includes new python suppress unit tests)
- [x] `./build/c/test-runner pipeline` (includes `pipeline_python_suppresses_weak_generic_edges`)
- [ ] Maintainer CI green


Made with [Cursor](https://cursor.com)