### PR TITLE
fix(ci): finish the single-composition sweep in the smoke workflow

### DIFF
--- a/.github/workflows/_smoke.yml
+++ b/.github/workflows/_smoke.yml
@@ -71,12 +71,11 @@ jobs:
             WIN=$(jq -cn --argjson a "$CORE_WIN" '$a')
             PORTABLE=$(jq -cn --argjson a "$CORE_PORTABLE" '$a')
           fi
-          # Keep the UI marker explicit because the smoke wrappers use it to
-          # require and validate the shipped content-addressed frontend pack.
-          VARIANTS='["ui"]'
-          UNIX_M=$(jq -cn --argjson a "$UNIX" --argjson v "$VARIANTS" '{include:[$a[] as $o | $v[] as $t | ($o + {variant:$t})]}')
-          WIN_M=$(jq -cn --argjson a "$WIN" --argjson v "$VARIANTS" '{include:[$a[] as $o | $v[] as $t | ($o + {variant:$t})]}')
-          PORTABLE_M=$(jq -cn --argjson a "$PORTABLE" --argjson v "$VARIANTS" '{include:[$a[] as $o | $v[] as $t | ($o + {variant:$t})]}')
+          # One composition ships; the wrappers assert the embedded UI themselves
+          # (SMOKE_REQUIRE_UI in scripts/ci/smoke-artifact.sh and below).
+          UNIX_M=$(jq -cn --argjson a "$UNIX" '{include:$a}')
+          WIN_M=$(jq -cn --argjson a "$WIN" '{include:$a}')
+          PORTABLE_M=$(jq -cn --argjson a "$PORTABLE" '{include:$a}')
           echo "unix=$UNIX_M" >> "$GITHUB_OUTPUT"
           echo "windows=$WIN_M" >> "$GITHUB_OUTPUT"
           echo "portable=$PORTABLE_M" >> "$GITHUB_OUTPUT"
@@ -102,9 +101,8 @@ jobs:
 
       - name: Extract release artifact
         run: |
-          SUFFIX=${{ matrix.variant == 'ui' && '-ui' || '' }}
           mkdir -p "$RUNNER_TEMP/cbm-artifact"
-          tar -xzf codebase-memory-mcp${SUFFIX}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz \
+          tar -xzf codebase-memory-mcp-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz \
             -C "$RUNNER_TEMP/cbm-artifact"
           chmod +x "$RUNNER_TEMP/cbm-artifact/codebase-memory-mcp"
 
@@ -116,10 +114,10 @@ jobs:
       # the wrapper (no env isolation, no user-PATH guard, fixed port).
       - name: Smoke test (shared wrapper)
         run: |
-          scripts/smoke-local.sh \
-            "$RUNNER_TEMP/cbm-artifact/codebase-memory-mcp" ${{ matrix.variant }}
+          scripts/smoke-local.sh "$RUNNER_TEMP/cbm-artifact/codebase-memory-mcp"
         env:
           CBM_SMOKE_ARTIFACT_DIR: ${{ runner.temp }}/cbm-artifact
+          SMOKE_REQUIRE_UI: "1"
 
       - name: Security audits
         run: |
@@ -195,11 +193,10 @@ jobs:
       - name: Extract release artifact
         shell: msys2 {0}
         run: |
-          SUFFIX=${{ matrix.variant == 'ui' && '-ui' || '' }}
           ARCH=${{ matrix.arch }}
           ARTIFACT_DIR="$(cygpath -u "$RUNNER_TEMP")/cbm-artifact"
           mkdir -p "$ARTIFACT_DIR"
-          unzip -o "codebase-memory-mcp${SUFFIX}-windows-${ARCH}.zip" -d "$ARTIFACT_DIR"
+          unzip -o "codebase-memory-mcp-windows-${ARCH}.zip" -d "$ARTIFACT_DIR"
           test -s "$ARTIFACT_DIR/codebase-memory-mcp.exe"
           # ONE executable per runtime set: a payload sibling would mean the
           # removed launcher split came back.
@@ -226,7 +223,7 @@ jobs:
         shell: msys2 {0}
         env:
           SMOKE_ARCH: ${{ matrix.arch }}
-          SMOKE_VARIANT: ${{ matrix.variant }}
+          SMOKE_REQUIRE_UI: "1"
         run: |
           export CBM_SMOKE_ARTIFACT_DIR="$(cygpath -u "$RUNNER_TEMP")/cbm-artifact"
           bash test-infrastructure/vm/vm-smoke.sh
@@ -288,9 +285,8 @@ jobs:
 
       - name: Extract release artifact
         run: |
-          SUFFIX=${{ matrix.variant == 'ui' && '-ui' || '' }}
           mkdir -p "$RUNNER_TEMP/cbm-artifact"
-          tar -xzf codebase-memory-mcp${SUFFIX}-linux-${{ matrix.arch }}-portable.tar.gz \
+          tar -xzf codebase-memory-mcp-linux-${{ matrix.arch }}-portable.tar.gz \
             -C "$RUNNER_TEMP/cbm-artifact"
           chmod +x "$RUNNER_TEMP/cbm-artifact/codebase-memory-mcp"
 
@@ -301,10 +297,10 @@ jobs:
       # exactly the phases it most needs to run.
       - name: Smoke test (shared wrapper)
         run: |
-          scripts/smoke-local.sh \
-            "$RUNNER_TEMP/cbm-artifact/codebase-memory-mcp" ${{ matrix.variant }}
+          scripts/smoke-local.sh "$RUNNER_TEMP/cbm-artifact/codebase-memory-mcp"
         env:
           CBM_SMOKE_ARTIFACT_DIR: ${{ runner.temp }}/cbm-artifact
+          SMOKE_REQUIRE_UI: "1"
 
       # The -portable binary is what all linux install/update paths now deliver;
       # it MUST start on old glibc (Debian 11 / RHEL 8 / Ubuntu 20.04). Runs it


### PR DESCRIPTION
The first full dry run after #1508 failed in all three `smoke-linux-portable` legs: `_smoke.yml` still expanded a variant matrix and extracted `codebase-memory-mcp-ui-<os>-<arch>.tar.gz` — a name the build no longer produces. PR CI never exercises this job (`pr.yml` calls the smoke wrappers directly), so the miss only surfaced in the dry-run/release path.

- The matrix loses its variant dimension.
- All three legs extract the unsuffixed archive.
- `SMOKE_VARIANT` / positional variant plumbing becomes `SMOKE_REQUIRE_UI=1`: these legs smoke the **shipped** artifact, so a binary serving no embedded UI is a defect here, mirroring `scripts/ci/smoke-artifact.sh`.

Workflows-only change. Verified locally: venue-parity and smoke-fixture contracts pass; YAML parses. Dry run 31357346999 was cancelled at the first failing job and will be re-dispatched once this lands.