### PR TITLE
fix(test): qualify build-dir owner with its domain

### DIFF
--- a/scripts/memlab.sh
+++ b/scripts/memlab.sh
@@ -35,7 +35,13 @@ if [[ "$BINARY" == *.exe ]] && command -v cygpath >/dev/null 2>&1 &&
     ! command -v winepath >/dev/null 2>&1; then
     WIN_ROOT=$(mktemp -d "$(cygpath "$USERPROFILE")/cbm-memlab.XXXXXX")
     WIN_ROOT_W="$(cygpath -w "$WIN_ROOT")"
+    # Qualify with the domain: a bare name from coreutils `whoami` resolves
+    # against the machine first, so on a host whose name equals the user's the
+    # grant lands on an empty principal.
     ME="$(whoami | tr -d '\r')"
+    if [ -n "${USERDOMAIN:-}" ]; then
+        ME="${USERDOMAIN}\\${ME}"
+    fi
     MSYS2_ARG_CONV_EXCL='*' icacls "$WIN_ROOT_W" /reset /Q >/dev/null 2>&1 || true
     if ! MSYS2_ARG_CONV_EXCL='*' icacls "$WIN_ROOT_W" /inheritance:r \
         /grant:r "${ME}:(OI)(CI)F" '*S-1-5-18:(OI)(CI)F' '*S-1-5-32-544:(OI)(CI)F' \

--- a/scripts/run-tests-parallel.sh
+++ b/scripts/run-tests-parallel.sh
@@ -58,7 +58,16 @@ stamp_windows_build_dir() {
     esac
     local runner_dir_w me norm_out stamp_out reset_out
     runner_dir_w="$(cygpath -w "$(dirname "$RUNNER")")"
+    # Qualify the account with its domain. Git Bash resolves `whoami` to
+    # coreutils, which prints a bare name, and icacls resolves a bare name
+    # against the machine first: on a host whose name equals the user's
+    # (COMPUTERNAME=BUILD, user build) the grant lands on an empty principal
+    # (BUILD\) and, combined with /inheritance:r above, locks this script out
+    # of its own log directory.
     me="$(whoami | tr -d '\r')"
+    if [ -n "${USERDOMAIN:-}" ]; then
+        me="${USERDOMAIN}\\${me}"
+    fi
     # Normalize FIRST: some runner images stamp EXPLICIT (non-inherited)
     # Authenticated-Users ACEs onto the workspace tree, which /inheritance:r
     # cannot strip and /grant:r does not touch (it replaces only the granted

--- a/scripts/soak-test.sh
+++ b/scripts/soak-test.sh
@@ -77,7 +77,13 @@ mkdir -p "$RESULTS_DIR"
 soak_stamp_windows_dir() {
     local dir_w me output
     dir_w="$(cygpath -w "$1")"
+    # Qualify with the domain: a bare name from coreutils `whoami` resolves
+    # against the machine first, so on a host whose name equals the user's the
+    # grant lands on an empty principal.
     me="$(whoami | tr -d '\r')"
+    if [ -n "${USERDOMAIN:-}" ]; then
+        me="${USERDOMAIN}\\${me}"
+    fi
     if ! output=$(MSYS2_ARG_CONV_EXCL='*' icacls "$dir_w" /reset /Q 2>&1); then
         echo "FAIL: soak DACL normalize failed (dir=$dir_w user=$me)" >&2
         printf '%s\n' "$output" >&2


### PR DESCRIPTION
## Problem

The Windows DACL stamps in `scripts/run-tests-parallel.sh`, `scripts/soak-test.sh` and `scripts/memlab.sh` pass the current user to `icacls` by bare name:

```bash
me="$(whoami | tr -d '\r')"
icacls "$dir" /inheritance:r /grant:r "${me}:(OI)(CI)F" '*S-1-5-18:(OI)(CI)F' '*S-1-5-32-544:(OI)(CI)F'
```

Git Bash resolves `whoami` to coreutils, which prints an unqualified name, and `icacls` resolves an unqualified name against the machine before the user. On a host whose name equals the user's, the grant lands on an empty principal:

```
C:\...\build\c BUILTIN\Administrators:(OI)(CI)(F)
               NT AUTHORITY\SYSTEM:(OI)(CI)(F)
               PETRO\:(OI)(CI)(F)
```

Combined with the `/inheritance:r` in the same invocation, the directory grants no usable account. `run-tests-parallel.sh` then cannot write its own log directory:

```
build-dir DACL stamped clean (pre-wave, build\c, user=petro)
scripts/run-tests-parallel.sh: line 91: build/c/test-logs/results.txt: Permission denied
scripts/run-tests-parallel.sh: line 96: build/c/test-runner: Is a directory
FAIL: test-runner --list-suites exited nonzero
make: *** [Makefile.cbm:877: test-par] Error 1
```

The stamp reports success because the `Authenticated Users` / `CREATOR OWNER` check that follows it passes: an empty principal grants neither.

## Change

Prefix the name with `USERDOMAIN` when it is set, which makes the account unambiguous, and fall back to the bare name otherwise. `SYSTEM` and `Administrators` in the same invocations already use SID form and are unaffected.

Verified on the affected configuration:

```
with USERDOMAIN: [PETRO\petro]
without USERDOMAIN: [petro]
```

## Reproducing

Set the machine name equal to the account name (`COMPUTERNAME=BUILD`, user `build`), then run `scripts/test.sh`. `icacls <build dir>` after the stamp shows `BUILD\:` with an empty account name.

This is unrelated to #1531; I hit it while trying to run the suite for that change.
