### PR TITLE
diag(daemon): name the cohort path that admits a mismatched build

### DIFF
--- a/src/daemon/version_cohort.c
+++ b/src/daemon/version_cohort.c
@@ -457,6 +457,14 @@ cbm_version_cohort_status_t cbm_version_cohort_acquire(cbm_version_cohort_manage
                                           CBM_PRIVATE_FILE_LOCK_EX, &lease->lifetime);
     cbm_version_cohort_status_t status = version_cohort_status_from_lock(lock_status);
     if (status == CBM_VERSION_COHORT_OK) {
+        /* No live holder: this participant CLAIMS the cohort and NO identity
+         * comparison happens — a mismatched build is admitted, not refused.
+         * That is correct when nothing is running, and it is the only path by
+         * which a mismatched client can join. Name it: "was the lifetime lock
+         * held?" is exactly what separates a local run (conflict raised) from
+         * a CI run (client admitted), and it was not observable in any log. */
+        cbm_log_info("version_cohort.claimed_unheld", "build",
+                     identity->build_fingerprint ? identity->build_fingerprint : "<null>");
         status = version_cohort_claim_new(lease, identity, deadline_ms);
     } else if (status == CBM_VERSION_COHORT_BUSY) {
         lock_status =


### PR DESCRIPTION
Observability only — **no admission behaviour changes.**

## Why

A forced client/daemon build mismatch raises a cohort conflict **locally** but is **admitted on every CI leg**, which is why the #1388 conflict regression could never bind there (it is now a documented local-only test).

Reading `cbm_version_cohort_acquire` explains how that is possible: identity comparison happens **only in the `BUSY` branch** — when another process already holds the cohort lifetime lock. When the `EX` acquire *succeeds* (no live holder), the participant claims the cohort and **no comparison runs at all**, so a mismatched build joins.

That is correct when nothing is running. What was missing is the ability to tell the two situations apart afterwards: *"was the lifetime lock held?"* is exactly what separates the local run from the CI run, and no log line answered it.

## What this adds

One `version_cohort.claimed_unheld` info line on the claim path, carrying the build fingerprint.

The next CI run that exercises this will say which branch it took, which decides whether the CI daemon simply is not holding the lease (an environment fact, and the test stays local-only) or the lease is released early (a real bug worth its own fix). Shipping a behaviour change to a security-relevant admission path on a guess would be the wrong move.

## Verification

`version_cohort` + `daemon_version`: 24 passed. `lint-ci` clean.
