### PR TITLE
fix(foundation): suppress flashing console on Windows child spawns

### DIFF
--- a/src/foundation/compat_fs.c
+++ b/src/foundation/compat_fs.c
@@ -310,8 +310,13 @@ static FILE *cbm_popen_isolated(const char *cmd, const char **stage, DWORD *gle)
         *stage = "cmdline";
         *gle = ERROR_NOT_ENOUGH_MEMORY;
     } else {
-        created = CreateProcessW(app, wcmdline, NULL, NULL, TRUE, EXTENDED_STARTUPINFO_PRESENT,
-                                 NULL, NULL, &si.StartupInfo, &pi);
+        /* CREATE_NO_WINDOW: the MCP server runs with no attached console, so
+         * without this flag every `cmd.exe /c <git...>` spawn allocates a
+         * fresh console that flashes on screen. Stdio is already redirected
+         * to the pipe/NUL above, so no console window is ever needed. */
+        const DWORD creation_flags = EXTENDED_STARTUPINFO_PRESENT | CREATE_NO_WINDOW;
+        created = CreateProcessW(app, wcmdline, NULL, NULL, TRUE, creation_flags, NULL, NULL,
+                                 &si.StartupInfo, &pi);
         if (!created) {
             *stage = "spawn";
             *gle = GetLastError();
@@ -685,7 +690,7 @@ int cbm_exec_no_shell(const char *const *argv) {
     memset(&pi, 0, sizeof(pi));
     si.cb = sizeof(si);
 
-    if (!CreateProcessW(NULL, cmdline, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi)) {
+    if (!CreateProcessW(NULL, cmdline, NULL, NULL, FALSE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
         free(cmdline);
         return CBM_NOT_FOUND;
     }

--- a/src/foundation/subprocess.c
+++ b/src/foundation/subprocess.c
@@ -734,7 +734,8 @@ static int cbm_subprocess_spawn_win(cbm_subprocess_t *process) {
 
     PROCESS_INFORMATION child;
     ZeroMemory(&child, sizeof(child));
-    DWORD flags = EXTENDED_STARTUPINFO_PRESENT | CREATE_SUSPENDED | CREATE_NEW_PROCESS_GROUP;
+    DWORD flags = EXTENDED_STARTUPINFO_PRESENT | CREATE_SUSPENDED | CREATE_NEW_PROCESS_GROUP |
+                  CREATE_NO_WINDOW;
     BOOL created = CreateProcessW(wbin, wcmdline, NULL, NULL, TRUE, flags, NULL, NULL,
                                   &startup.StartupInfo, &child);
     cbm_win_close_spawn_handles(nul, log, attrs, attrs_init);


### PR DESCRIPTION
When the MCP server runs without an attached console (launched by an MCP client), every cmd.exe /c child spawned via CreateProcessW allocates a fresh console window that flashes on screen and immediately closes. This is most visible during indexing and the watcher poll loop, which fire git commands in rapid succession.

Add CREATE_NO_WINDOW to the three Windows spawn sites that were missing it (cbm_popen_isolated, cbm_exec_no_shell, cbm_subprocess_spawn_win). The daemon bootstrap path already sets it; these were inconsistently omitted. The flag is compatible with EXTENDED_STARTUPINFO_PRESENT, CREATE_SUSPENDED, CREATE_NEW_PROCESS_GROUP and STARTF_USESTDHANDLES, and stdio is already redirected to pipes/NUL. Linux/macOS are unaffected - all changes are inside #ifdef _WIN32.