### PR TITLE
fix(mcp): validate search_code limit

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -604,7 +604,7 @@ static const tool_def_t TOOLS[] = {
      "\"description\":\"Max enriched results per call. Default 10. Response includes "
      "'total_grep_matches' and 'total_results' so callers can detect truncation. No "
      "offset parameter — raise limit or narrow with file_pattern / path_filter to see more."
-     "\",\"default\":10}},\"required\":[\"pattern\",\"project\"]}"},
+     "\",\"default\":10,\"minimum\":1}},\"required\":[\"pattern\",\"project\"]}"},
 
     {"list_projects", "List projects", "List all indexed projects",
      "{\"type\":\"object\",\"properties\":{}}"},
@@ -9577,6 +9577,9 @@ static char *handle_search_code(cbm_mcp_server_t *srv, const char *args) {
     char *path_filter = cbm_mcp_get_string_arg(args, "path_filter");
     char *mode_str = cbm_mcp_get_string_arg(args, "mode");
     int limit = cbm_mcp_get_int_arg(args, "limit", MCP_DEFAULT_LIMIT);
+    if (limit < 1) {
+        limit = MCP_DEFAULT_LIMIT;
+    }
     int context_lines = cbm_mcp_get_int_arg(args, "context", 0);
     bool use_regex = cbm_mcp_get_bool_arg(args, "regex");
     uint64_t search_t0 = cbm_now_ms();

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -3973,6 +3973,59 @@ TEST(tool_search_code_missing_pattern) {
     PASS();
 }
 
+TEST(tool_search_code_negative_limit_is_not_echoed) {
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+
+    char *resp =
+        cbm_mcp_server_handle(srv, "{\"jsonrpc\":\"2.0\",\"id\":35,\"method\":\"tools/call\","
+                                   "\"params\":{\"name\":\"search_code\","
+                                   "\"arguments\":{\"pattern\":\"func main\","
+                                   "\"project\":\"nonexistent\",\"limit\":-5}}}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NULL(strstr(resp, "results: -5"));
+    free(resp);
+
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
+TEST(tool_search_code_limit_declares_a_minimum) {
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+
+    char *resp = cbm_mcp_server_handle(
+        srv, "{\"jsonrpc\":\"2.0\",\"id\":36,\"method\":\"tools/list\",\"params\":{}}");
+    ASSERT_NOT_NULL(resp);
+
+    yyjson_doc *doc = yyjson_read(resp, strlen(resp), 0);
+    yyjson_val *root = doc ? yyjson_doc_get_root(doc) : NULL;
+    yyjson_val *result = root ? yyjson_obj_get(root, "result") : NULL;
+    yyjson_val *tools = result ? yyjson_obj_get(result, "tools") : NULL;
+    yyjson_val *minimum = NULL;
+    if (tools && yyjson_is_arr(tools)) {
+        size_t index, max;
+        yyjson_val *tool;
+        yyjson_arr_foreach(tools, index, max, tool) {
+            yyjson_val *name = yyjson_obj_get(tool, "name");
+            if (!name || !yyjson_is_str(name) ||
+                strcmp(yyjson_get_str(name), "search_code") != 0) {
+                continue;
+            }
+            yyjson_val *schema = yyjson_obj_get(tool, "inputSchema");
+            yyjson_val *props = schema ? yyjson_obj_get(schema, "properties") : NULL;
+            yyjson_val *limit = props ? yyjson_obj_get(props, "limit") : NULL;
+            minimum = limit ? yyjson_obj_get(limit, "minimum") : NULL;
+            break;
+        }
+    }
+    bool declared = minimum && yyjson_is_int(minimum) && yyjson_get_int(minimum) >= 1;
+    yyjson_doc_free(doc);
+    free(resp);
+    cbm_mcp_server_free(srv);
+
+    ASSERT_TRUE(declared);
+    PASS();
+}
+
 TEST(tool_search_code_no_project) {
     cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
 
@@ -10552,6 +10605,8 @@ SUITE(mcp) {
     RUN_TEST(tool_get_code_snippet_missing_qn);
     RUN_TEST(tool_get_code_snippet_not_found);
     RUN_TEST(tool_search_code_missing_pattern);
+    RUN_TEST(tool_search_code_negative_limit_is_not_echoed);
+    RUN_TEST(tool_search_code_limit_declares_a_minimum);
     RUN_TEST(tool_search_code_no_project);
     RUN_TEST(search_code_multi_word);
     RUN_TEST(search_code_scoped_path_with_spaces_issue687);


### PR DESCRIPTION
Closes #1511.

`search_code` never range checked `limit`. `--limit -5` was echoed back as the result count (`results: -5`) and then fell through to the raw path, so the call still returned something.

- clamp `limit < 1` to `MCP_DEFAULT_LIMIT` in `handle_search_code`
- declare `"minimum": 1` in the tool schema, so a schema validating client rejects it before the handler

Both already hold for sibling tools. `search_graph --limit -5` on the same project returns a clamped `results: 50`.

## Test plan

Two tests in `tests/test_mcp.c`:

- `tool_search_code_negative_limit_is_not_echoed` — asserts `results: -5` does not appear in the response
- `tool_search_code_limit_declares_a_minimum` — walks `tools/list` with yyjson to `search_code.inputSchema.properties.limit.minimum`, matching how `mcp_response_has_exact_tool` inspects responses

`./build/c/test-runner mcp` under ASan/UBSan on Linux x86_64: both new tests pass, 94 passing overall.

## Correction, and a pre-existing failure

An earlier version of this description said "0 fail". That was wrong, and I would rather flag it than leave it: the suite exits 1 on `main` here, independently of this change.

```
FAIL tests/test_mcp.c:6803: strstr(dc_resp, "seed_symbols: 1\n") is NULL
```

That is `detect_changes_seeds_only_touched_symbol_issue1363`. The `3417 bytes leaked in 3 allocations` ASan also reports is a consequence rather than a separate bug: the assertion returns before the test's `free(dc_resp)`, `free(project)` and `cbm_mcp_server_free(srv)`, which is exactly three allocations.

This PR touches only `handle_search_code` and the `search_code` schema string, so it cannot reach `detect_changes`. Happy to open a separate issue with the full trace if it is not already known.