### PR TITLE
fix(cli): add native FreeBSD self-executable path resolution

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -107,6 +107,10 @@ static int cbm_powershell_quote_word(const char *value, char *out, size_t out_si
 #include <stdlib.h>
 #include <string.h>   // strtok_r
 #include <sys/stat.h> // mode_t, S_IXUSR
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#endif
 #include <time.h>
 #include <wchar.h>
 #include <zlib.h> // MAX_WBITS
@@ -8910,6 +8914,13 @@ static bool cbm_detect_self_path(char *buf, size_t buf_sz, const char *home) {
 #elif defined(__APPLE__)
     uint32_t sp_sz = (uint32_t)buf_sz;
     exact = _NSGetExecutablePath(buf, &sp_sz) == 0;
+    if (!exact) {
+        buf[0] = '\0';
+    }
+#elif defined(__FreeBSD__)
+    int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+    size_t cb = buf_sz;
+    exact = sysctl(mib, 4, buf, &cb, NULL, 0) == 0 && cb > 0;
     if (!exact) {
         buf[0] = '\0';
     }


### PR DESCRIPTION
## What does this PR do?

> Extracted from PR #1138 as requested during review.

`cbm_detect_self_path` had no branch for FreeBSD, falling through to the generic `#else` that reads `/proc/self/exe`. In this environment `/proc` is a native FreeBSD procfs mount left empty (only `/compat/linux/proc` is populated, for Linux-ABI processes under the compat layer), so the `readlink` always failed silently and the function fell back to the expected install path instead of the actual running binary's path.

This broke `install`: with no valid self path, the activation transaction could never confirm what to publish and aborted early before attempting any `linkat`/`rename`.

Add `sysctl(CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1)` for FreeBSD in `src/cli/cli.c`, matching the pattern already used in the test suites, and include `<sys/sysctl.h>` guarded by `__FreeBSD__`.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`make -f Makefile.cbm test`)
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [ ] New behavior is covered by a test (reproduce-first for bug fixes)
