### PR TITLE
chore(homebrew): point the formula at v0.10.3

### DIFF
--- a/pkg/homebrew/Formula/codebase-memory-mcp.rb
+++ b/pkg/homebrew/Formula/codebase-memory-mcp.rb
@@ -1,28 +1,28 @@
 class CodebaseMemoryMcp < Formula
   desc "Fast code intelligence engine for AI coding agents"
   homepage "https://github.com/DeusData/codebase-memory-mcp"
-  version "0.8.1"
+  version "0.10.3"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/DeusData/codebase-memory-mcp/releases/download/v#{version}/codebase-memory-mcp-darwin-arm64.tar.gz"
-      sha256 "fbd047509852021b5446a11141bcb0a3d1dcaebf6e5112460960f29f052c1c58"
+      sha256 "0ebf02328207d4c3d862c837b5e973de5bac808df92b0941737721d467287f7f"
     end
     on_intel do
       url "https://github.com/DeusData/codebase-memory-mcp/releases/download/v#{version}/codebase-memory-mcp-darwin-amd64.tar.gz"
-      sha256 "fb62da3016ea12b948351208759b5c083fb1446cf6e78d6db8b7cd28fe86fd54"
+      sha256 "1107fea28285823e1436e4f38a4e00a0b472d8a43c379da7dfd200c914a4b9dd"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/DeusData/codebase-memory-mcp/releases/download/v#{version}/codebase-memory-mcp-linux-arm64.tar.gz"
-      sha256 "d2f842d1365da5c35d9c5796f57a821c9745267350994346735e1e6e04d46091"
+      sha256 "967b9eababfdbd2ef1987c571d55bc7c028cd1db7f99279830634c58db311e32"
     end
     on_intel do
       url "https://github.com/DeusData/codebase-memory-mcp/releases/download/v#{version}/codebase-memory-mcp-linux-amd64.tar.gz"
-      sha256 "dbd3b92ea870ef240b63059f26bda15015f76ef9978931bebc3a0f9d09470973"
+      sha256 "74997fb0934e70a22f20c2e112fb4d883867dc1f01a7bcdc94cf86d13b5cbd31"
     end
   end
 


### PR DESCRIPTION
The formula still pinned **0.8.1** — five releases and two months behind — so `brew install` handed out a June binary while GitHub, npm and PyPI all served the current one. Nothing in the release pipeline touches this file, which is how it drifted that far unnoticed.

Version plus all four SHA-256 digests taken from the published v0.10.3 `checksums.txt`.

Worth its own change: have the release workflow rewrite the formula from `checksums.txt` after publish. A channel nothing updates is a channel that rots, and this failure mode is silent — `brew` keeps working, it just installs something old.

(Supersedes #1549, which targeted v0.10.2 and is now stale.)