### PR TITLE
fix(subprocess): back off exponentially when the kernel says "try again"

### DIFF
--- a/src/foundation/subprocess.c
+++ b/src/foundation/subprocess.c
@@ -885,21 +885,75 @@ static cbm_proc_poll_t cbm_subprocess_poll_win(cbm_subprocess_t *process, cbm_pr
 /* Transient spawn-failure retry (see the EAGAIN note in cbm_posix_spawn_apple).
  * Three attempts over ~30ms total: long enough to ride out a burst of process
  * creation, short enough that a genuinely exhausted system still fails fast. */
-enum { CBM_SPAWN_RETRY = 2, CBM_SPAWN_RETRY_ATTEMPTS = 3 };
-static const struct timespec CBM_SPAWN_RETRY_DELAY = {0, 10L * 1000L * 1000L};
-#define CBM_SPAWN_RETRY_DELAY_NS (&CBM_SPAWN_RETRY_DELAY)
+enum { CBM_SPAWN_RETRY = 2, CBM_SPAWN_RETRY_ATTEMPTS = 6 };
+
+/* Exponential backoff: 10, 20, 40, 80, 160, 320ms — ~630ms of total patience.
+ *
+ * The first version waited a flat 3 x 10ms, which was enough for a momentary
+ * dip and NOT enough for the real thing: a CI runner building and testing in
+ * parallel stays process-starved for hundreds of milliseconds at a stretch, and
+ * `subprocess_run_spawn_failure` kept failing with the retry shipped (macos-15-
+ * intel on a release matrix, macos-14 under ThreadSanitizer, which is itself
+ * slow enough to create the pressure). A fixed short delay samples the same
+ * congested instant repeatedly; doubling walks out of it.
+ *
+ * The ceiling is deliberate. ~0.6s is invisible next to spawning a process that
+ * does real work, and a machine still refusing after that is genuinely out of
+ * capacity — at which point failing IS the correct answer, and failing fast
+ * beats hanging. */
+#ifdef CBM_ENABLE_TEST_SEAMS
+/* Deterministic EAGAIN injection: see the header. Counts DOWN, so a test asks
+ * for N simulated refusals and the (N+1)th attempt proceeds for real. */
+static int g_force_spawn_eagain = 0;
+void cbm_subprocess_force_spawn_eagain_for_testing(int attempts) {
+    g_force_spawn_eagain = attempts > 0 ? attempts : 0;
+}
+int cbm_subprocess_pending_spawn_eagain_for_testing(void) {
+    return g_force_spawn_eagain;
+}
+static bool cbm_spawn_eagain_injected(void) {
+    if (g_force_spawn_eagain > 0) {
+        g_force_spawn_eagain--;
+        return true;
+    }
+    return false;
+}
+#endif
+
+static void cbm_spawn_backoff(int attempt) {
+    long ms = 10L << (attempt < 6 ? attempt : 6);
+    struct timespec delay = {ms / 1000L, (ms % 1000L) * 1000L * 1000L};
+    (void)cbm_nanosleep(&delay, NULL);
+}
 
 /* fork() fails with EAGAIN under the same pressure posix_spawn does, and the
  * fallback path must not be less robust than the primary one. */
 static pid_t cbm_fork_with_retry(void) {
-    for (int attempt = 0; attempt < CBM_SPAWN_RETRY_ATTEMPTS; attempt++) {
+    /* CBM_SPAWN_RETRY_ATTEMPTS backoffs means ATTEMPTS+1 tries. Every try goes
+     * through the same branch — including the last — so the injection seam
+     * models production exactly rather than leaving a final unguarded fork() the
+     * tests could never reach. */
+    for (int attempt = 0;; attempt++) {
+#ifdef CBM_ENABLE_TEST_SEAMS
+        if (cbm_spawn_eagain_injected()) {
+            if (attempt >= CBM_SPAWN_RETRY_ATTEMPTS) {
+                errno = EAGAIN;
+                return -1;
+            }
+            cbm_spawn_backoff(attempt);
+            continue;
+        }
+#endif
         pid_t pid = fork();
         if (pid >= 0 || (errno != EAGAIN && errno != ENOMEM)) {
             return pid;
         }
-        (void)cbm_nanosleep(CBM_SPAWN_RETRY_DELAY_NS, NULL);
+        if (attempt >= CBM_SPAWN_RETRY_ATTEMPTS) {
+            errno = EAGAIN;
+            return -1;
+        }
+        cbm_spawn_backoff(attempt);
     }
-    return fork();
 }
 
 /* Used by the fork+exec child. posix_spawn performs the same reset
@@ -989,6 +1043,14 @@ static int cbm_posix_fd_at_least_three(int fd) {
  *     because dup2 clears close-on-exec.
  * posix_spawnp keeps execvp's PATH semantics for a bare tool name. */
 static int cbm_posix_spawn_apple(cbm_subprocess_t *process, int input, int output, pid_t *pid_out) {
+    /* posix_spawn is the PRIMARY path on macOS; fork+exec is only the
+     * exec-class fallback. Injection therefore has to live here too, or a test
+     * on macOS exercises nothing. */
+#ifdef CBM_ENABLE_TEST_SEAMS
+    if (cbm_spawn_eagain_injected()) {
+        return CBM_SPAWN_RETRY;
+    }
+#endif
     posix_spawn_file_actions_t actions;
     posix_spawnattr_t attr;
     if (posix_spawn_file_actions_init(&actions) != 0) {
@@ -1089,7 +1151,7 @@ static int cbm_subprocess_spawn_posix(cbm_subprocess_t *process) {
     int spawn_rc = cbm_posix_spawn_apple(process, input, output, &pid);
     for (int attempt = 0; spawn_rc == CBM_SPAWN_RETRY && attempt < CBM_SPAWN_RETRY_ATTEMPTS;
          attempt++) {
-        (void)cbm_nanosleep(CBM_SPAWN_RETRY_DELAY_NS, NULL);
+        cbm_spawn_backoff(attempt);
         spawn_rc = cbm_posix_spawn_apple(process, input, output, &pid);
     }
     if (spawn_rc == CBM_SPAWN_RETRY) {

--- a/src/foundation/subprocess.h
+++ b/src/foundation/subprocess.h
@@ -177,4 +177,12 @@ bool cbm_build_win_cmdline(char *buf, size_t cap, const char *const *argv);
 bool cbm_build_win_cmd_payload(char *buf, size_t cap, const char *cmd_executable,
                                const char *payload);
 
+#ifdef CBM_ENABLE_TEST_SEAMS
+/* Force the next N spawn attempts to behave as if the kernel returned EAGAIN
+ * ("try again"), so the retry path can be exercised deterministically instead
+ * of hoping a loaded machine reproduces it. Test builds only. */
+void cbm_subprocess_force_spawn_eagain_for_testing(int attempts);
+int cbm_subprocess_pending_spawn_eagain_for_testing(void);
+#endif
+
 #endif /* CBM_SUBPROCESS_H */

--- a/tests/test_subprocess.c
+++ b/tests/test_subprocess.c
@@ -169,6 +169,45 @@ TEST(subprocess_run_hang_is_hang) {
 }
 
 /* A spawn of a non-existent binary fails cleanly (no child), not a crash. */
+/* The kernel refusing a spawn with EAGAIN means "not right now", not "never" —
+ * a momentarily full process table on a busy machine. We used to treat it as a
+ * permanent failure, so a git probe or LSP server refused to start for a reason
+ * the user could neither see nor act on, and `subprocess_run_spawn_failure`
+ * failed on loaded CI runners with the contract intact.
+ *
+ * These pin the retry itself rather than the constant. Injecting refusals is
+ * deterministic, so this proves the loop retries on EVERY machine instead of
+ * only on one that happens to be starved. */
+TEST(subprocess_retries_transient_spawn_refusal) {
+#ifdef _WIN32
+    SKIP_PLATFORM("POSIX fork/EAGAIN path");
+#else
+    /* Fewer refusals than the budget: the spawn must still succeed. */
+    cbm_subprocess_force_spawn_eagain_for_testing(3);
+    cbm_proc_result_t r = run_sh("exit 0", 0);
+    ASSERT_EQ(cbm_subprocess_pending_spawn_eagain_for_testing(), 0);
+    ASSERT_EQ(r.outcome, CBM_PROC_CLEAN);
+    ASSERT_EQ(r.exit_code, 0);
+    PASS();
+#endif
+}
+
+TEST(subprocess_gives_up_after_the_retry_budget) {
+#ifdef _WIN32
+    SKIP_PLATFORM("POSIX fork/EAGAIN path");
+#else
+    /* More refusals than the budget: it must fail rather than retry forever.
+     * A machine still refusing after ~0.6s is genuinely out of capacity, and
+     * failing fast beats hanging. */
+    cbm_subprocess_force_spawn_eagain_for_testing(50);
+    cbm_proc_result_t r = run_sh("exit 0", 0);
+    bool refused = r.outcome == CBM_PROC_SPAWN_FAILED;
+    cbm_subprocess_force_spawn_eagain_for_testing(0); /* never leak into later tests */
+    ASSERT_TRUE(refused);
+    PASS();
+#endif
+}
+
 TEST(subprocess_run_spawn_failure) {
 #ifdef _WIN32
     SKIP_PLATFORM("POSIX exec semantics");
@@ -993,6 +1032,8 @@ SUITE(subprocess) {
     RUN_TEST(subprocess_run_resolves_literal_binary_name_from_path);
     RUN_TEST(subprocess_run_crash_is_crash);
     RUN_TEST(subprocess_run_hang_is_hang);
+    RUN_TEST(subprocess_retries_transient_spawn_refusal);
+    RUN_TEST(subprocess_gives_up_after_the_retry_budget);
     RUN_TEST(subprocess_run_spawn_failure);
     RUN_TEST(subprocess_run_null_bin_rejected);
     RUN_TEST(subprocess_spawn_returns_while_child_is_running);


### PR DESCRIPTION
The EAGAIN retry shipped in v0.10.3 is **too small to matter**: a flat 3 × 10ms covers a momentary dip, not a CI runner that stays process-starved for hundreds of milliseconds while building and testing in parallel.

`subprocess_run_spawn_failure` kept failing **with the retry in place** — macos-15-intel on the release matrix, then macos-14 under ThreadSanitizer **twice on the same SHA**, which is what moves it out of the flake bucket. A fixed short delay samples the same congested instant repeatedly; doubling walks out of it. This is currently blocking the v0.10.3 release.

**Now:** 10/20/40/80/160/320ms, ~0.6s total. Invisible next to spawning a process that does real work, and a machine still refusing after that is genuinely out of capacity — where failing fast beats hanging.

**The part the last attempt was missing:** a way to prove it works. `CBM_ENABLE_TEST_SEAMS` builds can force N simulated refusals, and two tests pin it deterministically — under budget must still spawn, over budget must fail rather than retry forever. Both revert-checked. The seam compiles out of production entirely (cppcheck correctly flagged the always-false branch as dead code, so it is removed rather than suppressed).

**Two defects the tests caught that review had not:**
- macOS spawns via `posix_spawn`, not `fork` — injecting only into the fork fallback exercised *nothing* on macOS.
- `cbm_fork_with_retry` ended with an unconditional `fork()` outside the loop, so its final attempt was unreachable from any test.

Verified: subprocess 31/31, cli 266/266, `lint-ci` green.