### PR TITLE
fix(mcp): remove top-level anyOf from check_index_coverage schema

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -636,16 +636,19 @@ static const tool_def_t TOOLS[] = {
      "use scopes before negative/exhaustive claims because fully skipped files cannot appear in "
      "normal graph results. Returns coverage status separately from filesystem metadata freshness, "
      "plus structured parse-error ranges and direct-source fallback actions. The signal is "
-     "best-effort: indexed_no_recorded_gap is not a completeness guarantee.",
+     "best-effort: indexed_no_recorded_gap is not a completeness guarantee. At least one of "
+     "'paths' or 'scopes' is required; the call is rejected at runtime if both are omitted.",
      "{\"type\":\"object\",\"properties\":{"
      "\"project\":{\"type\":\"string\"},"
      "\"paths\":{\"type\":\"array\",\"items\":{\"type\":\"string\"},\"maxItems\":128,"
-     "\"description\":\"Repository-relative files to check exactly.\"},"
+     "\"description\":\"Repository-relative files to check exactly. Required if 'scopes' is "
+     "omitted.\"},"
      "\"scopes\":{\"type\":\"array\",\"items\":{\"type\":\"string\"},\"maxItems\":32,"
-     "\"description\":\"Repository-relative path prefixes; use . for the project root.\"},"
+     "\"description\":\"Repository-relative path prefixes; use . for the project root. Required "
+     "if 'paths' is omitted.\"},"
      "\"scope_limit\":{\"type\":\"integer\",\"default\":200,\"minimum\":1,\"maximum\":1000},"
      "\"scope_offset\":{\"type\":\"integer\",\"default\":0,\"minimum\":0}},"
-     "\"required\":[\"project\"],\"anyOf\":[{\"required\":[\"paths\"]},{\"required\":[\"scopes\"]}]"
+     "\"required\":[\"project\"]"
      "}"},
 
     {"detect_changes", "Detect changes",


### PR DESCRIPTION
Fixes #1524

### Problem

`check_index_coverage`'s `inputSchema` had a top-level `anyOf`:

```json
"required":["project"],"anyOf":[{"required":["paths"]},{"required":["scopes"]}]
```

Anthropic (Claude), AWS Bedrock, Google Vertex/Gemini, and Azure OpenAI reject custom tool schemas containing a top-level `oneOf`/`allOf`/`anyOf`. Once this tool's schema reaches the model (e.g. after `tools/list`), the provider rejects the request outright, breaking every tool call in the session for MCP clients backed by those providers.

### Fix

- Removed the top-level `anyOf` from `check_index_coverage`'s `inputSchema`.
- The "at least one of `paths` or `scopes`" requirement was already enforced independently at **runtime** in `handle_check_index_coverage` (`path_count == 0U && scope_count == 0U` rejection), so no validation is lost.
- Moved the requirement into the tool description and the `paths`/`scopes` property descriptions so it's still discoverable by callers.
- No other tool schema in `src/mcp/mcp.c` uses `oneOf`/`allOf`/`anyOf` (verified via grep), so this was the only occurrence of the defect.

### Testing

- `make -f Makefile.cbm cbm` — clean build.
- `make -f Makefile.cbm test-focused TEST_SUITES=mcp` (ASan+UBSan) — **192 passed, 2 skipped (Windows-only), 0 failed**, including all 6 `tool_check_index_coverage_*` tests exercising paths/scopes/error paths.
- Manually verified via stdio JSON-RPC (`tools/list`) that the live `inputSchema` for `check_index_coverage` no longer contains `anyOf`, only `"required":["project"]`.
- `scripts/check-dco.sh origin/main..HEAD` passes.

This is a one-file, no-behavior-change fix (schema only); scope is limited to the bug fix per the "bug fixes ... welcome without prior discussion" exception in CONTRIBUTING.md, and #1524 documents the root cause and repro for maintainer review.
