### PR TITLE
fix(diagnostics): report OS-truth RSS, not mimalloc's Linux commit counter

### DIFF
--- a/src/foundation/diagnostics.c
+++ b/src/foundation/diagnostics.c
@@ -528,9 +528,16 @@ static void write_diagnostics(void) {
     size_t page_faults = 0;
     mi_process_info(&elapsed_ms, &user_ms, &sys_ms, &current_rss, &peak_rss, &current_commit,
                     &peak_commit, &page_faults);
-    if (current_rss == 0) {
-        current_rss = cbm_mem_rss();
-    }
+    /* Do NOT report mi_process_info's rss fields: on Linux mimalloc never sets
+     * current_rss, so the field keeps mimalloc's internal committed-page
+     * counter — deliberately tuned low here (purge_decommits=1, purge_delay=0)
+     * and able to go transiently NEGATIVE under purge, which wraps through
+     * size_t and printed rss_bytes of ~2^64 (soak read it as a 17-exabyte
+     * "leak"). cbm_mem_rss()/cbm_mem_peak_rss() already encode the whole
+     * lesson: /proc statm is authoritative on Linux, mimalloc is correct on
+     * macOS/Windows, and peak is reconciled to never undercut current. */
+    current_rss = cbm_mem_rss();
+    peak_rss = cbm_mem_peak_rss();
 
     int fds = count_open_fds();
     time_t now = time(NULL);


### PR DESCRIPTION
Both Linux `soak-quick` legs in dry run 31364739675 failed with `FAIL: RSS 17592186044293MB > 200MB ceiling` — that value is 2^44−123, i.e. **−123 MB wrapped through `size_t`**, not a leak.

The diagnostics snapshot reported `mi_process_info()` `current_rss` verbatim. On Linux mimalloc never sets that field; it keeps mimalloc-internal committed-page accounting, which this project deliberately tunes low (`purge_decommits=1`, `purge_delay=0`) and which can transiently go negative under purge. macOS/Windows are unaffected (mimalloc reports real RSS there) — matching the observed split exactly: both Linux legs red, both macOS legs green, same binary.

`mem.c` already encodes the full lesson for `cbm_mem_over_budget` (documented in its comment block): `cbm_mem_rss()` is `/proc/self/statm`-primary on Linux and mimalloc-correct elsewhere; `cbm_mem_peak_rss()` reconciles peak ≥ current. The diagnostics writer now uses both.

Verified: diagnostics suite passes locally; compiles + clang-format clean. Dry run re-dispatch follows the merge.