### PR TITLE
fix(cypher): unify repeated variable-length nodes

### DIFF
--- a/src/cypher/cypher.c
+++ b/src/cypher/cypher.c
@@ -3151,12 +3151,17 @@ static void expand_var_length(cbm_store_t *store, cbm_rel_pattern_t *rel,
     cbm_traverse_result_t tr = {0};
     const char *dir = rel->direction ? rel->direction : "outbound";
     cbm_store_bfs(store, src->id, dir, rel->types, rel->type_count, max_depth, CBM_PERCENT, &tr);
+    cbm_node_t *bound_to = binding_get(b, to_var);
+    int64_t bound_to_id = bound_to ? bound_to->id : 0;
     /* Same contract as process_edges: the budget caps materialisation, never
      * detection, so a saturated source cannot report match_count == 0 and get a
      * fabricated OPTIONAL "no match" row. */
     for (int v = 0; v < tr.visited_count; v++) {
         cbm_node_hop_t *hop = &tr.visited[v];
         if (hop->hop < rel->min_hops) {
+            continue;
+        }
+        if (bound_to && hop->node.id != bound_to_id) {
             continue;
         }
         if (target_node->label && !label_alt_matches(hop->node.label, target_node->label)) {

--- a/tests/test_cypher.c
+++ b/tests/test_cypher.c
@@ -1371,6 +1371,22 @@ TEST(cypher_exec_variable_length) {
     PASS();
 }
 
+TEST(cypher_exec_variable_length_repeated_node_var_unifies) {
+    cbm_store_t *s = setup_cypher_store();
+    cbm_cypher_result_t r = {0};
+
+    int rc = cbm_cypher_execute(s,
+                                "MATCH (f:Function)-[:CALLS*1..2]->(f:Function) "
+                                "RETURN f.name",
+                                "test", 0, &r);
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(r.row_count, 0);
+
+    cbm_cypher_result_free(&r);
+    cbm_store_close(s);
+    PASS();
+}
+
 /* Reproduce-first (#887): an EXPLICIT variable-length upper bound must still be
  * capped at the engine ceiling (cbm_cypher_max_depth(), default 10). On
  * origin/main, expand_var_length honoured an explicit `*1..N` verbatim (only the
@@ -3612,6 +3628,7 @@ SUITE(cypher) {
     RUN_TEST(cypher_exec_limit);
     RUN_TEST(cypher_exec_order_by);
     RUN_TEST(cypher_exec_variable_length);
+    RUN_TEST(cypher_exec_variable_length_repeated_node_var_unifies);
     RUN_TEST(cypher_exec_var_length_explicit_bound_capped);
     RUN_TEST(cypher_exec_defines_edge);
     RUN_TEST(cypher_exec_no_results);


### PR DESCRIPTION
## What does this PR do?

Part of #797. This is the repeated-node-variable fix split from #883 as requested in maintainer review.

Variable-length expansion currently overwrites an existing terminal-node binding with each BFS result. As a result, a pattern such as `MATCH (f)-[:CALLS*1..2]->(f)` can return paths ending at a different node even though both `f` occurrences must identify the same node.

The change applies the same binding-unification rule already used by fixed-length relationships: when the terminal variable is bound, variable-length expansion only accepts traversal results with the same node id.

This PR intentionally does not include the trail-enumeration semantics, BFS fork, row cap, or related tests from #883.

## Verification

```sh
make -f Makefile.cbm test
make -f Makefile.cbm lint-ci
make -f Makefile.cbm security
```

The focused Cypher suite passes 171 tests. The repository lint and all eight security layers pass. The full test target reaches and passes the changed Cypher suite; unrelated subprocess and install-staging failures reproduce on the exact unmodified `main` base in the same environment.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects unsigned commits
- [x] New behavior is covered by a reproduce-first test
- [x] Lint passes
- [x] Security checks pass
