### PR TITLE
fix(tests): resolve the prod binary from CBM_TEST_BINARY, not a hardcoded build/c

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -280,7 +280,7 @@ CBM_TEST_BINARY="$WATCHDOG_BINARY" bash "$ROOT/tests/test_worker_watchdog.sh"
 # still exits nonzero for the user-facing tool error, but the supervisor must
 # preserve that response instead of misreporting exit_nonzero as a file crash.
 echo "=== Step 5c: worker error-response transport regression ==="
-bash "$ROOT/tests/test_worker_error_response.sh"
+CBM_TEST_BINARY="$WATCHDOG_BINARY" bash "$ROOT/tests/test_worker_error_response.sh"
 
 # Step 5d (#1388) is DELIBERATELY NOT GATING HERE — see
 # tests/test_hook_conflict_notice.sh for the full what-was-tried record.

--- a/tests/test_hook_conflict_notice.sh
+++ b/tests/test_hook_conflict_notice.sh
@@ -24,7 +24,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BINARY="${ROOT}/build/c/codebase-memory-mcp"
+BINARY="${CBM_TEST_BINARY:-${ROOT}/build/c/codebase-memory-mcp}"
 if [[ ! -x "${BINARY}" && -x "${BINARY}.exe" ]]; then
   BINARY="${BINARY}.exe"
 fi

--- a/tests/test_worker_error_response.sh
+++ b/tests/test_worker_error_response.sh
@@ -6,7 +6,11 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BINARY="${ROOT}/build/c/codebase-memory-mcp"
+# scripts/test.sh builds into $BUILD_DIR, which is NOT build/c on every leg (the
+# Linux containers use build/linux-arm64 / build/linux-amd64). Honour the binary
+# the caller built, exactly as test_parent_watchdog.sh and test_worker_watchdog.sh
+# do; the build/c default keeps a bare manual invocation working.
+BINARY="${CBM_TEST_BINARY:-${ROOT}/build/c/codebase-memory-mcp}"
 if [[ ! -x "${BINARY}" && -x "${BINARY}.exe" ]]; then
   BINARY="${BINARY}.exe"
 fi


### PR DESCRIPTION
Found by the local 3-OS ladder while gating the 0.9.1-rc.2 fix set.

## Symptom

The Linux arm64 leg (`./test-infrastructure/run.sh test`) fails:

```
=== Step 5c: worker error-response transport regression ===
missing binary: /src/build/c/codebase-memory-mcp
```

## Cause

The container legs build into `build/linux-arm64` / `build/linux-amd64`; only `build/c` is the default. Steps 5 and 5b already hand their scripts `CBM_TEST_BINARY="$ROOT/$BUILD_DIR/codebase-memory-mcp"`, but Step 5c does not, and `tests/test_worker_error_response.sh` (from #1369) hardcodes `build/c`.

**CI could never catch this** — every CI leg runs with the default `BUILD_DIR=build/c`. The container legs are the only place the paths diverge, which is exactly what the local ladder is for.

## Fix

- `test_worker_error_response.sh` honours `${CBM_TEST_BINARY:-…/build/c/…}`, matching its sibling watchdog tests; the fallback keeps a bare manual invocation working.
- `scripts/test.sh` passes `CBM_TEST_BINARY` to Step 5c, consistent with 5 and 5b.
- `test_hook_conflict_notice.sh` had the identical hardcoding (local-only today) and is fixed the same way.

## Verification

With the fix, the test passes against an out-of-tree binary; reverting it reproduces the ladder's exact failure (`rc=2`, `missing binary: <worktree>/build/c/codebase-memory-mcp`). Full Linux leg re-run is in progress.