### PR TITLE
fix(subprocess): bound the spawn backoff by the wait, not by the budget

### DIFF
--- a/src/foundation/subprocess.c
+++ b/src/foundation/subprocess.c
@@ -912,8 +912,9 @@ enum { CBM_SPAWN_RETRY = 2, CBM_SPAWN_RETRY_ATTEMPTS = 6 };
 /* Exponential backoff, doubling from 10ms: 10, 20, 40, 80, 160, 320 — ~630ms of
  * total patience on an ordinary build, and three further doublings (640, 1280,
  * 2560) to roughly 5s on a sanitized one. The waits follow from
- * CBM_SPAWN_RETRY_ATTEMPTS above rather than being listed separately here, so
- * changing the budget cannot leave this description behind.
+ * CBM_SPAWN_RETRY_ATTEMPTS above and from the per-wait ceiling at
+ * cbm_spawn_backoff, rather than being listed separately here, so changing the
+ * budget cannot leave this description behind.
  *
  * The first version waited a flat 3 x 10ms, which was enough for a momentary
  * dip and NOT enough for the real thing: a CI runner building and testing in
@@ -948,13 +949,26 @@ static bool cbm_spawn_eagain_injected(void) {
 }
 #endif
 
+/* The bound is on a single WAIT, and 2560ms (10ms << 8) is the largest wait
+ * either budget produces today: 10..320 on an ordinary build, 10..2560 on a
+ * sanitized one. So this changes nothing now — it changes what happens next.
+ *
+ * The clamp it replaces bounded `attempt` by CBM_SPAWN_RETRY_ATTEMPTS, which no
+ * caller can reach: both retry loops return before passing the budget, so the
+ * clamp never fired and the comment claiming "the budget is the only bound
+ * needed" described a bound that did not exist. Doubling with nothing to stop
+ * it is the actual risk, and it grows fast — a budget of 12 would make the last
+ * wait ~20s and the total ~41s, which is precisely the "hang instead of fail
+ * fast" the retry was written to avoid. Flattening at the ceiling keeps a
+ * budget increase linear.
+ *
+ * Spelled as a shift so the value cannot overflow `long` on the way to being
+ * clamped. */
+enum { CBM_SPAWN_BACKOFF_BASE_MS = 10, CBM_SPAWN_BACKOFF_MAX_SHIFT = 8 };
+
 static void cbm_spawn_backoff(int attempt) {
-    /* Cap the shift at the budget, not at a constant: with the sanitized budget
-     * of 9 a hard-coded 6 would flatten the last three waits to 320ms each
-     * instead of continuing to double. The budget is the only bound needed —
-     * callers never exceed it, and a second clamp would be dead code. */
-    int shift = attempt < CBM_SPAWN_RETRY_ATTEMPTS ? attempt : CBM_SPAWN_RETRY_ATTEMPTS;
-    long ms = 10L << shift;
+    int shift = attempt < CBM_SPAWN_BACKOFF_MAX_SHIFT ? attempt : CBM_SPAWN_BACKOFF_MAX_SHIFT;
+    long ms = (long)CBM_SPAWN_BACKOFF_BASE_MS << shift;
     struct timespec delay = {ms / 1000L, (ms % 1000L) * 1000L * 1000L};
     (void)cbm_nanosleep(&delay, NULL);
 }


### PR DESCRIPTION
## What does this PR do?

`cbm_spawn_backoff` clamps its shift with

```c
int shift = attempt < CBM_SPAWN_RETRY_ATTEMPTS ? attempt : CBM_SPAWN_RETRY_ATTEMPTS;
```

and the comment above it says *"the budget is the only bound needed — callers never exceed it, and a
second clamp would be dead code"*. The clamp that stayed is the dead one: both retry loops return
before `attempt` reaches the budget (`cbm_fork_with_retry`, and the `posix_spawn` loop on Apple), so
it can never fire.

What it leaves unbounded is the case it was written for. Nothing stops the doubling, so the schedule
explodes with the budget instead of flattening:

| budget | waits | total |
|---|---|---|
| 6 | 10 20 40 80 160 320 | 630 ms |
| 9 | 10 20 40 80 160 320 640 1280 2560 | 5110 ms |
| 12 | 10 20 40 80 160 320 640 1280 2560 5120 10240 20480 | **40950 ms** |

40 s of waiting is exactly the "hang instead of fail fast" this retry exists to avoid, and it is one
edit to `CBM_SPAWN_RETRY_ATTEMPTS` away.

This bounds a single **wait** instead, at 2560 ms — the largest wait either shipping budget already
produces.

## Verification

Old vs new schedule, computed for both shipping budgets and one hypothetical:

| budget | old total | new total | |
|---|---|---|---|
| 6 | 630 ms | 630 ms | identical |
| 9 | 5110 ms | 5110 ms | identical |
| 12 | 40950 ms | 12790 ms | flattens at the ceiling |

So **nothing changes today**; a future budget increase costs 2560 ms per extra attempt instead of
doubling. The ceiling is spelled as a shift so the value cannot overflow `long` on the way to being
clamped.

`clang-format` clean. Subprocess suite green on Windows (14 passed, 17 skipped) — the POSIX retry
probes skip there, so the loop bounds themselves are CI's to confirm; this box has no POSIX-target
compiler.

Independent of #1615, which touches the `#if` above this function but not the function itself.

## Checklist

- [x] Every commit is signed off (`git commit -s`)
- [ ] Tests pass locally (`make -f Makefile.cbm test`) — subprocess suite green on Windows; no POSIX
      toolchain on this box
- [x] Lint passes — clang-format clean
- [x] New behavior is covered — there is no new behaviour on either shipping budget, which is the
      claim the table above verifies; `subprocess_gives_up_after_the_retry_budget` already exercises
      the exhausted path
