### PR TITLE
fix(cli): default-export Pi extension factory

### DIFF
--- a/src/cli/client_adapter.c
+++ b/src/cli/client_adapter.c
@@ -156,7 +156,7 @@ char *cbm_client_adapter_pi(const char *binary_path) {
 
     /* Register every tool the registry advertises — never a hand-picked subset,
      * which is the drift this generator exists to prevent. */
-    sb_append(&sb, "export function register(pi) {\n");
+    sb_append(&sb, "export default function (pi) {\n");
     for (int i = 0; i < count; i++) {
         const char *name = cbm_mcp_tool_name(i);
         if (!name || !name[0]) {

--- a/tests/test_agent_clients.c
+++ b/tests/test_agent_clients.c
@@ -1071,6 +1071,18 @@ TEST(agent_clients_continue_refuses_foreign_same_name_and_nonsequence_section) {
  * of the tool surface. #534 shipped one mirroring 7 of 15 tools; every tool
  * added afterwards would have been silently missing for that client. This pins
  * the property that makes generation worth doing: EVERY registry tool appears. */
+TEST(client_adapter_pi_default_exports_factory) {
+    char *js = cbm_client_adapter_pi("/usr/local/bin/codebase-memory-mcp");
+    ASSERT_NOT_NULL(js);
+
+    /* Pi imports only the module's default export as its extension factory. */
+    ASSERT_NOT_NULL(strstr(js, "export default function (pi) {"));
+    ASSERT_NULL(strstr(js, "export function register(pi) {"));
+
+    free(js);
+    PASS();
+}
+
 TEST(client_adapter_pi_registers_every_registry_tool) {
     char *js = cbm_client_adapter_pi("/usr/local/bin/codebase-memory-mcp");
     ASSERT_NOT_NULL(js);
@@ -1184,6 +1196,7 @@ SUITE(agent_clients) {
     RUN_TEST(agent_clients_deep_same_name_json_fails_closed_byte_identically);
     RUN_TEST(agent_clients_continue_uses_owned_yaml_sequence_item);
     RUN_TEST(agent_clients_continue_refuses_foreign_same_name_and_nonsequence_section);
+    RUN_TEST(client_adapter_pi_default_exports_factory);
     RUN_TEST(client_adapter_pi_registers_every_registry_tool);
     RUN_TEST(client_adapter_escapes_windows_paths_and_quotes);
     RUN_TEST(client_adapter_opencode_sends_the_required_hook_event);


### PR DESCRIPTION
## Summary
- emit the generated Pi adapter as a default-exported factory, matching Pi's extension contract
- add a regression test that rejects the incompatible named `register(pi)` export

## Testing
- `make -f Makefile.cbm test-focused TEST_SUITES=agent_clients` (31 passed, ASan/UBSan)
- regression test confirmed failing before the generator fix and passing afterward
- `git diff --check`

Fixes #1550