### PR TITLE
fix(installer): ignore archive ownership on extraction

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -225,7 +225,7 @@ echo "Extracting..."
 if [ "$EXT" = "zip" ]; then
     unzip -q "$DLDIR/$ARCHIVE" -d "$DLDIR"
 else
-    tar -xzf "$DLDIR/$ARCHIVE" -C "$DLDIR"
+    tar --no-same-owner -xzf "$DLDIR/$ARCHIVE" -C "$DLDIR"
 fi
 
 DLBIN="$DLDIR/codebase-memory-mcp"

--- a/tests/test_smoke_fixture_contract.sh
+++ b/tests/test_smoke_fixture_contract.sh
@@ -137,6 +137,11 @@ for relative, source in (
 # Unix fixtures mirror the release archive surface and Linux update aliases.
 for name in ("LICENSE", "install.sh", "THIRD_PARTY_NOTICES.md"):
     require(name in smoke_local, f"smoke-local.sh archive must include {name}")
+install_script = read("install.sh")
+require(
+    'tar --no-same-owner -xzf "$DLDIR/$ARCHIVE" -C "$DLDIR"' in install_script,
+    "install.sh must not preserve release-builder ownership when extracting tar archives",
+)
 # One composition ships, so there is one archive name and no variant alias.
 require(
     "codebase-memory-mcp-${OS}-${ARCH}.tar.gz" in smoke_local


### PR DESCRIPTION
## What does this PR do?

Prevents the Unix installer from preserving release-builder ownership when extracting verified tar archives.

The official v0.10.0 Linux portable archive records `codebase-memory-mcp` as `runner/runner`. When root extracts it with plain `tar -xzf`, GNU tar restores that foreign UID. Candidate staging then rejects the file because activation requires the source owner to match `geteuid()`, producing:

```text
error: failed to stage install candidate: activation transaction I/O failed
```

Using `tar --no-same-owner` keeps extracted files owned by the invoking user and satisfies the existing activation security check. A smoke contract prevents the extraction flag from regressing.

Duplicate search found no issue or PR for this release-archive ownership root cause. Related but distinct reports: #1529 (Windows temporary-directory ACL) and #1483 (test fixtures under umask 002).

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Focused tests pass locally
- [x] Focused lint/syntax checks pass locally
- [x] New behavior is covered by a test (reproduce-first for bug fixes)

Verification:

- `bash -n install.sh`
- `bash -n tests/test_smoke_fixture_contract.sh`
- `bash tests/test_smoke_fixture_contract.sh`
- `scripts/check-dco.sh HEAD^..HEAD`
- `git diff --check origin/main...HEAD`
- Reproduced with a foreign-owner tar entry: plain extraction retained UID 12345; `--no-same-owner` produced current EUID.
- Verified official v0.10.0 archive records `runner/runner`; plain root extraction produced UID 1001 while patched extraction produced UID 0.
