### PR TITLE
fix(cli): attribute activation refusals to the recorded safety check (#1416)

### DIFF
--- a/src/cli/activation_transaction.c
+++ b/src/cli/activation_transaction.c
@@ -110,6 +110,18 @@ const char *cbm_activation_transaction_refusal_note(void) {
     return g_activation_refusal_note;
 }
 
+#ifdef CBM_ENABLE_TEST_SEAMS
+/* #1416 test seam: install a refusal note so the CLI attribution path is
+ * testable without constructing a real Windows ACL refusal. */
+void cbm_activation_transaction_note_refusal_for_testing(const char *predicate,
+                                                         unsigned long os_error) {
+    activation_refusal_clear();
+    if (predicate && predicate[0]) {
+        activation_note_refusal(predicate, os_error);
+    }
+}
+#endif
+
 #ifdef _WIN32
 typedef HANDLE activation_native_file_t;
 #define ACTIVATION_INVALID_FILE INVALID_HANDLE_VALUE

--- a/src/cli/activation_transaction.h
+++ b/src/cli/activation_transaction.h
@@ -97,4 +97,9 @@ const char *cbm_activation_transaction_status_message(cbm_activation_transaction
  * entry; single-threaded like the rest of the transaction API. */
 const char *cbm_activation_transaction_refusal_note(void);
 
+#ifdef CBM_ENABLE_TEST_SEAMS
+void cbm_activation_transaction_note_refusal_for_testing(const char *predicate,
+                                                         unsigned long os_error);
+#endif
+
 #endif /* CBM_ACTIVATION_TRANSACTION_H */

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -197,6 +197,24 @@ static const char *g_cli_activation_runtime_parent_for_test = NULL;
 
 static void cli_activation_diagnostic(const cbm_cli_activation_ops_t *ops, const char *message) {
     const char *diagnostic = message ? message : CLI_ACTIVATION_REFUSED_MESSAGE;
+    /* #1416: when the transaction recorded a concrete refusal (an ACL or
+     * filesystem safety check), say THAT. The generic text blames "active CBM
+     * sessions" for what is a validation refusal - reporters rebooted, killed
+     * every process, and hunted phantom handles because the message pointed at
+     * sessions that did not exist. The sessions wording remains for genuine
+     * stop/reservation failures, which record no refusal note. */
+    char attributed[CBM_SZ_1K];
+    const char *note = cbm_activation_transaction_refusal_note();
+    if (diagnostic == CLI_ACTIVATION_REFUSED_MESSAGE && note && note[0]) {
+        (void)snprintf(attributed, sizeof(attributed),
+                       "error: activation was refused by a filesystem safety check before any "
+                       "change was made: %s\n"
+                       "error: this is not a session problem. If the flagged directory is one you "
+                       "trust, remove the flagged permission grant (icacls <dir> /remove:g <sid>) "
+                       "or use an owner-private directory for --dir/CBM_CACHE_DIR, then retry.",
+                       note);
+        diagnostic = attributed;
+    }
     if (ops && ops->visible_diagnostic) {
         ops->visible_diagnostic(ops->context, diagnostic);
         return;

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -14,6 +14,7 @@
 #include "test_framework.h"
 #include "test_helpers.h"
 #include <cli/agent_profiles.h>
+#include <cli/activation_transaction.h>
 #include <cli/cli.h>
 #include <cli/progress_sink.h>
 #include <daemon/bootstrap.h>
@@ -643,6 +644,41 @@ TEST(cli_activation_refuses_when_cohort_does_not_drain) {
     ASSERT_EQ(fake.mutation_lease_release_count, 0);
     ASSERT_FALSE(fake.mutation_lease_held);
     ASSERT_TRUE(fake.diagnostic[0] != '\0');
+    PASS();
+}
+
+/* Regression for #1416: when the activation transaction recorded a concrete
+ * refusal (e.g. the Windows ACL safety check), the CLI must attribute the
+ * failure to that check instead of blaming "active CBM sessions" - reporters
+ * rebooted and hunted phantom handles because no sessions existed. The
+ * sessions wording must remain for refusals with no recorded note. */
+TEST(cli_activation_refusal_note_reaches_diagnostic_issue1416) {
+    cbm_activation_transaction_note_refusal_for_testing(
+        "acl-grants-cross-account-mutation to S-1-5-11", 0UL);
+    cli_activation_fake_t fake = {
+        .participants_active = true,
+        .mutation_reserve_result = 0,
+    };
+    cbm_cli_activation_ops_t ops = {
+        .context = &fake,
+        .reserve_for_mutation = cli_activation_fake_reserve_mutation,
+        .mutation_lease_release = cli_activation_fake_release_mutation,
+        .visible_diagnostic = cli_activation_fake_diagnostic,
+    };
+    ASSERT_EQ(cbm_cli_activation_guard_with_ops(&ops, cli_activation_fake_mutation, &fake), 1);
+    ASSERT_NOT_NULL(strstr(fake.diagnostic, "acl-grants-cross-account-mutation"));
+    ASSERT_NOT_NULL(strstr(fake.diagnostic, "not a session problem"));
+    ASSERT_NULL(strstr(fake.diagnostic, "could not be stopped safely"));
+
+    /* No note recorded -> the sessions wording is still the right message. */
+    cbm_activation_transaction_note_refusal_for_testing(NULL, 0UL);
+    cli_activation_fake_t plain = {
+        .participants_active = true,
+        .mutation_reserve_result = 0,
+    };
+    ops.context = &plain;
+    ASSERT_EQ(cbm_cli_activation_guard_with_ops(&ops, cli_activation_fake_mutation, &plain), 1);
+    ASSERT_NOT_NULL(strstr(plain.diagnostic, "could not be stopped safely"));
     PASS();
 }
 
@@ -11789,6 +11825,7 @@ SUITE(cli) {
     /* Mandatory daemon activation safety */
     RUN_TEST(cli_activation_quiesces_active_cohort_before_mutation);
     RUN_TEST(cli_activation_refuses_when_cohort_does_not_drain);
+    RUN_TEST(cli_activation_refusal_note_reaches_diagnostic_issue1416);
     RUN_TEST(cli_activation_refuses_unsafe_cohort_reservation);
     RUN_TEST(cli_activation_releases_maintenance_lease_after_success);
     RUN_TEST(cli_activation_releases_maintenance_lease_when_mutation_fails);


### PR DESCRIPTION
Part of #1416 (the misattribution half — the actionable-error fix).

## Reproduced on the Windows VM

A directory carrying the **stock `Authenticated Users:(M)` inheritance from a drive root** (any plain `mkdir` under `C:\`, most secondary-drive paths) trips the activation transaction's ACL safety check. The refusal was recorded internally — predicate, SID, path — but `install`/`uninstall`/`doctor` surfaced only:

> error: active CBM sessions and operations could not be stopped safely; no activation was committed.

Both reporters killed processes, rebooted, and hunted phantom handles because the message points at sessions that never existed.

## Fix

`cli_activation_diagnostic` now prefixes the recorded refusal note plus one remediation line (remove the flagged grant via icacls, or choose an owner-private `--dir`/`CBM_CACHE_DIR`). The sessions wording remains for genuine stop/reservation failures, which record no note. No change to what is accepted or refused — attribution only.

## Verification

- Portable regression test via a new `CBM_ENABLE_TEST_SEAMS` refusal-note setter: note ⇒ diagnostic names the check, no note ⇒ sessions text intact. **RED → GREEN → RED-on-revert.**
- `cli` suite 258 passed, `lint-ci` clean.
- End-to-end on the Windows VM (UTM, clangarm64): tainted-ancestry `uninstall`/`doctor` now name the ACL check.

## Deliberately NOT in this PR (maintainer decision pending)

Whether the ACL gate should **tolerate ancestor-inherited cross-account grants** when the final directory is owner-private with a protected DACL — that decides whether default secondary-drive installs work at all, and it's a security-posture question, not a bug fix. Decision matrix goes to the maintainer separately. The #1351 empty-ACL destruction did not reproduce in any VM variant (files stayed owner-usable through daemon-refusal, failed install, failed uninstall); reporter question outstanding.