### PR TITLE
test(cli): neutralize ambient client home overrides in the C runner

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -54,8 +54,7 @@ static bool tf_invoked_as_windows_git_module(void) {
      * Inspect the actual loaded module so the copied git.exe probe cannot fall
      * through into the ordinary test runner when argv[0] is merely "git". */
     wchar_t image[32768];
-    DWORD image_length =
-        GetModuleFileNameW(NULL, image, (DWORD)(sizeof(image) / sizeof(image[0])));
+    DWORD image_length = GetModuleFileNameW(NULL, image, (DWORD)(sizeof(image) / sizeof(image[0])));
     if (image_length == 0 || image_length >= (DWORD)(sizeof(image) / sizeof(image[0]))) {
         return false;
     }
@@ -86,8 +85,7 @@ static bool tf_invoked_as_blocking_git(const char *argv0) {
             base = cursor + 1;
         }
     }
-    return strcmp(base, "git") == 0 || strcmp(base, "git.exe") == 0 ||
-           strcmp(base, "GIT.EXE") == 0;
+    return strcmp(base, "git") == 0 || strcmp(base, "git.exe") == 0 || strcmp(base, "GIT.EXE") == 0;
 #endif
 }
 
@@ -165,6 +163,38 @@ static void tf_cleanup_cache_sentinel(void) {
     }
 }
 
+/* Client home overrides the CLI honours BEFORE $HOME, so redirecting HOME alone
+ * does not isolate them: cbm_codex_config_dir() and its siblings return the
+ * ambient path and the suite resolves against the developer's real config —
+ * reading its state and writing to it. Same inventory the shell fixtures are
+ * already required to neutralize (tests/test_smoke_fixture_contract.sh), kept
+ * in one place so a new client cannot be isolated in the smoke scripts and
+ * forgotten here. A test that exercises one of these sets it after setup. */
+static const char *const tf_client_home_overrides[] = {
+    "CLAUDE_CONFIG_DIR",
+    "CODEX_HOME",
+    "KIRO_HOME",
+    "HERMES_HOME",
+    "QWEN_HOME",
+    "CLINE_DATA_DIR",
+    "OPENCLAW_HOME",
+    "OPENCLAW_STATE_DIR",
+    "OPENCLAW_PROFILE",
+    "OPENCLAW_CONFIG_PATH",
+    "OPENCLAW_WORKSPACE_DIR",
+    "OPENCODE_CONFIG",
+    "OPENCODE_CONFIG_DIR",
+    "COPILOT_HOME",
+    "CRUSH_GLOBAL_CONFIG",
+    "VIBE_HOME",
+    "GLAB_CONFIG_DIR",
+    "KIMI_CODE_HOME",
+    "CBM_CONTINUE_CONFIG_PATH",
+    "CBM_TRAE_CONFIG_PATH",
+    "CBM_ROO_CONFIG_PATH",
+    "CBM_CODY_CONFIG_PATH",
+};
+
 static bool tf_setup_cache_sentinel(void) {
     snprintf(tf_home_sentinel, sizeof(tf_home_sentinel), "/tmp/cbm-test-home-XXXXXX");
     if (!cbm_mkdtemp(tf_home_sentinel)) {
@@ -175,6 +205,10 @@ static bool tf_setup_cache_sentinel(void) {
      * override keeps both conventions pointed at the same isolated tree. */
     cbm_setenv("HOME", tf_home_sentinel, 1);
     cbm_unsetenv("CBM_CACHE_DIR");
+    for (size_t i = 0U; i < sizeof(tf_client_home_overrides) / sizeof(tf_client_home_overrides[0]);
+         i++) {
+        cbm_unsetenv(tf_client_home_overrides[i]);
+    }
     atexit(tf_cleanup_cache_sentinel);
     return true;
 }

--- a/tests/test_smoke_fixture_contract.sh
+++ b/tests/test_smoke_fixture_contract.sh
@@ -69,6 +69,44 @@ require(
     "smoke-local.sh must not reserve/release a port or launch a separate http.server",
 )
 
+# Every environment variable the CLI honours ahead of $HOME. A fixture that
+# redirects only HOME still resolves these to the developer's real config, so
+# both the shell fixtures and the C runner must neutralize the whole set.
+CLIENT_HOME_OVERRIDES = (
+    "CLAUDE_CONFIG_DIR",
+    "CODEX_HOME",
+    "KIRO_HOME",
+    "HERMES_HOME",
+    "QWEN_HOME",
+    "CLINE_DATA_DIR",
+    "OPENCLAW_HOME",
+    "OPENCLAW_STATE_DIR",
+    "OPENCLAW_PROFILE",
+    "OPENCLAW_CONFIG_PATH",
+    "OPENCLAW_WORKSPACE_DIR",
+    "OPENCODE_CONFIG",
+    "OPENCODE_CONFIG_DIR",
+    "COPILOT_HOME",
+    "CRUSH_GLOBAL_CONFIG",
+    "VIBE_HOME",
+    "GLAB_CONFIG_DIR",
+    "KIMI_CODE_HOME",
+    "CBM_CONTINUE_CONFIG_PATH",
+    "CBM_TRAE_CONFIG_PATH",
+    "CBM_ROO_CONFIG_PATH",
+    "CBM_CODY_CONFIG_PATH",
+)
+
+# The C suite exercises the same install/uninstall paths as the shell fixtures,
+# so it needs the same neutralization — otherwise a green run on a developer
+# machine only proves the ambient config happened to be writable.
+test_main = read("tests/test_main.c")
+for variable in CLIENT_HOME_OVERRIDES:
+    require(
+        f'"{variable}"' in test_main,
+        f"tests/test_main.c must neutralize ambient {variable}",
+    )
+
 for relative, source in (
     ("scripts/smoke-local.sh", smoke_local),
     ("test-infrastructure/vm/vm-smoke.sh", vm_smoke),
@@ -89,31 +127,7 @@ for relative, source in (
         'wait "$SERVER_PID"' in source,
         f"{relative} cleanup must reap the fixture-server process",
     )
-    for variable in (
-        "CLAUDE_CONFIG_DIR",
-        "CODEX_HOME",
-        "KIRO_HOME",
-        "HERMES_HOME",
-        "QWEN_HOME",
-        "CLINE_DATA_DIR",
-        "OPENCLAW_HOME",
-        "OPENCLAW_STATE_DIR",
-        "OPENCLAW_PROFILE",
-        "OPENCLAW_CONFIG_PATH",
-        "OPENCLAW_WORKSPACE_DIR",
-        "OPENCODE_CONFIG",
-        "OPENCODE_CONFIG_DIR",
-        "COPILOT_HOME",
-        "CRUSH_GLOBAL_CONFIG",
-        "VIBE_HOME",
-        "GLAB_CONFIG_DIR",
-        "KIMI_CODE_HOME",
-        "CBM_CONTINUE_CONFIG_PATH",
-        "CBM_TRAE_CONFIG_PATH",
-        "CBM_ROO_CONFIG_PATH",
-        "CBM_CODY_CONFIG_PATH",
-        "CBM_TEST_WINDOWS_USER_PATH_RUN_ID",
-    ):
+    for variable in CLIENT_HOME_OVERRIDES + ("CBM_TEST_WINDOWS_USER_PATH_RUN_ID",):
         require(
             f"-u {variable}" in source,
             f"{relative} must neutralize ambient {variable}",


### PR DESCRIPTION
## Problem

The CLI resolves each client's config home from that client's own environment variable **before** falling back to `$HOME`. `cbm_codex_config_dir()` (`src/cli/cli.c:2211`) returns `$CODEX_HOME` and ignores the `home_dir` it is handed; the same holds for `CLAUDE_CONFIG_DIR`, `OPENCODE_CONFIG_DIR`, `COPILOT_HOME` and the rest.

A test that redirects only `HOME` therefore does **not** isolate those clients. On any machine with `$CODEX_HOME` exported — every Codex user, and every Orca user, whose runtime home is exported into the shell — the `cli` suite resolves, reads and *writes* the developer's real configuration.

On this machine that is 27 failures out of 269, and none of them is a defect in the behaviour under test:

```
$ build/c/test-runner cli
  241 passed, 28 failed          # 27 unique assertions
```

Each failure is an `rc` assertion. The CLI was reporting real failures — against the ambient config, not the fixture:

- an unbalanced managed marker left in the real `config.toml` → `toml_find_markers` is fail-closed (`src/cli/config_toml_edit.c:857`)
- an `AGENTS.md` that is a symlink → refused by the `O_NOFOLLOW` writer (`src/cli/config_text_edit.c:441`)
- user-modified agent profiles → correctly preserved, and preservation is counted as an install error by design

Every content assertion in those tests passed. One test prints its own diagnostic, which makes the shape obvious:

```
VS Code durable diag install_rc=-1 hook=1 skill=1 agent=1 mcp_absent=1
  instructions_absent=1 uninstall_rc=1 hook_removed=1 skill_removed=1 agent_preserved=1
```

Worse than the red: the run **mutated the real configuration**, installing and removing `skills/codebase-memory/SKILL.md` under the user's Codex home roughly fifteen times.

## Why not another per-test list

The tests that already neutralize `CODEX_HOME` (`tests/test_cli.c:4535`, `:4969`, `:5546`, …) are exactly the ones that pass. The file also carries a comment admitting a suite was *"green only via env leaked from earlier suites"*. Extending those ad-hoc lists a 13th time leaves the next client to be forgotten again.

`tests/test_smoke_fixture_contract.sh` already defines the canonical inventory and *enforces* it — but only for the shell fixtures. This applies the same contract to the C runner.

## Change

- `tests/test_main.c` — neutralize the client home overrides once, in `tf_setup_cache_sentinel()`, next to the existing `HOME` / `CBM_CACHE_DIR` isolation. A test that exercises one of these sets it after setup, so the existing per-test `setenv` calls keep working unchanged.
- `tests/test_smoke_fixture_contract.sh` — hoist the inventory into one constant and require the C runner to neutralize it too, so a client isolated in the smoke scripts cannot be forgotten in the runner.

No change outside `tests/`.

## Verification

macOS arm64, with `$CODEX_HOME` and `$OPENCODE_CONFIG_DIR` exported (i.e. the polluted environment, no `env -u` workaround):

| | before | after |
|---|---|---|
| `test-runner cli` | 241 passed, 28 failed | **268 passed, 0 failed** |
| `test-runner` (full) | 7431 passed, 30 failed | **7461 passed, 0 failed, 4 skipped** |

The guard was checked to be non-vacuous: removing one variable from the runner's list makes the contract fail with `tests/test_main.c must neutralize ambient KIMI_CODE_HOME`.

## Unrelated observation, not addressed here

While confirming the full-suite numbers, one test failed only when a real daemon was running on the machine:

```
daemon_ipc_posix_record_publication_windows_recover_from_crash
  FAIL tests/test_daemon_ipc.c:3465: ASSERT(case_ok[index])
```

It passes in isolation, and the full suite is green once no daemon is live. The daemon rendezvous directory is keyed per-uid and not derived from `HOME` or `CBM_CACHE_DIR` (`src/daemon/ipc.c:867`), so the suite shares `/tmp/cbm-daemon-<uid>` with whatever daemon the developer has installed. `cbm_cli_set_activation_runtime_parent_for_test` already exists as the seam but only one test uses it. Happy to open a separate issue if that is useful — keeping this PR to one thing.
