### PR TITLE
fix(extract): resolve Go route paths built via string concatenation

### DIFF
--- a/internal/cbm/extract_calls.c
+++ b/internal/cbm/extract_calls.c
@@ -1707,6 +1707,24 @@ static const char *extract_keyword_url(CBMExtractCtx *ctx, TSNode arg) {
     return extract_string_value(ctx, val_node);
 }
 
+// `prefixVar + "/route"` (Go's idiomatic configurable-base-path pattern):
+// recover the literal suffix. A right side that is not itself a literal is
+// left unresolved rather than guessed (issue #1249).
+static const char *extract_binary_concat_suffix(CBMExtractCtx *ctx, TSNode node) {
+    TSNode op_node = ts_node_child_by_field_name(node, TS_FIELD("operator"));
+    if (!ts_node_is_null(op_node)) {
+        char *op = cbm_node_text(ctx->arena, op_node, ctx->source);
+        if (!op || strcmp(op, "+") != 0) {
+            return NULL;
+        }
+    }
+    TSNode rhs = ts_node_child_by_field_name(node, TS_FIELD("right"));
+    if (ts_node_is_null(rhs) || !is_string_like(ts_node_type(rhs))) {
+        return NULL;
+    }
+    return strip_and_validate_string_arg(ctx->arena, cbm_node_text(ctx->arena, rhs, ctx->source));
+}
+
 // Try to extract URL/topic from a positional argument (string or constant).
 static const char *extract_positional_url(CBMExtractCtx *ctx, TSNode arg, const char *ak) {
     /* JS/TS template literals: `/things/${id}` normalizes to "/things/{}" so the
@@ -1715,6 +1733,12 @@ static const char *extract_positional_url(CBMExtractCtx *ctx, TSNode arg, const 
         const char *flat = cbm_template_string_text(ctx->arena, arg, ctx->source);
         if (flat) {
             return strip_and_validate_string_arg(ctx->arena, (char *)flat);
+        }
+    }
+    if (strcmp(ak, "binary_expression") == 0) {
+        const char *suffix = extract_binary_concat_suffix(ctx, arg);
+        if (suffix) {
+            return suffix;
         }
     }
     if (is_string_like(ak)) {

--- a/tests/test_extraction.c
+++ b/tests/test_extraction.c
@@ -3181,6 +3181,57 @@ TEST(extract_ts_template_string_url_issue1006) {
     PASS();
 }
 
+/* Issue #1249: a mux route built as `configVar + "/literal"` (Go's idiomatic
+ * configurable-base-path pattern) must index the literal suffix, both for a
+ * route registration and for an outbound URL built the same way. A real BFF
+ * with 47 such registrations produced only 9 Route nodes before this fix. */
+TEST(extract_go_binary_concat_url_issue1249) {
+    CBMFileResult *r = extract("package main\n"
+                               "import \"net/http\"\n"
+                               "func setup(mux *http.ServeMux, base string) {\n"
+                               "    mux.HandleFunc(base+\"/login\", loginHandler)\n"
+                               "}\n"
+                               "func report(host string, port string) {\n"
+                               "    http.Get(\"http://\" + host + \":\" + port + \"/log\")\n"
+                               "}\n",
+                               CBM_LANG_GO, "t", "routes.go");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+
+    const CBMCall *reg = find_call_by_callee(r, "mux.HandleFunc");
+    ASSERT_NOT_NULL(reg);
+    ASSERT_NOT_NULL(reg->first_string_arg);
+    ASSERT_STR_EQ(reg->first_string_arg, "/login");
+
+    const CBMCall *out = find_call_by_callee(r, "http.Get");
+    ASSERT_NOT_NULL(out);
+    ASSERT_NOT_NULL(out->first_string_arg);
+    ASSERT_STR_EQ(out->first_string_arg, "/log");
+
+    cbm_free_result(r);
+    PASS();
+}
+
+/* Same issue: when the right side of the concatenation is not itself a
+ * literal (`base + suffixVar`), there is no literal route to recover. The
+ * fix must leave this unresolved rather than fabricate a path. */
+TEST(extract_go_binary_concat_url_no_literal_suffix_issue1249) {
+    CBMFileResult *r = extract("package main\n"
+                               "func setup(mux *http.ServeMux, base string, suffix string) {\n"
+                               "    mux.HandleFunc(base+suffix, dynHandler)\n"
+                               "}\n",
+                               CBM_LANG_GO, "t", "routes.go");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+
+    const CBMCall *reg = find_call_by_callee(r, "mux.HandleFunc");
+    ASSERT_NOT_NULL(reg);
+    ASSERT_NULL(reg->first_string_arg);
+
+    cbm_free_result(r);
+    PASS();
+}
+
 
 /* Reproduce-first: Java module QN must derive from the CONTAINING DIRECTORY, not
  * the filename stem, so a top-level class `Outer` in `Outer.java` is `t.Outer`,
@@ -5315,6 +5366,8 @@ SUITE(extraction) {
     RUN_TEST(extract_java_method_annotations_issue382);
     RUN_TEST(extract_java_jaxrs_path_composition_issue1005);
     RUN_TEST(extract_ts_template_string_url_issue1006);
+    RUN_TEST(extract_go_binary_concat_url_issue1249);
+    RUN_TEST(extract_go_binary_concat_url_no_literal_suffix_issue1249);
     RUN_TEST(extract_java_no_double_class_qn);
     RUN_TEST(extract_go_no_filename_in_module_qn);
     RUN_TEST(extract_large_ts_has_functions_issue213);


### PR DESCRIPTION
## What does this PR do?

`r.HandleFunc(base+"/login", loginHandler)` and outbound calls built the same way (`"http://" + host + ":" + port + "/log"`) were not indexed: `extract_positional_url` (internal/cbm/extract_calls.c) has no branch for `binary_expression`, the AST node Go's `+` produces, so the argument falls through and `first_string_arg` stays NULL. On the reporter's real BFF (47 `HandleFunc` registrations, all `BaseURL+"literal"`), the graph contained only 9 Route nodes.

Added `extract_binary_concat_suffix`: for a `+` concatenation, recover the literal string on the right-hand side (the config-prefix pattern this issue describes). When the right side is not itself a literal, the call is left unresolved rather than guessing a path, matching the reporter's own expected behavior.

## Checklist

- [x] Every commit is signed off (`git commit -s`)
- [x] Tests pass locally (`make -f Makefile.cbm test`)
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)

## Verification

- New regression test (`extract_go_binary_concat_url_issue1249`) fails on unmodified `main` (`first_string_arg is NULL`) and passes on this branch, covering both the mux registration and the outbound-URL case from the issue.
- A second test confirms a concatenation whose right side is not a literal (`base+suffixVar`) still resolves to no route, so nothing is fabricated.
- Full `extraction` suite (273 tests) passes under ASan+UBSan; `scripts/lint.sh --ci` (cppcheck + clang-format) is clean on the changed files.
- Not run: the full sanitized suite outside `extraction`, and the macOS/Windows CI legs (no such runners here).

Fixes #1249
