### PR TITLE
fix(cli): install into an existing opencode.jsonc instead of a second file (#1560)

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -2432,6 +2432,20 @@ static void cbm_opencode_config_path(const char *home_dir, char *out, size_t out
         snprintf(out, out_sz, "%s", custom);
         return;
     }
+    /* OpenCode reads either opencode.json or opencode.jsonc. We always wrote
+     * the .json name, so a user whose real config is .jsonc got a SECOND file
+     * that OpenCode ignores — their MCP server silently never appeared, and the
+     * install looked like it had succeeded (discussion #1560). Prefer whichever
+     * file already exists, .jsonc first since it is the one we used to miss;
+     * with neither present, create .json as before. Other clients in this file
+     * (pochi, kilo) already carry .jsonc paths — OpenCode was the gap. */
+    char candidate[CLI_BUF_1K];
+    int written = snprintf(candidate, sizeof(candidate), "%s/.config/opencode/opencode.jsonc",
+                           home_dir ? home_dir : "");
+    if (written > 0 && (size_t)written < sizeof(candidate) && cbm_file_exists(candidate)) {
+        snprintf(out, out_sz, "%s", candidate);
+        return;
+    }
     snprintf(out, out_sz, "%s/.config/opencode/opencode.json", home_dir);
 }
 

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -7349,6 +7349,40 @@ TEST(cli_opencode_honors_custom_config) {
     PASS();
 }
 
+/* Discussion #1560: OpenCode reads either opencode.json or opencode.jsonc, but
+ * we always wrote the .json name. A user whose real config is .jsonc got a
+ * SECOND file that OpenCode ignores — the MCP server silently never appeared
+ * while the install reported success. Prefer an existing .jsonc; with neither
+ * present, .json is still created, so fresh installs are unchanged. */
+TEST(cli_opencode_prefers_existing_jsonc_config_discussion1560) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-opencode-jsonc-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+    char config_dir[512];
+    snprintf(config_dir, sizeof(config_dir), "%s/.config/opencode", tmpdir);
+    test_mkdirp(config_dir);
+    char jsonc_path[640];
+    snprintf(jsonc_path, sizeof(jsonc_path), "%s/opencode.jsonc", config_dir);
+    write_test_file(jsonc_path, "{\n  // user's hand-written config\n  \"theme\": \"dark\"\n}\n");
+
+    char *saved_path = save_test_env("PATH");
+    char *saved_file = save_test_env("OPENCODE_CONFIG");
+    cbm_setenv("PATH", tmpdir, 1);
+    cbm_unsetenv("OPENCODE_CONFIG");
+
+    char *json = cbm_build_install_plan_json(tmpdir, "/usr/local/bin/codebase-memory-mcp");
+    bool targets_jsonc = json && strstr(json, "/.config/opencode/opencode.jsonc") != NULL;
+
+    free(json);
+    restore_test_env("PATH", saved_path);
+    restore_test_env("OPENCODE_CONFIG", saved_file);
+    test_rmdir_r(tmpdir);
+    if (!targets_jsonc)
+        FAIL("an existing opencode.jsonc must be the install target, not a new opencode.json");
+    PASS();
+}
+
 TEST(cli_opencode_config_dir_detects_without_retargeting_global_json) {
     char tmpdir[256];
     snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-opencode-dir-XXXXXX");
@@ -12416,6 +12450,7 @@ SUITE(cli) {
     RUN_TEST(cli_antigravity_does_not_imply_gemini);
     RUN_TEST(cli_antigravity_plan_uses_documented_global_files);
     RUN_TEST(cli_opencode_honors_custom_config);
+    RUN_TEST(cli_opencode_prefers_existing_jsonc_config_discussion1560);
     RUN_TEST(cli_opencode_config_dir_detects_without_retargeting_global_json);
     RUN_TEST(cli_kiro_and_hermes_homes_are_honored);
     RUN_TEST(cli_detect_agents_finds_official_kiro_cli_executable);


### PR DESCRIPTION
OpenCode reads either `opencode.json` **or** `opencode.jsonc`. We always wrote the `.json` name, so a user whose real config is `.jsonc` got a **second** config file that OpenCode ignores — the MCP server never appeared while the installer reported success. Silent, and indistinguishable from "the tool is broken".

Reported by @iandol in discussion #1560, who spotted that their config was `.jsonc` while the installer named `.json`.

**Change:** the install target is whichever file already exists, `.jsonc` first since that is the one we used to miss. With neither present, `.json` is created exactly as before — fresh installs are unchanged. Other clients in this file (pochi, kilo) already resolve `.jsonc` paths; OpenCode was the gap, not the exception.

**Verification:** `cli` suite 266 passed / 0 failed; revert-checked (the new test fails without the fix, passes with it); `lint-ci` green.

Targeted for **v0.10.3**.