### PR TITLE
build(windows): do not pass -z noexecstack when cross-compiling to PE

### DIFF
--- a/Makefile.cbm
+++ b/Makefile.cbm
@@ -162,7 +162,11 @@ endif
 # shipped artifact. ELF-only: Apple's ld rejects -z noexecstack outright and it
 # is meaningless for PE, so it is gated rather than made "common".
 ELF_HARDENING_FLAGS :=
-ifeq ($(IS_LINUX),yes)
+# IS_LINUX comes from uname, i.e. the HOST. Cross-compiling to Windows from a
+# Linux container satisfies it while emitting PE, and lld then rejects the
+# unknown -z argument. Gate on the TARGET too: IS_MINGW is derived from the
+# compiler's own _WIN32 define, so it names what is actually being produced.
+ifeq ($(IS_LINUX)$(IS_MINGW),yesno)
 ELF_HARDENING_FLAGS := -Wl,-z,noexecstack
 endif
 


### PR DESCRIPTION
`ELF_HARDENING_FLAGS` is gated on `IS_LINUX`, which comes from `uname` and therefore describes the **host**. Cross-compiling to Windows from a Linux container satisfies that gate while the compiler emits PE, and the link fails:

```
lld: error: unknown argument: -z
clang: error: linker command failed with exit code 1
```

Reproduced on `main` with the repo's own recipe:

```
docker compose -f test-infrastructure/docker-compose.yml run --rm build-windows
```

The fix restores the flag's documented intent — the comment above it already states it is ELF-only and "meaningless for PE, so it is gated". The gate just tested the wrong end of the toolchain. `IS_MINGW` is derived from the compiler's own `_WIN32` define, so adding it names the target rather than the host.

Native Windows CI (MSYS2 CLANG64) is unaffected: `uname` reports `MINGW64_NT` there, so `IS_LINUX` was already `no`. Linux and macOS are unaffected. Only the Linux-host → Windows-target combination changes, and only to stop emitting a flag that cannot apply.

On CONTRIBUTING's "Build system / Makefile changes — beyond trivial fixes": I read this as a trivial fix (one gate condition, no behaviour change on any venue CI builds). Happy to move it to an issue first if you would rather discuss it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)