### PR TITLE
fix(mem): route ordinary malloc through mimalloc on Linux (#1360)

### DIFF
--- a/Makefile.cbm
+++ b/Makefile.cbm
@@ -75,7 +75,8 @@ endif
 # CBM_BIND_TS_ALLOCATOR=1: bind the tree-sitter runtime to mimalloc (#424). Only
 # the prod build uses mimalloc (MI_OVERRIDE=1); the test build is CRT+ASan, where
 # binding would create an alloc/free mismatch, so the guard is prod-only.
-CFLAGS_PROD = $(CFLAGS_COMMON) -O2 -DCBM_BIND_TS_ALLOCATOR=1 $(TEST_SEAM_DEFINE) $(CFLAGS_EXTRA)
+CFLAGS_PROD = $(CFLAGS_COMMON) -O2 -DCBM_BIND_TS_ALLOCATOR=1 $(TEST_SEAM_DEFINE) \
+              $(GLOBAL_OVERRIDE_DEFINE) $(CFLAGS_EXTRA)
 CXXFLAGS_PROD = $(CXXFLAGS_COMMON) -O2
 
 # Test flags: debug + sanitizers (override SANITIZE= to disable on Windows)
@@ -386,9 +387,34 @@ UI_SRCS = \
 # derives it from the MI_OVERRIDE option); MI_OVERRIDE alone is not read by the
 # source — it is kept here only as this project's prod/test marker.
 MIMALLOC_SRC = vendored/mimalloc/src/static.c
+# Linux belongs on this list too (#1360). The "Unix relies on static-link-order
+# override" strategy described above never actually worked: mimalloc defines
+# malloc/free ONLY when MI_MALLOC_OVERRIDE is set (it gates alloc-override.c),
+# so with the define off there were no strong symbols for the link order to
+# prefer. Measured on the shipped v0.9.1-rc.1 artifacts — linux-arm64 glibc AND
+# musl-static both report 0/6 allocator-owned size classes, i.e. ordinary malloc
+# was going to libc and every purge/reclaim option set in cbm_mem_init applied
+# only to the bound sqlite/tree-sitter populations.
+#
+# The macOS objection does not transfer. That abort is specific to the two-level
+# namespace, where this binary's free becomes mi_free while system libraries keep
+# allocating from the system allocator, so a pointer crossing the boundary hits
+# "mi_free: invalid pointer". ELF is a flat namespace: interposition is
+# process-wide and all-or-nothing, which is the configuration mimalloc is
+# normally deployed in. macOS therefore stays off, deliberately and permanently.
+#
+# TWO defines, switched together in ONE place so they cannot drift:
+# MI_MALLOC_OVERRIDE reaches the mimalloc translation unit and turns the
+# override on; CBM_MEM_GLOBAL_OVERRIDE reaches OUR sources and tells the startup
+# audit what to expect. CBM_MEM_GLOBAL_OVERRIDE goes only into CFLAGS_PROD,
+# because MIMALLOC_CFLAGS_TEST compiles mimalloc with -DMI_OVERRIDE=0 and no
+# override define at all — a test binary has no global override BY CONSTRUCTION
+# and must never be told to expect one, or it warns on every run.
 MIMALLOC_OVERRIDE_DEFINE :=
-ifeq ($(IS_MINGW),yes)
+GLOBAL_OVERRIDE_DEFINE :=
+ifneq ($(filter yes,$(IS_MINGW) $(IS_LINUX)),)
 MIMALLOC_OVERRIDE_DEFINE := -DMI_MALLOC_OVERRIDE=1
+GLOBAL_OVERRIDE_DEFINE := -DCBM_MEM_GLOBAL_OVERRIDE=1
 endif
 MIMALLOC_CFLAGS = -std=c11 -O2 -w \
                   -Ivendored/mimalloc/include \

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -187,6 +187,58 @@ if ! echo "$OUTPUT" | grep -qE 'v?[0-9]+\.[0-9]+|dev'; then
 fi
 echo "OK"
 
+echo ""
+echo "=== Phase 1b: allocator override matches this platform's contract ==="
+# Asserts the SHIPPED binary's actual allocator wiring, per platform:
+#
+#   Windows, Linux -> ordinary malloc MUST reach mimalloc (all size classes
+#                     owned). If it does not, every purge/reclaim option in
+#                     cbm_mem_init is decoration and freed pages stay committed
+#                     — that is #581, which hid in production for months
+#                     precisely because nothing asserted it on a real artifact.
+#   macOS          -> it MUST NOT. Enabling the override there aborts on the
+#                     first pointer crossing the two-level-namespace boundary
+#                     ("mi_free: invalid pointer"), so "owned" here would mean
+#                     we shipped a binary that crashes on index.
+#
+# Both directions fail. A silent flip either way is a release blocker, which is
+# why this lives in smoke (real artifact, all platforms) and not only in a unit
+# test built from source.
+ALLOC_LOG=$("$BINARY" cli list_projects 2>&1 >/dev/null || true)
+case "$(uname -s)" in
+  Darwin)
+    if echo "$ALLOC_LOG" | grep -q 'mem.allocator.not_owned'; then
+      echo "FAIL: macOS emitted the not_owned WARNING; expected the by-design"
+      echo "      bound-populations INFO line (see #1360)"
+      exit 1
+    fi
+    if echo "$ALLOC_LOG" | grep -q 'mem.allocator.owned'; then
+      echo "FAIL: macOS reports ordinary malloc as allocator-owned. The override"
+      echo "      must stay OFF here: under the two-level namespace it aborts"
+      echo "      with 'mi_free: invalid pointer' on the first crossing pointer."
+      exit 1
+    fi
+    echo "OK: macOS serves ordinary malloc from the system allocator, no warning"
+    ;;
+  MINGW*|MSYS*|CYGWIN*|Linux)
+    if echo "$ALLOC_LOG" | grep -q 'mem.allocator.not_owned'; then
+      echo "FAIL: ordinary malloc does NOT reach mimalloc on $(uname -s)."
+      echo "      Allocator tuning is inert and freed pages will stay committed (#581/#1360)."
+      echo "$ALLOC_LOG" | grep 'mem.allocator' | head -2
+      exit 1
+    fi
+    if echo "$ALLOC_LOG" | grep -q 'mem.allocator.bound_populations_only'; then
+      echo "FAIL: $(uname -s) reports bound-populations-only; the global override"
+      echo "      is expected to be compiled in on this platform (#1360)."
+      exit 1
+    fi
+    echo "OK: ordinary malloc reaches the allocator on $(uname -s)"
+    ;;
+  *)
+    echo "SKIP: no allocator contract defined for $(uname -s)"
+    ;;
+esac
+
 if [ "$SMOKE_MODE" != "--agent-config-only" ]; then
 echo ""
 echo "=== Phase 2: index test project ==="

--- a/src/foundation/mem.c
+++ b/src/foundation/mem.c
@@ -36,6 +36,32 @@
 #include <unistd.h>
 #endif
 
+/* Does THIS build ask mimalloc to replace ordinary malloc process-wide?
+ *
+ * Set by Makefile.cbm alongside MI_MALLOC_OVERRIDE itself — the two are
+ * switched together in one place, because MI_MALLOC_OVERRIDE reaches only the
+ * mimalloc translation unit and this one needs the same answer. Do NOT infer it
+ * from the platform here: the override is compiled into PROD builds only
+ * (MIMALLOC_CFLAGS_TEST uses -DMI_OVERRIDE=0 and no override define), so a
+ * Linux test binary genuinely has no global override, and a platform-based
+ * guess would make every test run warn about a build that is correct.
+ *
+ * macOS never gets it, and that is not a defect to warn about: enabling the
+ * override there compiles alloc-override.c's forwarding definitions, and under
+ * the two-level namespace this binary's free becomes mi_free while system
+ * libraries keep allocating from the system allocator, so the first pointer
+ * crossing that boundary aborts with "mi_free: invalid pointer". ELF's flat
+ * namespace has no such split, which is why Linux can have it and macOS cannot.
+ *
+ * The shipped artifact's actual wiring is pinned by scripts/smoke-test.sh
+ * Phase 1b, which fails in BOTH directions on the real binary — the only place
+ * this can be checked honestly, since a from-source test build never has it. */
+#if defined(CBM_MEM_GLOBAL_OVERRIDE)
+#define CBM_MEM_EXPECT_GLOBAL_OVERRIDE 1
+#else
+#define CBM_MEM_EXPECT_GLOBAL_OVERRIDE 0
+#endif
+
 #ifdef _WIN32
 /* mimalloc internals. Not in the public header, but the allocator is compiled
  * into this binary as a unity object, so the symbols are present.
@@ -284,10 +310,33 @@ void cbm_mem_init_with_cap(double ram_fraction, size_t hard_cap_bytes) {
      * and nothing checked, so a long-lived daemon ratcheted committed memory
      * for months (#581). Probe it once, out loud: a real malloc asked whether
      * mimalloc owns it. Anything but true means the tuning here is decoration
-     * and freed pages will not come back. */
+     * and freed pages will not come back.
+     *
+     * ...but "anything but true" only means that where the build actually ASKED
+     * for a global override: prod builds on Windows and Linux. Everywhere else —
+     * macOS, and every test binary on any platform — the override body is
+     * compiled out, so ordinary malloc is SUPPOSED to reach libc and the probe
+     * is answering a question this build never posed. Same measurement,
+     * different meaning per build config, hence the split below. */
     cbm_mem_ownership_audit_t audit;
     cbm_mem_audit_ownership(&audit);
-    if (!audit.all_owned) {
+    char owned_str[CBM_SZ_32];
+    snprintf(owned_str, sizeof(owned_str), "%d/%d", audit.owned_count, audit.probed_count);
+    if (!audit.all_owned && !CBM_MEM_EXPECT_GLOBAL_OVERRIDE) {
+        /* Expected: this build never asked mimalloc to replace ordinary malloc,
+         * so ordinary malloc reaching libc is the design, not a fault. Say what
+         * IS allocator-served instead, because the interesting question here is
+         * "are the bound populations bound", not "did the override fire".
+         *
+         * Reported at INFO deliberately. A warning that fires on every run of a
+         * correctly configured build is not a tripwire, it is background noise —
+         * it trained readers to ignore the one line that catches #581, and cost
+         * a user the time to file and self-close #1360. */
+        cbm_log_info("mem.allocator.bound_populations_only", "owned_classes", owned_str,
+                     "populations", "sqlite,tree_sitter", "detail",
+                     "ordinary malloc is served by the system allocator in this build by "
+                     "design; allocator tuning applies to the bound populations");
+    } else if (!audit.all_owned) {
         /* Name the classes that escaped, because "not owned" is actionable
          * only if you know WHICH sizes. A class listed here either bypasses
          * the override or is misclassified by the routing predicate, and both
@@ -306,8 +355,6 @@ void cbm_mem_init_with_cap(double ram_fraction, size_t hard_cap_bytes) {
                 length += written;
             }
         }
-        char owned_str[CBM_SZ_32];
-        snprintf(owned_str, sizeof(owned_str), "%d/%d", audit.owned_count, audit.probed_count);
         cbm_log_warn("mem.allocator.not_owned", "owned_classes", owned_str, "unowned_bytes",
                      length > 0 ? classes : "?", "detail",
                      "allocations in these size classes are not allocator-owned: purge and "

--- a/src/foundation/mem_override_posix.c
+++ b/src/foundation/mem_override_posix.c
@@ -1,13 +1,30 @@
 /*
  * mem_override_posix.c — allocation-site visibility on POSIX.
  *
- * On POSIX the build links mimalloc's object first, so its strong malloc/free
- * win and every allocation already lands in mimalloc — nothing needs
- * redirecting for correctness. What is missing is a place to OBSERVE those
- * allocations: the Windows side gets it for free from the --wrap interposer it
- * needs anyway, and without an equivalent here the profiler could only ever
- * describe Windows, which makes the platform comparison — the one measurement
- * that actually isolates #581 — impossible.
+ * What is missing on POSIX is a place to OBSERVE allocations: the Windows side
+ * gets it for free from the --wrap interposer it needs anyway, and without an
+ * equivalent here the profiler could only ever describe Windows, which makes the
+ * platform comparison — the one measurement that actually isolates #581 —
+ * impossible.
+ *
+ * CORRECTION (#1360). This header previously claimed that "on POSIX the build
+ * links mimalloc's object first, so its strong malloc/free win and every
+ * allocation already lands in mimalloc". That was never true, and believing it
+ * inverts the meaning of the startup ownership audit. mimalloc emits those
+ * strong malloc/free definitions only when MI_MALLOC_OVERRIDE is set — the
+ * define its source actually gates alloc-override.c on — while MI_OVERRIDE,
+ * which the build sets everywhere, is this project's own prod/test marker that
+ * mimalloc never reads. With the override body compiled out there were no
+ * strong symbols for link order to prefer, so ordinary malloc went to libc. The
+ * shipped v0.9.1-rc.1 binaries confirm it: linux-arm64 (glibc AND musl-static)
+ * and darwin-arm64 all reported 0/6 allocator-owned size classes.
+ *
+ * Linux PROD builds now set MI_MALLOC_OVERRIDE (see Makefile.cbm), so the strong
+ * symbols exist there and ordinary malloc genuinely reaches mimalloc. macOS
+ * stays off permanently — its two-level namespace would split this binary's
+ * free from the system libraries' malloc — and test builds stay off everywhere
+ * by construction, which is why this observation shim remains the only way to
+ * see POSIX allocation sites.
  *
  * So this file exists purely for symmetry of measurement. Each wrapper forwards
  * to the same mi_* entry point the symbol would have reached on its own and


### PR DESCRIPTION
## The claim that was never true

The comment above `MIMALLOC_OVERRIDE_DEFINE` said Unix "relies on static-link-order override". It doesn't work that way. mimalloc emits strong `malloc`/`free` definitions **only** when `MI_MALLOC_OVERRIDE` is set — the define its source gates `alloc-override.c` on — and the build set that for MinGW only. `MI_OVERRIDE`, which the build *does* set everywhere, is this project's own prod/test marker that mimalloc never reads.

With the override body compiled out there were no strong symbols for link order to prefer, so ordinary `malloc` went to libc.

## Measured, not inferred

The shipped v0.9.1-rc.1 artifacts report **0/6 allocator-owned size classes** on linux-arm64 glibc *and* musl-static. Same A/B reproduced on ubuntu-arm64 for this PR:

| build | startup audit |
|---|---|
| main | `warn mem.allocator.not_owned owned_classes=0/6` |
| this PR | `info mem.allocator.owned classes=all` |

So every purge/reclaim option `cbm_mem_init` sets was **inert on Linux**, applying only to the bound sqlite/tree-sitter populations. Same class of defect as #581, where committed memory ratcheted for months because nothing asserted the wiring on a real artifact.

## macOS stays off, deliberately and permanently

Enabling the override there compiles `alloc-override.c`'s forwarding definitions; under the two-level namespace this binary's `free` becomes `mi_free` while system libraries keep allocating from the system allocator, so the first pointer crossing that boundary aborts with `mi_free: invalid pointer`. ELF's flat namespace has no such split — which is why Linux can have this and macOS cannot.

## Three parts

1. **`Makefile.cbm`** switches `MI_MALLOC_OVERRIDE` and a new `CBM_MEM_GLOBAL_OVERRIDE` **together in one place**, for MinGW and Linux. The latter tells our own sources what to expect and goes into `CFLAGS_PROD` only — `MIMALLOC_CFLAGS_TEST` builds mimalloc with `-DMI_OVERRIDE=0` and no override define, so a **test binary has no global override by construction** and must never be told to expect one. Deriving the expectation from the *platform* instead would make every Linux test run warn about a correctly configured build.

2. **`mem.c`** splits the startup audit by what the build actually asked for. Where no override was requested, ordinary malloc reaching libc is the design, so it reports the *measured* ownership at INFO and names what IS bound. A warning that fires on every run of a correct build is not a tripwire, it's noise — it trains readers to ignore the one line that catches #581. The genuine warning still fires wherever an override was requested and did not take.

3. **`smoke-test.sh` Phase 1b** pins the SHIPPED artifact's wiring per platform and fails in **both** directions: Windows/Linux must own all classes, macOS must not. This cannot live in a unit test — a from-source test build never has the override — which is precisely why the defect survived so long.

## Verification

**ubuntu-arm64**: prod owns all classes; test build reports bound-populations-only at INFO (0/6) and the `mem` suite stays green; smoke Phase 1b passes — and **fails with the expected message** when the same tree is built with the override forced off (revert-check on the guard itself).

**macOS**: prod reports `bound_populations_only` at INFO, smoke Phase 1b passes, `mem` suite 51/51. `make lint-ci` clean.

## Worth a maintainer's eye

This changes allocator behaviour in shipped **Linux** binaries — that is the point, but it means Linux RSS/throughput characteristics now reflect the tuning that was previously inert. Prior Linux memory baselines were taken against an allocator we believed was configured and wasn't, so they aren't directly comparable.
