### PR TITLE
chore(homebrew): point the formula at v0.10.2

### DIFF
--- a/pkg/homebrew/Formula/codebase-memory-mcp.rb
+++ b/pkg/homebrew/Formula/codebase-memory-mcp.rb
@@ -1,28 +1,28 @@
 class CodebaseMemoryMcp < Formula
   desc "Fast code intelligence engine for AI coding agents"
   homepage "https://github.com/DeusData/codebase-memory-mcp"
-  version "0.8.1"
+  version "0.10.2"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/DeusData/codebase-memory-mcp/releases/download/v#{version}/codebase-memory-mcp-darwin-arm64.tar.gz"
-      sha256 "fbd047509852021b5446a11141bcb0a3d1dcaebf6e5112460960f29f052c1c58"
+      sha256 "fa3ee085485fd9c16d1c1bd8a102df518862dabd2d6a09e4c6d8dfb3cd2a7eb4"
     end
     on_intel do
       url "https://github.com/DeusData/codebase-memory-mcp/releases/download/v#{version}/codebase-memory-mcp-darwin-amd64.tar.gz"
-      sha256 "fb62da3016ea12b948351208759b5c083fb1446cf6e78d6db8b7cd28fe86fd54"
+      sha256 "bb6cb47aea9e50e2193cdd917d5dbafa63b7d9c1cbe74bab5ec9bf4faa67e295"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/DeusData/codebase-memory-mcp/releases/download/v#{version}/codebase-memory-mcp-linux-arm64.tar.gz"
-      sha256 "d2f842d1365da5c35d9c5796f57a821c9745267350994346735e1e6e04d46091"
+      sha256 "b70148686cec55c31673fc0cebc0caf7f664f4ae29f7ba7f07b9617c2e5eaf85"
     end
     on_intel do
       url "https://github.com/DeusData/codebase-memory-mcp/releases/download/v#{version}/codebase-memory-mcp-linux-amd64.tar.gz"
-      sha256 "dbd3b92ea870ef240b63059f26bda15015f76ef9978931bebc3a0f9d09470973"
+      sha256 "6e3bb7353be21407a78e67b5465e53e3afb1a4a213e7a561606900ac08dcfdd6"
     end
   end
 


### PR DESCRIPTION
The formula still pinned **0.8.1** — four releases and two months behind — so `brew install` handed out a June binary while npm, PyPI and the GitHub archives all served the current one. Nothing in the release pipeline touches this file, which is how it drifted that far unnoticed.

Version plus all four SHA-256 digests taken from the published v0.10.2 `checksums.txt`.

Follow-up worth its own change: have the release workflow rewrite the formula from `checksums.txt` after publish, so this channel cannot silently rot again.