### PR TITLE
ci(release): pin and verify the mcp-publisher download on every platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -459,9 +459,22 @@ jobs:
           scripts/ci/gen-mcpb-registry-entries.sh server.json checksums.txt "$RELEASE_VERSION"
           cat server.json
 
+      # Pinned by version AND content hash: `latest` would let an upstream
+      # release (or a compromised one) change what runs in the job that holds
+      # the registry publish credential, and piping curl straight into tar
+      # executes the payload before anything can verify it. The job is
+      # ubuntu-latest, so the linux/amd64 asset is the only one needed.
+      # Checksum from registry_1.8.1_checksums.txt of the same release.
       - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.1
+          MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
         run: |
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          asset="mcp-publisher_linux_amd64.tar.gz"
+          curl -fsSLo "$asset" \
+            "https://github.com/modelcontextprotocol/registry/releases/download/$MCP_PUBLISHER_VERSION/$asset"
+          echo "$MCP_PUBLISHER_SHA256  $asset" | sha256sum -c -
+          tar xzf "$asset" mcp-publisher
 
       - name: Authenticate to MCP Registry (GitHub OIDC)
         run: ./mcp-publisher login github-oidc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -462,18 +462,32 @@ jobs:
       # Pinned by version AND content hash: `latest` would let an upstream
       # release (or a compromised one) change what runs in the job that holds
       # the registry publish credential, and piping curl straight into tar
-      # executes the payload before anything can verify it. The job is
-      # ubuntu-latest, so the linux/amd64 asset is the only one needed.
-      # Checksum from registry_1.8.1_checksums.txt of the same release.
+      # executes the payload before anything can verify it.
+      #
+      # One pin covers every platform. Upstream ships a checksums file for the
+      # whole release, so we pin that file's own SHA-256 and verify whichever
+      # asset this runner needs against it. Moving the job to a different OS or
+      # architecture therefore needs no change here, and an unlisted asset
+      # fails closed rather than installing unverified.
       - name: Install mcp-publisher
         env:
           MCP_PUBLISHER_VERSION: v1.8.1
-          MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
+          MCP_PUBLISHER_CHECKSUMS_SHA256: f7937a7908096f63147658e13f0f63a393a1c9fc722a2d10017593940d36e59e
         run: |
-          asset="mcp-publisher_linux_amd64.tar.gz"
-          curl -fsSLo "$asset" \
-            "https://github.com/modelcontextprotocol/registry/releases/download/$MCP_PUBLISHER_VERSION/$asset"
-          echo "$MCP_PUBLISHER_SHA256  $asset" | sha256sum -c -
+          base="https://github.com/modelcontextprotocol/registry/releases/download/$MCP_PUBLISHER_VERSION"
+          sums="registry_${MCP_PUBLISHER_VERSION#v}_checksums.txt"
+          asset="mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz"
+
+          curl -fsSLo "$sums" "$base/$sums"
+          echo "$MCP_PUBLISHER_CHECKSUMS_SHA256  $sums" | sha256sum -c -
+
+          curl -fsSLo "$asset" "$base/$asset"
+          # Exact filename match: a substring match would also accept the
+          # .sbom.json / .sigstore.json lines for the same asset.
+          awk -v a="$asset" '$2 == a' "$sums" > expected.sha256
+          test -s expected.sha256 || { echo "no checksum listed for $asset" >&2; exit 1; }
+          sha256sum -c expected.sha256
+
           tar xzf "$asset" mcp-publisher
 
       - name: Authenticate to MCP Registry (GitHub OIDC)


### PR DESCRIPTION
## What

The `publish-mcp-registry` job installed `mcp-publisher` like this:

```bash
curl -fsSL ".../releases/latest/download/mcp-publisher_$(uname -s ...)_$(uname -m ...).tar.gz" | tar xz mcp-publisher
```

Two problems, in the one job that holds the MCP Registry publish credential:

1. **`latest` is unpinned.** Whatever upstream publishes at the moment the job runs is what executes. A new upstream release — or a compromised one — silently changes our publishing step with no diff on our side.
2. **`curl | tar` executes before verification.** The payload is unpacked as it streams; there is no point at which we could check it.

## Change

Pin the version, verify, *then* extract — without giving up platform independence:

```bash
base="https://github.com/modelcontextprotocol/registry/releases/download/$MCP_PUBLISHER_VERSION"
sums="registry_${MCP_PUBLISHER_VERSION#v}_checksums.txt"
asset="mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz"

curl -fsSLo "$sums" "$base/$sums"
echo "$MCP_PUBLISHER_CHECKSUMS_SHA256  $sums" | sha256sum -c -

curl -fsSLo "$asset" "$base/$asset"
awk -v a="$asset" '$2 == a' "$sums" > expected.sha256
test -s expected.sha256 || { echo "no checksum listed for $asset" >&2; exit 1; }
sha256sum -c expected.sha256

tar xzf "$asset" mcp-publisher
```

**One pinned value covers every platform.** Rather than pinning a hash per asset, we pin the SHA-256 of the release's *own checksums file*, then verify whichever asset the runner selects against it. Upstream publishes that file for the whole release — linux, darwin and windows, on both amd64 and arm64 — so the existing `uname`-based selection keeps working and moving this job to another runner needs no change here. Bumping the version stays a one-line change.

Two details worth calling out:

- **Exact filename match.** A substring match would also accept the `.sbom.json` and `.sigstore.json` lines for the same asset, so the lookup compares the whole field.
- **Fails closed.** An asset absent from the checksums file aborts the step instead of installing unverified.

## Verification

Ran the step verbatim against the pinned release:

| Check | Result |
|---|---|
| Checksums file matches its pinned hash | ✅ `registry_1.8.1_checksums.txt: OK` |
| Asset selection resolves to a **listed** asset | ✅ linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 |
| linux/amd64 asset verifies | ✅ `mcp-publisher_linux_amd64.tar.gz: OK` |
| Extracts a usable binary | ✅ statically linked x86-64 ELF |
| **Tampered asset is rejected** | ✅ appending one byte → `FAILED`, step exits non-zero |
| Workflow YAML parses, step count unchanged | ✅ |

The tamper test is the one that matters: it shows the gate actually binds rather than passing vacuously.

## Notes

Found by @ahundt while reviewing our release path in #1245, and credited as co-author. Extracted here as a standalone change so it can land on its own merits.