### PR TITLE
test: cover wrong JSON types in the MCP robustness layer

### DIFF
--- a/scripts/security-fuzz.sh
+++ b/scripts/security-fuzz.sh
@@ -116,6 +116,19 @@ test_payload "array instead of object" '[1,2,3]'
 test_payload "deeply nested json" '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search_graph","arguments":{"name_pattern":{"a":{"b":{"c":{"d":{"e":{"f":"deep"}}}}}}}}}'
 
 echo ""
+echo "--- Wrong JSON types ---"
+
+test_payload "null tool name" '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":null,"arguments":{}}}'
+test_payload "numeric tool name" '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":42,"arguments":{}}}'
+test_payload "object tool name" '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":{"a":1},"arguments":{}}}'
+test_payload "array arguments" '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search_graph","arguments":[1,2]}}'
+test_payload "string arguments" '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search_graph","arguments":"nope"}}'
+test_payload "null arguments" '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search_graph","arguments":null}}'
+test_payload "array params" '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":[1,2]}'
+test_payload "numeric params" '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":7}'
+test_payload "numeric method" '{"jsonrpc":"2.0","id":2,"method":7,"params":{}}'
+
+echo ""
 echo "--- Oversized inputs ---"
 
 # 1MB string argument


### PR DESCRIPTION
The robustness layer varies argument *values* thoroughly (oversized, injection, negative, ReDoS) but always sends the expected *type*. These nine send a value of the wrong JSON type for the envelope fields parsed before tool dispatch: `name`, `arguments`, `params`, `method`.

All nine pass against the current binary. This is a regression guard for a class the layer does not currently reach, not a bug report — I went looking for a NULL deref and did not find one; `cbm_mcp_parse_request` rejects a non-string `method` before use, and `heap_strdup` returns NULL safely.

Kept to the envelope. I also wrote per-tool field cases (wrong-typed `name_pattern`, `query`, `limit`) and dropped them: they stop at project validation like the existing adversarial cases, so they added runtime without reaching new code.

Layer goes 23/23 in 88s to 32/32 in 120s on this machine.