### PR TITLE
fix(windows): hide the console windows of spawned child processes

### DIFF
--- a/src/foundation/compat_fs.c
+++ b/src/foundation/compat_fs.c
@@ -310,8 +310,9 @@ static FILE *cbm_popen_isolated(const char *cmd, const char **stage, DWORD *gle)
         *stage = "cmdline";
         *gle = ERROR_NOT_ENOUGH_MEMORY;
     } else {
-        created = CreateProcessW(app, wcmdline, NULL, NULL, TRUE, EXTENDED_STARTUPINFO_PRESENT,
-                                 NULL, NULL, &si.StartupInfo, &pi);
+        created = CreateProcessW(app, wcmdline, NULL, NULL, TRUE,
+                                 EXTENDED_STARTUPINFO_PRESENT | CREATE_NO_WINDOW, NULL, NULL,
+                                 &si.StartupInfo, &pi);
         if (!created) {
             *stage = "spawn";
             *gle = GetLastError();

--- a/src/foundation/subprocess.c
+++ b/src/foundation/subprocess.c
@@ -730,7 +730,8 @@ static int cbm_subprocess_spawn_win(cbm_subprocess_t *process) {
 
     PROCESS_INFORMATION child;
     ZeroMemory(&child, sizeof(child));
-    DWORD flags = EXTENDED_STARTUPINFO_PRESENT | CREATE_SUSPENDED | CREATE_NEW_PROCESS_GROUP;
+    DWORD flags = EXTENDED_STARTUPINFO_PRESENT | CREATE_SUSPENDED | CREATE_NEW_PROCESS_GROUP |
+                  CREATE_NO_WINDOW;
     BOOL created = CreateProcessW(wbin, wcmdline, NULL, NULL, TRUE, flags, NULL, NULL,
                                   &startup.StartupInfo, &child);
     cbm_win_close_spawn_handles(nul, log, attrs, attrs_init);


### PR DESCRIPTION
Two `CreateProcessW` call sites in `src/foundation/` spawn children without `CREATE_NO_WINDOW`, so on Windows each one flashes a console window:

- `cbm_subprocess_spawn_win` (`src/foundation/subprocess.c`) — the supervisor → index-worker spawn.
- `cbm_popen_isolated` (`src/foundation/compat_fs.c`).

`src/daemon/bootstrap.c` already passes the flag for the daemon self-spawn, so this brings the remaining two in line with it.

User-visible effect: when the MCP server is driven by an editor/agent over stdio, indexing a repository pops console windows onto the desktop — one per worker spawn. Nothing breaks, but on a machine that reindexes on file changes it is a steady stream of windows stealing focus.

`CREATE_NO_WINDOW` only suppresses console allocation; it does not detach the process, change the process group, or affect the inherited handle list, so the existing `EXTENDED_STARTUPINFO_PRESENT | CREATE_SUSPENDED | CREATE_NEW_PROCESS_GROUP` semantics and the worker-log handle plumbing are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
