### PR TITLE
fix(windows): stat paths through the long-path-aware converter

### DIFF
--- a/src/foundation/compat_fs.c
+++ b/src/foundation/compat_fs.c
@@ -125,7 +125,7 @@ int cbm_path_info_utf8(const char *path, cbm_path_info_t *out) {
     if (!path || !out) {
         return CBM_NOT_FOUND;
     }
-    wchar_t *wpath = cbm_utf8_to_wide(path);
+    wchar_t *wpath = cbm_path_to_wide(path);
     if (!wpath) {
         return CBM_NOT_FOUND;
     }


### PR DESCRIPTION
`cbm_path_info_utf8` converts with `cbm_utf8_to_wide`, the plain UTF-8 converter, while every other filesystem entry point in the same file — `cbm_opendir`, `cbm_fopen`, `cbm_rename_replace`, `cbm_canonical_path` — uses `cbm_path_to_wide`, which canonicalises and applies the `\\?\` prefix past the legacy limit.

The mismatch is observable within a single walk: `cbm_opendir` successfully enumerates a deep directory *because* it prefixes, then the per-entry stat fails *because* it does not. `GetFileAttributesExW` gets a bare path and returns `ERROR_PATH_NOT_FOUND`.

Consequences, both in the semantic-manifest code:

- `semantic_manifest_walk_controls` — one unstattable entry aborts the entire walk (`CBM_NOT_FOUND`).
- `semantic_manifest_hash_file` — returns `CBM_NOT_FOUND`, so the file is silently dropped from the manifest.

Either way the index degrades with no error surfaced. Machines with `LongPathsEnabled=0` are the exposed case, and a mingw-cross PE carries no `longPathAware` manifest, so flipping that registry policy is not a workaround there.

One-word change, consistent with the convention the rest of the file already follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
