### PR TITLE
test(bench): make the py-lsp time budget a liveness backstop, not a perf gate

### DIFF
--- a/tests/test_py_lsp_bench.c
+++ b/tests/test_py_lsp_bench.c
@@ -255,14 +255,15 @@ TEST(pylsp_bench_resolution_ratio) {
         ASSERT_GTE(resolved * 2, calls);
     }
 
-    /* Time budget. ASan+UBSan instrumentation slows the parse ~5-10×, so
-     * scale the budget when a sanitizer is active. Native: 150 ms for a
-     * ~200-line fixture; sanitized: 1500 ms. */
-#if defined(CBM_SANITIZED_BUILD) || defined(__SANITIZE_ADDRESS__)
-    ASSERT(ms < 1500.0);
-#else
-    ASSERT(ms < 150.0);
-#endif
+    /* Liveness backstop ONLY — not a perf gate. The perf content of this test
+     * is the resolution-ratio assertion above; wall-clock on a shared CI
+     * runner is not a property of the code (the 1500 ms sanitized budget was
+     * exceeded twice on loaded ubuntu-24.04-arm runners by the SAME sha that
+     * passed hours earlier). Absolute timings belong to
+     * scripts/benchmark-*.sh, which record rather than gate. This bound
+     * exists solely so a catastrophic hang fails the suite instead of the
+     * 900 s shard wall clock. */
+    ASSERT(ms < 30000.0);
     PASS();
 }
 


### PR DESCRIPTION
The v0.10.0 release run failed twice on genuine attempts at `test_py_lsp_bench.c:262 ASSERT(ms < 1500.0)` (ubuntu-24.04-arm 3/3), while the **same SHA** passed that shard in the morning's dry run. Two same-SHA verdicts that differ = the wall-clock bound is measuring runner load, not code.

Per the repo's testing doctrine, perf tests assert a **ratio**; a time bound may exist only as a **liveness backstop**. This test's perf content already is ratio-form (resolution ratio with the sanitizer-aware floor) — the 150/1500 ms absolute budget was the anti-pattern half. It becomes a 30 s liveness backstop (catastrophic hangs still fail the suite instead of eating the 900 s shard wall clock); absolute timings stay in `scripts/benchmark-*.sh`, which record rather than gate.

Test-only change; unblocks re-dispatching the v0.10.0 release pipeline on a fresh SHA rather than re-rolling the same one.