### PR TITLE
fix(daemon): print the validation detail when the secure endpoint cannot be created

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2119,7 +2119,10 @@ int main(int argc, char **argv) {
 
     cbm_daemon_ipc_endpoint_t *endpoint = cbm_daemon_bootstrap_endpoint_new(NULL);
     if (!endpoint) {
-        (void)fprintf(stderr, "codebase-memory-mcp: secure daemon endpoint could not be created\n");
+        const char *validation_detail = cbm_daemon_ipc_validation_detail();
+        (void)fprintf(stderr,
+                      "codebase-memory-mcp: secure daemon endpoint could not be created%s%s\n",
+                      validation_detail[0] ? " - " : "", validation_detail);
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
The MCP-client startup path swallows the reason for a refused endpoint:

```c
cbm_daemon_ipc_endpoint_t *endpoint = cbm_daemon_bootstrap_endpoint_new(NULL);
if (!endpoint) {
    (void)fprintf(stderr, "codebase-memory-mcp: secure daemon endpoint could not be created\n");
    return EXIT_FAILURE;
}
```

Every refusal inside the ancestor DACL walk — owner mismatch, an untrusted grant, a failed repair — arrives as that one sentence. `cbm_daemon_ipc_validation_detail()` has already recorded exactly which component failed and why, and the worker path a few hundred lines up already prints it for the identity check. This just does the same at the endpoint site.

Concretely, this turns

```
codebase-memory-mcp: secure daemon endpoint could not be created
```

into

```
codebase-memory-mcp: secure daemon endpoint could not be created - C:\Users\<user>\AppData: DACL entry 0 grants mutation rights 0x000d0152 to untrusted identity (other S-1-15-3-...)
```

Diagnosing the first form took a purpose-built instrumented binary. The second names the directory, the mask and the SID.

No behaviour change beyond the message; the detail buffer is a static already populated on this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
