### PR TITLE
fix(subprocess+tsan): widen the spawn-retry window where it was silently disabled

### DIFF
--- a/Makefile.cbm
+++ b/Makefile.cbm
@@ -105,9 +105,15 @@ CXXFLAGS_TEST = $(CXXFLAGS_COMMON) $(SANITIZED_DEFINE) -g -O1 $(SANITIZE) $(CXX_
 
 # TSan (can't combine with ASan)
 TSAN_SANITIZE = -fsanitize=thread -fno-omit-frame-pointer
+# CBM_SANITIZED_BUILD is unconditional here: this flag set exists only to build
+# an instrumented binary. SANITIZED_DEFINE keys off $(SANITIZE), which TSan does
+# not use (it has its own TSAN_SANITIZE), so the define was silently absent and
+# every sanitized-budget branch compiled to its NATIVE value on this leg —
+# exactly the failure the comment above SANITIZED_DEFINE describes for
+# trap-UBSan, repeated on a leg that was never wired up.
 CFLAGS_TSAN = $(CFLAGS_COMMON) $(EDITOR_TEST_DEFINES) $(KOTLIN_DEDUP_TEST_DEFINE) \
 	$(CALL_REFERENCE_LOOKUP_TEST_DEFINE) $(INCREMENTAL_TEST_DEFINE) \
-	-g -O1 $(TSAN_SANITIZE)
+	-DCBM_SANITIZED_BUILD=1 -g -O1 $(TSAN_SANITIZE)
 CXXFLAGS_TSAN = $(CXXFLAGS_COMMON) -g -O1 \
                 $(TSAN_SANITIZE)
 

--- a/src/foundation/subprocess.c
+++ b/src/foundation/subprocess.c
@@ -882,10 +882,12 @@ static cbm_proc_poll_t cbm_subprocess_poll_win(cbm_subprocess_t *process, cbm_pr
 
 #else /* POSIX */
 
-/* Transient spawn-failure retry (see the EAGAIN note in cbm_posix_spawn_apple).
- * Three attempts over ~30ms total: long enough to ride out a burst of process
- * creation, short enough that a genuinely exhausted system still fails fast. */
-/* A sanitized build needs a wider window than an ordinary one, and only a
+/* Transient spawn-failure retry (see the EAGAIN note in cbm_posix_spawn_apple):
+ * long enough to ride out a burst of process creation, short enough that a
+ * genuinely exhausted system still fails fast. The budget below is the single
+ * source of truth for both — see cbm_spawn_backoff for the resulting waits.
+ *
+ * A sanitized build needs a wider window than an ordinary one, and only a
  * sanitized one does.
  *
  * The exponential backoff (10/20/40/80/160/320ms, ~0.6s) fixed the ordinary
@@ -907,7 +909,11 @@ enum { CBM_SPAWN_RETRY = 2, CBM_SPAWN_RETRY_ATTEMPTS = 9 };
 enum { CBM_SPAWN_RETRY = 2, CBM_SPAWN_RETRY_ATTEMPTS = 6 };
 #endif
 
-/* Exponential backoff: 10, 20, 40, 80, 160, 320ms — ~630ms of total patience.
+/* Exponential backoff, doubling from 10ms: 10, 20, 40, 80, 160, 320 — ~630ms of
+ * total patience on an ordinary build, and three further doublings (640, 1280,
+ * 2560) to roughly 5s on a sanitized one. The waits follow from
+ * CBM_SPAWN_RETRY_ATTEMPTS above rather than being listed separately here, so
+ * changing the budget cannot leave this description behind.
  *
  * The first version waited a flat 3 x 10ms, which was enough for a momentary
  * dip and NOT enough for the real thing: a CI runner building and testing in
@@ -920,7 +926,9 @@ enum { CBM_SPAWN_RETRY = 2, CBM_SPAWN_RETRY_ATTEMPTS = 6 };
  * The ceiling is deliberate. ~0.6s is invisible next to spawning a process that
  * does real work, and a machine still refusing after that is genuinely out of
  * capacity — at which point failing IS the correct answer, and failing fast
- * beats hanging. */
+ * beats hanging. The sanitized ceiling is ~5s for the same reason in reverse:
+ * under instrumentation the starved window really does last that long, and only
+ * a build that already accepts a large slowdown pays for the extra wait. */
 #ifdef CBM_ENABLE_TEST_SEAMS
 /* Deterministic EAGAIN injection: see the header. Counts DOWN, so a test asks
  * for N simulated refusals and the (N+1)th attempt proceeds for real. */

--- a/src/foundation/subprocess.c
+++ b/src/foundation/subprocess.c
@@ -885,7 +885,27 @@ static cbm_proc_poll_t cbm_subprocess_poll_win(cbm_subprocess_t *process, cbm_pr
 /* Transient spawn-failure retry (see the EAGAIN note in cbm_posix_spawn_apple).
  * Three attempts over ~30ms total: long enough to ride out a burst of process
  * creation, short enough that a genuinely exhausted system still fails fast. */
+/* A sanitized build needs a wider window than an ordinary one, and only a
+ * sanitized one does.
+ *
+ * The exponential backoff (10/20/40/80/160/320ms, ~0.6s) fixed the ordinary
+ * case. `subprocess_run_spawn_failure` then kept failing on `test-tsan` — twice
+ * on one SHA, on a PR whose diff was a shell contract and a line in test.sh, so
+ * causation was impossible. ThreadSanitizer runs several times slower and holds
+ * far more process state, so the pressure window it creates is simply longer
+ * than 0.6s.
+ *
+ * Raising the budget for everyone would be the wrong fix: an unsanitized
+ * machine that is genuinely out of capacity should still fail fast rather than
+ * hang for seconds. So the extra patience is scoped to the builds that need it,
+ * the same way the daemon announce backstop is (test_daemon_frontend.c). Three
+ * more doublings take the sanitized ceiling to roughly 5s. */
+#if defined(CBM_SANITIZED_BUILD) || defined(__SANITIZE_ADDRESS__) || \
+    defined(__SANITIZE_MEMORY__) || defined(__SANITIZE_THREAD__)
+enum { CBM_SPAWN_RETRY = 2, CBM_SPAWN_RETRY_ATTEMPTS = 9 };
+#else
 enum { CBM_SPAWN_RETRY = 2, CBM_SPAWN_RETRY_ATTEMPTS = 6 };
+#endif
 
 /* Exponential backoff: 10, 20, 40, 80, 160, 320ms — ~630ms of total patience.
  *
@@ -921,7 +941,12 @@ static bool cbm_spawn_eagain_injected(void) {
 #endif
 
 static void cbm_spawn_backoff(int attempt) {
-    long ms = 10L << (attempt < 6 ? attempt : 6);
+    /* Cap the shift at the budget, not at a constant: with the sanitized budget
+     * of 9 a hard-coded 6 would flatten the last three waits to 320ms each
+     * instead of continuing to double. The budget is the only bound needed —
+     * callers never exceed it, and a second clamp would be dead code. */
+    int shift = attempt < CBM_SPAWN_RETRY_ATTEMPTS ? attempt : CBM_SPAWN_RETRY_ATTEMPTS;
+    long ms = 10L << shift;
     struct timespec delay = {ms / 1000L, (ms % 1000L) * 1000L * 1000L};
     (void)cbm_nanosleep(&delay, NULL);
 }


### PR DESCRIPTION
Two commits, and the second is why the first appeared not to work.

**1. Wider spawn-retry budget for sanitized builds.** The exponential backoff shipped in v0.10.3 (~0.6s) fixed the ordinary case, but `subprocess_run_spawn_failure` kept failing under ThreadSanitizer, which runs several times slower and holds far more process state. Raising the budget for everyone would be wrong — an unsanitized machine genuinely out of capacity should fail fast — so the extra patience is scoped to sanitized builds (~5s).

**2. …except `CBM_SANITIZED_BUILD` was never defined on the TSan leg**, so commit 1 did nothing there. It failed again on the very PR meant to fix it.

`SANITIZED_DEFINE` keys off `$(SANITIZE)`. TSan does not use that variable — it has its own `TSAN_SANITIZE` — and `CFLAGS_TSAN` never included `SANITIZED_DEFINE`. So the macro was undefined and every sanitized-budget branch compiled to its **native** value while running an instrumented binary.

The comment above `SANITIZED_DEFINE` already describes this precise failure for trap-UBSan: *"the build system is the single source of truth for is this binary instrumented; compiler-specific probes miss clang's feature-check spelling and every non-ASan sanitizer."* The lesson was recorded; the TSan leg was simply never wired up to it. And compiler probes would not have rescued it either — clang spells this `__has_feature(thread_sanitizer)`, not `__SANITIZE_THREAD__`.

**Checked the neighbours:** MSan (`scripts/msan.sh` passes `SANITIZE=`) and the diag lane (same) already get the define. TSan was the only gap — but while it existed, *any* sanitized-budget logic was silently inert there, including the daemon announce backstop.

**How this was verified.** TSan does not run in PR CI — it lives in `_test.yml`, which only the
dry-run and release workflows call — so these checks cannot prove the fix. The build configuration
proves it directly instead:

```
# pre-fix tree (a92b6be9)
$ make -f Makefile.cbm test-tsan -n | grep -c 'DCBM_SANITIZED_BUILD=1'   -> 0
$ make -f Makefile.cbm test-tsan -n | grep -c 'sanitize=thread'          -> 169

# this branch
$ make -f Makefile.cbm test-tsan -n | grep -c 'DCBM_SANITIZED_BUILD=1'   -> present
$ make -f Makefile.cbm test-tsan -n | grep -c 'sanitize=thread'          -> 169
```

169 thread-instrumented compile lines and not one of them carried the define. That is the whole
bug, and it is gone. The end-to-end confirmation is the TSan leg of the dry-run/release run.
