### PR TITLE
fix(pi): emit default-export factory in generated pi extension

### DIFF
--- a/src/cli/client_adapter.c
+++ b/src/cli/client_adapter.c
@@ -155,8 +155,14 @@ char *cbm_client_adapter_pi(const char *binary_path) {
              "}\n\n");
 
     /* Register every tool the registry advertises — never a hand-picked subset,
-     * which is the drift this generator exists to prevent. */
-    sb_append(&sb, "export function register(pi) {\n");
+     * which is the drift this generator exists to prevent.
+     *
+     * Pi loads extensions via jiti.import(path, { default: true }) and rejects
+     * anything that is not a function — i.e. the module must have a DEFAULT
+     * export factory. A named `export function register(pi)` makes the loader
+     * see the module namespace object instead, and every pi install fails with
+     * "Extension does not export a valid factory function". */
+    sb_append(&sb, "export default function (pi) {\n");
     for (int i = 0; i < count; i++) {
         const char *name = cbm_mcp_tool_name(i);
         if (!name || !name[0]) {

--- a/tests/test_agent_clients.c
+++ b/tests/test_agent_clients.c
@@ -1086,6 +1086,13 @@ TEST(client_adapter_pi_registers_every_registry_tool) {
          * exactly the failure this design removes. */
         ASSERT_NOT_NULL(strstr(js, needle));
     }
+    /* Pi's loader does jiti.import(path, { default: true }) and requires a
+     * function, so the module MUST export a default factory. A named-only
+     * `export function register(pi)` fails every install with "Extension does
+     * not export a valid factory function". Pin both: the default export
+     * exists, and the broken named-only form never reappears. */
+    ASSERT_NOT_NULL(strstr(js, "export default function (pi)"));
+    ASSERT_NULL(strstr(js, "export function register(pi)"));
     /* The body must NOT carry the ownership markers: cbm_text_upsert_managed_block
      * adds them and rejects content that already has them, so emitting them here
      * would make every install fail. */


### PR DESCRIPTION
## Problem

`codebase-memory-mcp install` generates `~/.pi/agent/extensions/cbmem.ts` for the pi client, but the emitted module uses a **named export**:

```ts
export function register(pi) { ... }
```

Pi's extension loader (pi's `core/extensions/loader.ts`) imports modules with `jiti.import(path, { default: true })` and then requires the result to be a **function**:

```ts
const factory = await jiti.import(extensionPath, { default: true });
if (typeof factory !== "function") {
    return undefined; // -> "Extension does not export a valid factory function"
}
```

Because `cbmem.ts` has no default export, jiti's interop returns the module namespace *object*, not the factory. Every pi startup then fails with:

```
Error: Failed to load extension "/Users/.../.pi/agent/extensions/cbmem.ts":
Extension does not export a valid factory function
```

Pi's documented extension contract is a default-export factory function (pi docs, extensions.md: "An extension exports a default factory function that receives ExtensionAPI"). Notably, the sibling `herdr-agent-state.ts` works precisely because it uses `export default`.

## Fix

Emit `export default function (pi) { ... }` in `cbm_client_adapter_pi()` and pin the property in `client_adapter_pi_registers_every_registry_tool` so the named-only form cannot regress.

## Verification

- Reproduced the failure with pi's actual loader: named export -> `typeof result === "object"`; default export -> `typeof result === "function"`.
- Compiled the changed `client_adapter.c` in a minimal harness (stub registry) and confirmed the generated output:
  - contains `export default function (pi)`
  - no longer contains `export function register(pi)`
  - still registers every registry tool
- Loaded the generated module through pi's jiti loader: `typeof factory === "function"` OK

I was not able to run the full `make -f Makefile.cbm lint` / `make test` gate locally (no clang-format/clang-tidy/cppcheck in this environment; full test build is heavy). The change is confined to a string literal plus comments in the adapter, and the existing test that touches this code path was updated rather than rewritten.

## Affected users

Anyone who ran `codebase-memory-mcp install` with pi as a target client and then started pi: the generated extension fails to load (pi still boots — it logs the error and continues — but none of the codebase-memory tools are registered). A workaround is to edit `cbmem.ts` to use a default export.
