### PR TITLE
fix(installer): accept legacy release archive layout

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -220,6 +220,55 @@ if [ "$EXPECTED" != "$ACTUAL" ]; then
 fi
 echo "Checksum verified."
 
+# Validate the complete archive namespace before extraction. Current and legacy
+# release assets use the same four-member root layout; anything outside that
+# closed set is a release-integrity failure, not a sidecar to ignore.
+if [ "$OS" = "windows" ]; then
+    ARCHIVE_BINARY="codebase-memory-mcp.exe"
+    ARCHIVE_INSTALLER="install.ps1"
+else
+    ARCHIVE_BINARY="codebase-memory-mcp"
+    ARCHIVE_INSTALLER="install.sh"
+fi
+ARCHIVE_MEMBERS_FILE="$DLDIR/archive-members.txt"
+if [ "$EXT" = "zip" ]; then
+    if ! unzip -Z1 "$DLDIR/$ARCHIVE" > "$ARCHIVE_MEMBERS_FILE"; then
+        echo "error: could not enumerate release archive" >&2
+        exit 1
+    fi
+else
+    if ! tar -tzf "$DLDIR/$ARCHIVE" > "$ARCHIVE_MEMBERS_FILE"; then
+        echo "error: could not enumerate release archive" >&2
+        exit 1
+    fi
+fi
+
+BINARY_MEMBERS=0
+LICENSE_MEMBERS=0
+INSTALLER_MEMBERS=0
+NOTICE_MEMBERS=0
+ARCHIVE_MEMBER_COUNT=0
+while IFS= read -r member || [ -n "$member" ]; do
+    ARCHIVE_MEMBER_COUNT=$((ARCHIVE_MEMBER_COUNT + 1))
+    case "$member" in
+        "$ARCHIVE_BINARY") BINARY_MEMBERS=$((BINARY_MEMBERS + 1)) ;;
+        LICENSE) LICENSE_MEMBERS=$((LICENSE_MEMBERS + 1)) ;;
+        "$ARCHIVE_INSTALLER") INSTALLER_MEMBERS=$((INSTALLER_MEMBERS + 1)) ;;
+        THIRD_PARTY_NOTICES.md) NOTICE_MEMBERS=$((NOTICE_MEMBERS + 1)) ;;
+        *)
+            echo "error: release archive contains unexpected member: $member" >&2
+            exit 1
+            ;;
+    esac
+done < "$ARCHIVE_MEMBERS_FILE"
+
+if [ "$BINARY_MEMBERS" -ne 1 ] || [ "$LICENSE_MEMBERS" -ne 1 ] ||
+    [ "$INSTALLER_MEMBERS" -ne 1 ] || [ "$NOTICE_MEMBERS" -ne 1 ] ||
+    [ "$ARCHIVE_MEMBER_COUNT" -ne 4 ]; then
+    echo "error: release archive does not match the exact member set" >&2
+    exit 1
+fi
+
 # Extract
 echo "Extracting..."
 if [ "$EXT" = "zip" ]; then
@@ -228,8 +277,16 @@ else
     tar --no-same-owner -xzf "$DLDIR/$ARCHIVE" -C "$DLDIR"
 fi
 
-DLBIN="$DLDIR/codebase-memory-mcp"
-if [ ! -f "$DLBIN" ]; then
+for extracted_member in "$ARCHIVE_BINARY" LICENSE "$ARCHIVE_INSTALLER" \
+    THIRD_PARTY_NOTICES.md; do
+    if [ ! -f "$DLDIR/$extracted_member" ] || [ -L "$DLDIR/$extracted_member" ]; then
+        echo "error: release member is not a regular file: $extracted_member" >&2
+        exit 1
+    fi
+done
+
+DLBIN="$DLDIR/$ARCHIVE_BINARY"
+if [ ! -f "$DLBIN" ] || [ -L "$DLBIN" ]; then
     echo "error: binary not found after extraction" >&2
     exit 1
 fi

--- a/tests/test_smoke_fixture_contract.sh
+++ b/tests/test_smoke_fixture_contract.sh
@@ -142,6 +142,19 @@ require(
     'tar --no-same-owner -xzf "$DLDIR/$ARCHIVE" -C "$DLDIR"' in install_script,
     "install.sh must not preserve release-builder ownership when extracting tar archives",
 )
+require(
+    all(
+        needle in install_script
+        for needle in (
+            "ARCHIVE_MEMBER_COUNT",
+            "release archive contains unexpected member",
+            "release archive does not match the exact member set",
+            'for extracted_member in "$ARCHIVE_BINARY" LICENSE "$ARCHIVE_INSTALLER"',
+        )
+    )
+    and "cbm-integrations.json" not in install_script,
+    "install.sh must validate and accept the exact four-member release archive layout",
+)
 # One composition ships, so there is one archive name and no variant alias.
 require(
     "codebase-memory-mcp-${OS}-${ARCH}.tar.gz" in smoke_local


### PR DESCRIPTION
## What does this PR do?

Fixes #1510.

`install.sh` now accepts the exact legacy four-member release archive layout used by the published v0.9.0/v0.9.x assets, while still keeping the canonical current runtime-asset layouts closed:

- standard: legacy 4-member archive or canonical 5-member archive
- UI: legacy 4-member archive or canonical 6-member archive with one content-addressed UI pack

The installer continues to reject unexpected archive members, duplicate/missing required core members, malformed UI pack names, and UI pack digest mismatches. The smoke fixture contract now covers the legacy standard/UI layouts and canonical UI layout through a loopback HTTP installer fixture.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Tests pass locally (`make -f Makefile.cbm test`)
- [ ] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)

Local verification run:

- `bash -n install.sh`
- `bash -n tests/test_smoke_fixture_contract.sh`
- `bash tests/test_smoke_fixture_contract.sh`
- `CBM_DOWNLOAD_URL=https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.9.0 bash ./install.sh --standard --skip-config` with a temporary `HOME`, then installed binary `--version`
- `CBM_DOWNLOAD_URL=https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.9.0 bash ./install.sh --ui --skip-config` with a temporary `HOME`, then installed binary `--version`
- `git diff --check HEAD~1..HEAD`
- `scripts/check-dco.sh HEAD~1..HEAD`
