### PR TITLE
fix(mcp): set stdio to binary mode on Windows

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -11177,6 +11177,13 @@ static int poll_for_input_unix(cbm_mcp_server_t *srv, int fd, FILE *in) {
 int cbm_mcp_server_run(cbm_mcp_server_t *srv, FILE *in, FILE *out) {
     int fd = cbm_fileno(in);
 
+#ifdef _WIN32
+    /* Ensure stdio is in binary mode to prevent CRLF translation from corrupting
+     * Content-Length byte counts and causing fread() to hang. */
+    _setmode(cbm_fileno(in), _O_BINARY);
+    _setmode(cbm_fileno(out), _O_BINARY);
+#endif
+
     for (;;) {
         /* Poll with idle timeout so we can evict unused stores between requests.
          *


### PR DESCRIPTION
## Problem

On Windows, `stdin`/`stdout` default to **text mode**, which translates `LF` -> `CRLF` on write and `CRLF` -> `LF` on read. The MCP framing layer counts bytes for `Content-Length`, so any translated byte makes the declared length disagree with the actual payload. The subsequent `fread()` then waits for bytes that never arrive and the server hangs with no error.

The symptom is a native MCP server that connects, handshakes, and then stops responding on the first message containing a newline — which in practice is every real request. It reproduces on Windows only, and it presents as a *client* timeout rather than a server bug, so it is easy to misattribute.

## Fix

Call `_setmode(_O_BINARY)` on both descriptors at the top of `cbm_mcp_server_run`, guarded by `#ifdef _WIN32`. No behaviour change on POSIX.

7 lines, one file.

## Verification

Built and running continuously on Windows 11 (build 26200) since 2026-07-30 with no further hangs, driving a ~70k-symbol index through the Claude Code MCP client.

## Note for maintainers

`_O_BINARY` is documented as coming from `<fcntl.h>`, which this file includes only in the `#else` (non-Windows) branch — `<io.h>` is what the `_WIN32` branch gets. It resolves today via transitive inclusion through `<windows.h>`, so the build is fine as-is, but an explicit `#include <fcntl.h>` in the `_WIN32` branch would make that independent of Windows SDK header layout.

I left it out to keep the change minimal — happy to add it if you'd prefer.