### PR TITLE
fix(windows): report why an atomic publish failed instead of blaming the repo

### DIFF
--- a/src/foundation/compat_fs.c
+++ b/src/foundation/compat_fs.c
@@ -1039,9 +1039,54 @@ int cbm_rename_replace(const char *src, const char *dst) {
     wchar_t *wdst = cbm_path_to_wide(dst);
     int ret = CBM_NOT_FOUND;
     if (wsrc && wdst) {
-        ret = MoveFileExW(wsrc, wdst, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)
-                  ? 0
-                  : CBM_NOT_FOUND;
+        if (MoveFileExW(wsrc, wdst, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+            ret = 0;
+        } else {
+            /* Translate the Win32 error into errno so callers can report WHY.
+             *
+             * Callers log `errno` after a failed rename (see
+             * finalize.rename_failed in the pipeline). Without this the value
+             * is whatever happened to be left there by an unrelated CRT call,
+             * so on Windows the one field that should explain an atomic-publish
+             * failure was noise. #1620 is exactly that: an ACL problem surfaced
+             * to the user as "Pipeline failed. Check repo_path exists and
+             * contains source files" — blaming their repository — because
+             * ERROR_ACCESS_DENIED never reached the log.
+             *
+             * ERROR_ACCESS_DENIED is the interesting one here: MoveFileEx needs
+             * DELETE on the destination, which a cache file created under an
+             * empty or foreign DACL does not grant. */
+            DWORD error = GetLastError();
+            switch (error) {
+            case ERROR_ACCESS_DENIED:
+            case ERROR_WRITE_PROTECT:
+                errno = EACCES;
+                break;
+            case ERROR_FILE_NOT_FOUND:
+            case ERROR_PATH_NOT_FOUND:
+                errno = ENOENT;
+                break;
+            case ERROR_SHARING_VIOLATION:
+            case ERROR_LOCK_VIOLATION:
+            case ERROR_USER_MAPPED_FILE:
+                errno = EBUSY;
+                break;
+            case ERROR_NOT_SAME_DEVICE:
+                errno = EXDEV;
+                break;
+            case ERROR_DISK_FULL:
+                errno = ENOSPC;
+                break;
+            case ERROR_INVALID_NAME:
+            case ERROR_FILENAME_EXCED_RANGE:
+                errno = ENAMETOOLONG;
+                break;
+            default:
+                errno = EIO;
+                break;
+            }
+            ret = CBM_NOT_FOUND;
+        }
     }
     free(wsrc);
     free(wdst);

--- a/src/pipeline/pipeline.c
+++ b/src/pipeline/pipeline.c
@@ -1806,6 +1806,15 @@ int cbm_pipeline_finalize_staged_generation(char *stage_path, const char *final_
     struct timespec t_fin;
     cbm_clock_gettime(CLOCK_MONOTONIC, &t_fin);
     if (cbm_remove_db_sidecars(stage_path) != 0) {
+        /* This returned PERSIST_FAILED with no log at all, which is how #1620
+         * presented: every pass succeeded, the worker exited 0, no error-level
+         * line was emitted anywhere, and the user was told "Pipeline failed.
+         * Check repo_path exists and contains source files" — pointed at their
+         * repository for a filesystem permission problem. A publish that fails
+         * must say so. */
+        char errno_text[16];
+        (void)snprintf(errno_text, sizeof(errno_text), "%d", errno);
+        cbm_log_error("finalize.sidecar_removal_failed", "errno", errno_text, "stage", stage_path);
         discard_generation_stage(stage_path);
         return CBM_PIPELINE_PERSIST_FAILED;
     }


### PR DESCRIPTION
In #1620 every `index_repository` run fails like this:

```json
{"status":"error","hint":"Pipeline failed. Check repo_path exists and contains source files."}
```

The repository is fine. Every pass succeeds, `gbuf.dump` completes, the supervised worker exits **0**, and **no error-level line is emitted anywhere**. The publish is failing on a filesystem permission problem, and two separate defects conspire to hide it.

**1. `cbm_rename_replace` discarded `GetLastError()`** and returned a bare `CBM_NOT_FOUND`. Callers log `errno` afterwards (`finalize.rename_failed`), so on Windows the one field that should explain an atomic-publish failure held whatever an unrelated CRT call happened to leave there. The Win32 error is now translated. `ERROR_ACCESS_DENIED` is the interesting case: `MoveFileEx` needs `DELETE` on the destination, which a cache file created under an empty or foreign DACL does not grant — precisely the state #1620 and #1601 describe.

**2. `cbm_pipeline_finalize_staged_generation` returned `PERSIST_FAILED` on a failed sidecar removal with no log at all.** That is the genuinely silent path.

Neither change fixes the underlying ACL problem — #1623 and the re-stamp work address that. Together they turn a report that misdirects the user at their own repository into one that names a permission failure on a specific file, which is the difference between an unactionable issue and a five-minute one.

`platform` + `pipeline` suites: **268 passed, 0 failed**.
