### PR TITLE
ci(codeql): bump init and analyze together to v4.37.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y zlib1g-dev
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: c-cpp
           build-mode: manual
@@ -38,6 +38,6 @@ jobs:
         run: scripts/build.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:c-cpp"


### PR DESCRIPTION
Dependabot split the codeql-action 4.36.2 → 4.37.3 bump into two PRs (#1398 init-only, #1399 analyze-only). CodeQL requires init and analyze at the same version, so each PR alone fails its own `analyze` job with:

> Loaded a configuration file for version '4.37.3', but running version '4.36.2'

This bumps both pins in one change. The SHA `e4fba868` is verified to match the upstream `v4.37.3` tag. Supersedes #1398 and #1399 (dependabot will close them once this lands).