### PR TITLE
fix: guard activation_finish_absent_publish behind its call-site conditions

### DIFF
--- a/src/cli/activation_transaction.c
+++ b/src/cli/activation_transaction.c
@@ -1695,6 +1695,7 @@ static activation_publish_status_t activation_publish_absent_link_fallback(
 }
 #endif
 
+#if defined(_WIN32) || defined(__APPLE__) || (defined(__linux__) && defined(SYS_renameat2))
 static activation_publish_status_t activation_finish_absent_publish(
     cbm_activation_transaction_t *transaction) {
     transaction->staged_exists = false;
@@ -1705,6 +1706,7 @@ static activation_publish_status_t activation_finish_absent_publish(
                ? ACTIVATION_PUBLISH_OK
                : ACTIVATION_PUBLISH_CHANGED_ERROR;
 }
+#endif
 
 static activation_publish_status_t activation_publish_absent_replacement(
     cbm_activation_transaction_t *transaction) {


### PR DESCRIPTION
## What does this PR do?

> Extracted from PR #1138 as requested during review.

Building on FreeBSD after syncing with upstream failed with -Werror,-Wunused-function on activation_finish_absent_publish in src/cli/activation_transaction.c.

The function is only invoked from three platform-specific branches: Windows (_WIN32, MoveFileExW), macOS (__APPLE__, renameatx_np), and modern Linux (__linux__ with SYS_renameat2, via syscall). On every other POSIX target — including FreeBSD and other BSDs — control falls through to the portable linkat(2) fallback, so the helper was defined but never called, tripping -Wunused-function under -Werror.

Rather than excluding FreeBSD by name (which would still break on OpenBSD, NetBSD, DragonFly, Solaris, or any Linux without SYS_renameat2), wrap the function definition in the same #if condition as its call sites. This keeps the guard mechanically tied to actual usage instead of enumerating platforms, so it stays correct as new targets are added.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test`)
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [ ] New behavior is covered by a test (reproduce-first for bug fixes)
