### PR TITLE
docs(readme): note npx/ephemeral invocation under daemon model

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ The native `install`, `update`, and `uninstall` commands are the deliberate exce
 
 Package-manager setup (npm, PyPI, or Go) verifies and publishes a coherent private cached runtime set. Sidecars are replaced before the executable with per-file atomic renames; an interrupted multi-file publication is detected and repaired on the next launch rather than being described as one crash-atomic filesystem transaction. It does not replace the active native installation and therefore does not stop running CBM sessions. When that cached binary is executed, it still enters the same exact-build admission barrier. The shell and PowerShell installers invoke the verified candidate's native `install` command, so they do receive the full account-wide activation guarantee.
 
+**Ephemeral invocations (`npx`, one-shot caches).** That admission barrier fingerprints each connecting client's running executable. A binary launched from a throwaway package cache — for example `npx -y codebase-memory-mcp`, whose executable lives under `~/.npm/_npx/<hash>/...` — cannot be fingerprinted, so the daemon rejects it as `image_unverifiable`. The rejected client then waits for admission until its timeout and exits with no JSON-RPC on stdout, which MCP clients surface as a silent connection failure (for example `-32000: Connection closed`). Use a [managed install](#installation) (`codebase-memory-mcp install`) so the binary lives at a stable, fingerprintable path, and point your MCP client at that path instead of `npx`. See [#1539](https://github.com/DeusData/codebase-memory-mcp/issues/1539).
+
 The ordinary `cli` mode is intentionally separate: it runs one command locally and never starts or connects to the coordination daemon, registers a daemon session, or starts watchers/UI. Its only shared state is the OS admission barrier plus per-project locks for graph mutations. While the command is running, a temporary monitor lets activation cancel that operation and its supervised worker safely; the monitor exits with the command and never becomes a standing daemon. See [CLI Mode](#cli-mode) for details.
 
 ### Graph Visualization UI
@@ -724,6 +726,7 @@ SQLite databases stored at `~/.cache/codebase-memory-mcp/`. Persists across rest
 | Queries return wrong project results | Add `project="name"` parameter. Use `list_projects` to see names. |
 | Binary not found after install | Add to PATH: `export PATH="$HOME/.local/bin:$PATH"` |
 | UI not loading | Ensure you ran `--ui=true`. Check `http://localhost:9749`. |
+| MCP client reports `-32000: Connection closed` / server exits silently at startup (launched via `npx`) | Under the daemon model the client binary must be fingerprintable; an `npx` cache path is ephemeral and rejected (`image_unverifiable`). Use a managed install: `codebase-memory-mcp install --yes` (→ `~/.local/bin/`), then point the MCP client at that binary instead of `npx -y codebase-memory-mcp`. See [Session Coordination Daemon](#session-coordination-daemon). |
 
 ## Hybrid LSP
 


### PR DESCRIPTION
## What

Docs-only PR adding the "npx / ephemeral invocation under the daemon model" note requested in [#1539](https://github.com/DeusData/codebase-memory-mcp/issues/1539), so people hitting `-32000: Connection closed` today can find the cause and the managed-install fix.

Under v0.10+'s daemon model, a client launched via `npx -y codebase-memory-mcp` runs from an ephemeral package cache (`~/.npm/_npx/<hash>/...`). The daemon's admission barrier fingerprints each connecting client's running executable, and an ephemeral cache binary can't be fingerprinted, so the daemon rejects it as `image_unverifiable`. The rejected client then waits for admission until its timeout and exits with no JSON-RPC on stdout, which MCP clients surface as a silent connection failure (e.g. `-32000: Connection closed`). A managed install (`codebase-memory-mcp install`) places the binary at a stable, fingerprintable path and works.

## Changes (README.md only, +3 lines)

1. **Session Coordination Daemon** — a short paragraph immediately after the existing package-manager / admission-barrier discussion, explaining why ephemeral `npx` invocation is rejected and pointing to the managed install.
2. **Troubleshooting table** — a row for the `-32000` / silent-startup symptom with the managed-install fix, cross-linked to the daemon section.

## Scope

Docs only — no code, no behavior change, no new dependencies, no tool/ABI surface. Does not close #1539 (the code-level fail-open/loud-failure work is separate); this only documents the current behavior and workaround as @maintainer asked for in [#1539](https://github.com/DeusData/codebase-memory-mcp/issues/1539#issuecomment-5251854714).

Refs #1539.

## Verification

- Reproduced the failure deterministically via `npx` and the success via the managed binary on Linux x86_64 (WSL2, `ptrace_scope=1`); details in the [#1539 root-cause comment](https://github.com/DeusData/codebase-memory-mcp/issues/1539#issuecomment-5251854714).
- README renders with the two new entries; anchor links (`#installation`, `#session-coordination-daemon`) resolve to existing headings.

DCO: commit signed off (`Signed-off-by: wassolles <136268174+wassolles@users.noreply.github.com>`).
