### PR TITLE
fix(build): give sanitized-build detection one spelling and a backstop

### DIFF
--- a/Makefile.cbm
+++ b/Makefile.cbm
@@ -111,10 +111,15 @@ TSAN_SANITIZE = -fsanitize=thread -fno-omit-frame-pointer
 # every sanitized-budget branch compiled to its NATIVE value on this leg —
 # exactly the failure the comment above SANITIZED_DEFINE describes for
 # trap-UBSan, repeated on a leg that was never wired up.
+#
+# The same define now goes on EVERY instrumented flag set of our own code, C and
+# C++ alike (CXXFLAGS_TSAN here, GRAMMAR_CFLAGS_TEST/TSAN below). Vendored flag
+# sets are left alone: mimalloc, sqlite3, tre, zstd, lz4 and tree-sitter read no
+# macro of ours.
 CFLAGS_TSAN = $(CFLAGS_COMMON) $(EDITOR_TEST_DEFINES) $(KOTLIN_DEDUP_TEST_DEFINE) \
 	$(CALL_REFERENCE_LOOKUP_TEST_DEFINE) $(INCREMENTAL_TEST_DEFINE) \
 	-DCBM_SANITIZED_BUILD=1 -g -O1 $(TSAN_SANITIZE)
-CXXFLAGS_TSAN = $(CXXFLAGS_COMMON) -g -O1 \
+CXXFLAGS_TSAN = $(CXXFLAGS_COMMON) -DCBM_SANITIZED_BUILD=1 -g -O1 \
                 $(TSAN_SANITIZE)
 
 # Windows needs ws2_32 (Winsock), psapi (GetProcessMemoryInfo), shell32
@@ -707,9 +712,9 @@ BUILD_DIR = build/c
 # Grammar + tree-sitter runtime: compiled without -Werror (upstream code has warnings)
 GRAMMAR_CFLAGS = -std=c11 -D_DEFAULT_SOURCE -O2 -w -I$(CBM_DIR) -I$(TS_INCLUDE) -I$(TS_SRC)
 GRAMMAR_CFLAGS_TEST = -std=c11 -D_DEFAULT_SOURCE -g -O1 -w -I$(CBM_DIR) -I$(TS_INCLUDE) -I$(TS_SRC) \
-                      $(SANITIZE)
+                      $(SANITIZED_DEFINE) $(SANITIZE)
 GRAMMAR_CFLAGS_TSAN = -std=c11 -D_DEFAULT_SOURCE -g -O1 -w -I$(CBM_DIR) -I$(TS_INCLUDE) -I$(TS_SRC) \
-                      $(TSAN_SANITIZE)
+                      -DCBM_SANITIZED_BUILD=1 $(TSAN_SANITIZE)
 
 # Object files for grammars + ts_runtime + lsp_all + preprocessor
 GRAMMAR_OBJS_TEST = $(patsubst $(CBM_DIR)/%.c,$(BUILD_DIR)/%.o,$(GRAMMAR_SRCS))

--- a/src/foundation/compat_thread.c
+++ b/src/foundation/compat_thread.c
@@ -8,6 +8,7 @@
 #include "foundation/compat_thread.h"
 
 #include "foundation/platform.h"
+#include "foundation/sanitized.h" /* CBM_SANITIZED — diagnostic stack floor */
 
 #include <mimalloc.h> /* mi_thread_done at thread exit */
 
@@ -31,7 +32,7 @@
  * exactly the threads that overflow. Diagnostic builds only: the shipping
  * binary keeps its fixed, predictable stack sizes. */
 static size_t cbm_thread_stack_floor(size_t requested) {
-#if defined(CBM_SANITIZED_BUILD) && CBM_SANITIZED_BUILD
+#if CBM_SANITIZED
     const char *env = getenv("CBM_THREAD_STACK_MB");
     if (env && env[0]) {
         char *end = NULL;

--- a/src/foundation/sanitized.h
+++ b/src/foundation/sanitized.h
@@ -1,0 +1,60 @@
+/*
+ * sanitized.h — One spelling of "is this binary instrumented?".
+ *
+ * Timing budgets, retry windows and stack floors all have to widen under a
+ * sanitizer, so several places need to ask this question. Before this header
+ * they each asked it differently — four sites, four spellings, one of which
+ * (the C# LSP bench) only recognised ASan and therefore ran a NATIVE 200ms
+ * budget on a ThreadSanitizer binary. Ask it here instead.
+ *
+ * The two sources are deliberate and neither replaces the other:
+ *
+ *   CBM_SANITIZED_BUILD — set by the build system (Makefile.cbm), and the ONLY
+ *   source that can answer for UBSan and trap-UBSan: undefined-behaviour
+ *   instrumentation leaves no macro and no __has_feature bit behind, so no
+ *   probe can see it. This is why the build system stays the source of truth.
+ *
+ *   Compiler probes — the backstop for the three sanitizers that DO announce
+ *   themselves, for when a new build lane forgets to pass the define. That is
+ *   not hypothetical: CFLAGS_TSAN never included SANITIZED_DEFINE (it keys off
+ *   $(SANITIZE), which TSan does not use), so every sanitized budget compiled
+ *   to its native value on the one leg they were written for, and
+ *   `subprocess_run_spawn_failure` failed on the very PR meant to fix it.
+ *
+ * Both clang and GCC spellings are listed because they disagree: clang reports
+ * thread and memory instrumentation through __has_feature only, GCC through
+ * __SANITIZE_*__ only, and __SANITIZE_THREAD__ alone — which is what the old
+ * per-site conditions used — is invisible on the clang lane that broke.
+ *
+ * Deliberately no #error when a probe fires without the define. Promoting
+ * leaves the binary CORRECT while the build lane is fixed, whereas an error
+ * would break it, and would also break an out-of-tree
+ * `make CFLAGS_EXTRA=-fsanitize=address` that never went near Makefile.cbm.
+ */
+#ifndef CBM_SANITIZED_H
+#define CBM_SANITIZED_H
+
+/* Define __has_feature away where it does not exist. `defined(__has_feature) &&
+ * __has_feature(...)` is NOT a substitute: && does not spare a preprocessor
+ * that lacks the builtin from parsing the call, and there `__has_feature(x)`
+ * becomes `0 (0)` — a syntax error rather than a 0. Nesting the arm under
+ * `#elif defined(__has_feature)` compiles everywhere but breaks cppcheck, which
+ * walks every configuration and rejects the file outright with "failed to
+ * evaluate #if condition, undefined function-like macro invocation". This is
+ * the idiom clang documents, and the one tests/test_mem.c already uses. */
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
+#if defined(CBM_SANITIZED_BUILD) && CBM_SANITIZED_BUILD
+#define CBM_SANITIZED 1
+#elif __has_feature(address_sanitizer) || __has_feature(thread_sanitizer) || \
+    __has_feature(memory_sanitizer)
+#define CBM_SANITIZED 1
+#elif defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__)
+#define CBM_SANITIZED 1
+#else
+#define CBM_SANITIZED 0
+#endif
+
+#endif /* CBM_SANITIZED_H */

--- a/src/foundation/subprocess.c
+++ b/src/foundation/subprocess.c
@@ -8,7 +8,8 @@
 #include "compat.h" /* cbm_nanosleep */
 #include "compat_fs.h"
 #include "log.h"
-#include "platform.h" /* cbm_now_ms */
+#include "platform.h"  /* cbm_now_ms */
+#include "sanitized.h" /* CBM_SANITIZED — spawn-retry budget */
 
 #include <stdio.h>
 #include <stdatomic.h>
@@ -902,8 +903,7 @@ static cbm_proc_poll_t cbm_subprocess_poll_win(cbm_subprocess_t *process, cbm_pr
  * hang for seconds. So the extra patience is scoped to the builds that need it,
  * the same way the daemon announce backstop is (test_daemon_frontend.c). Three
  * more doublings take the sanitized ceiling to roughly 5s. */
-#if defined(CBM_SANITIZED_BUILD) || defined(__SANITIZE_ADDRESS__) || \
-    defined(__SANITIZE_MEMORY__) || defined(__SANITIZE_THREAD__)
+#if CBM_SANITIZED
 enum { CBM_SPAWN_RETRY = 2, CBM_SPAWN_RETRY_ATTEMPTS = 9 };
 #else
 enum { CBM_SPAWN_RETRY = 2, CBM_SPAWN_RETRY_ATTEMPTS = 6 };

--- a/tests/test_cs_lsp_bench.c
+++ b/tests/test_cs_lsp_bench.c
@@ -28,6 +28,7 @@
  */
 #include "test_framework.h"
 #include "cbm.h"
+#include "foundation/sanitized.h"
 #include "lsp/cs_lsp.h"
 #include <stdlib.h>
 #include <time.h>
@@ -235,10 +236,12 @@ TEST(cslsp_bench_resolution_ratio) {
         ASSERT_GTE(resolved * 100, calls * 45);
     }
 
-    /* Time budget. ASan+UBSan instrumentation slows the parse ~5-10×, so
-     * scale the budget when a sanitizer is active. Native: 200 ms for a
-     * ~260-line fixture; sanitized: 2000 ms. */
-#if defined(CBM_SANITIZED_BUILD) || defined(__SANITIZE_ADDRESS__)
+    /* Time budget. Instrumentation slows the parse ~5-10×, so scale the budget
+     * when a sanitizer is active. Native: 200 ms for a ~260-line fixture;
+     * sanitized: 2000 ms. The condition used to name ASan specifically, which
+     * left the TSan and MSan lanes measuring an instrumented parse against the
+     * native 200 ms. */
+#if CBM_SANITIZED
     ASSERT(ms < 2000.0);
 #else
     ASSERT(ms < 200.0);

--- a/tests/test_daemon_frontend.c
+++ b/tests/test_daemon_frontend.c
@@ -11,6 +11,7 @@
 #include "foundation/compat.h"
 #include "foundation/compat_thread.h"
 #include "foundation/platform.h"
+#include "foundation/sanitized.h"
 
 #include <stdint.h>
 #include <stdatomic.h>
@@ -842,8 +843,7 @@ static bool frontend_backpressure_run_isolated(bool maintenance) {
      * MSan stayed green. Widening the backstop for sanitized builds costs
      * nothing when the daemon is healthy: a passing run returns as soon as the
      * byte arrives, whatever the ceiling is. */
-#if defined(CBM_SANITIZED_BUILD) || defined(__SANITIZE_ADDRESS__) || \
-    defined(__SANITIZE_MEMORY__) || defined(__SANITIZE_THREAD__)
+#if CBM_SANITIZED
     const uint64_t announce_backstop_ms = 180000U;
 #else
     const uint64_t announce_backstop_ms = 30000U;


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1590/#1595. Those widened the spawn-retry budget for sanitized builds and then had to
chase the define onto the TSan leg. This removes the class of failure rather than the instance.

**The four spellings.** Four places ask "is this binary instrumented?", each differently:

| site | condition |
|---|---|
| `src/foundation/subprocess.c` | `CBM_SANITIZED_BUILD` + three `__SANITIZE_*__` |
| `tests/test_daemon_frontend.c` | same four |
| `src/foundation/compat_thread.c` | `defined(X) && X` |
| `tests/test_cs_lsp_bench.c` | **ASan only** |

The last one means TSan and MSan were measuring an instrumented parse against the native 200 ms budget.

**Why the probes could not cover for the missing define.** `0a163d4f` concluded that compiler probes
would not have helped, because clang spells thread instrumentation `__has_feature(thread_sanitizer)`
rather than `__SANITIZE_THREAD__`. That is right about the probes we had — and it is exactly the
probe that was missing. No site consulted `__has_feature`.

**What replaces them.** `src/foundation/sanitized.h` answers once, as `CBM_SANITIZED`, from two
sources with distinct jobs:

- `CBM_SANITIZED_BUILD` from the build system stays the source of truth, and is the **only** thing
  that can answer for UBSan and trap-UBSan — UB instrumentation leaves no macro and no
  `__has_feature` bit behind.
- The clang and GCC probes are the backstop for the three sanitizers that do announce themselves, so
  a lane that forgets the define still gets correct budgets instead of native ones.

No `#error` when a probe fires without the define: promoting leaves the binary correct while the lane
gets fixed, and it does not break an out-of-tree `make CFLAGS_EXTRA=-fsanitize=address`.

**Build lanes.** The define now also goes on the instrumented flag sets of our own code that lacked
it: `CXXFLAGS_TSAN` (`preprocessor.cpp` is ours; `CXXFLAGS_TEST` already had it),
`GRAMMAR_CFLAGS_TEST`, `GRAMMAR_CFLAGS_TSAN`. Neither tree can include the header today (no `-Isrc`),
so this is the build system keeping its own promise, not a behaviour change. Vendored flag sets are
untouched.

**Behaviour change worth naming:** `test_cs_lsp_bench` now allows 2000 ms on the TSan and MSan lanes
instead of 200 ms. It loosens a bound that was being applied to an instrumented binary by accident.

## Verification

Resolution matrix, measured rather than assumed (clang 22, `-dM -E`):

| flags | `CBM_SANITIZED` |
|---|---|
| native | 0 |
| `-DCBM_SANITIZED_BUILD=1` | 1 |
| `-fsanitize=address` | 1 |
| `-fsanitize=thread` (linux target) | **1** |
| `-fsanitize=memory` (linux target) | 1 |
| `-fsanitize=undefined` | 0 — define-only, as designed |

The thread row is the point: the failure this header is named after would have self-healed.

**Not verified locally, needs CI:** this machine has no POSIX-target compiler, so the POSIX half of
`subprocess.c` was compiled only on the Windows leg, and the sanitized lanes (`test-tsan`, ASan,
MSan, trap-UBSan) were not run. `make -f Makefile.cbm test-foundation` does not link here for an
unrelated pre-existing reason — `tests/test_main.c` references the store/cypher/... suites
unconditionally, so that target cannot link against `TEST_FOUNDATION_SRCS` alone.

## Checklist

- [x] Every commit is signed off (`git commit -s`)
- [ ] Tests pass locally (`make -f Makefile.cbm test`) — see above, no POSIX toolchain on this box
- [x] Lint passes — clang-format clean on every touched file
- [x] New behavior is covered — the macro matrix above; the change is a compile-time contract with no
      runtime surface of its own
