### PR TITLE
fix(windows): re-stamp the runtime DACL only when it is actually wrong

### DIFF
--- a/src/daemon/ipc.c
+++ b/src/daemon/ipc.c
@@ -4225,7 +4225,7 @@ static bool win_runtime_directory_secure(const wchar_t *runtime_dir) {
     DWORD secure_result = ERROR_ACCESS_DENIED;
     bool already_correct =
         valid_handle && owner_exact &&
-        win_file_security_secure(&security, directory, true, win_private_mutation_rights(), false);
+        win_file_security_secure(&security, directory, true, win_private_mutation_rights());
     if (already_correct) {
         secure_result = ERROR_SUCCESS;
     } else if (valid_handle && owner_ok) {

--- a/src/daemon/ipc.c
+++ b/src/daemon/ipc.c
@@ -4225,7 +4225,7 @@ static bool win_runtime_directory_secure(const wchar_t *runtime_dir) {
     DWORD secure_result = ERROR_ACCESS_DENIED;
     bool already_correct =
         valid_handle && owner_exact &&
-        win_file_security_secure(&security, directory, true, win_private_mutation_rights());
+        win_file_security_secure(&security, directory, true, win_private_mutation_rights(), false);
     if (already_correct) {
         secure_result = ERROR_SUCCESS;
     } else if (valid_handle && owner_ok) {

--- a/src/daemon/ipc.c
+++ b/src/daemon/ipc.c
@@ -4204,8 +4204,31 @@ static bool win_runtime_directory_secure(const wchar_t *runtime_dir) {
      * refused, and the final validation below still demands the exact user. */
     bool owner_ok = owner_exact || (valid_handle && can_write_owner &&
                                     win_file_owner_secure(&security, directory, false));
+    /* Re-stamp only when the directory is not ALREADY correct.
+     *
+     * This used to fire on every process start, whether or not anything was
+     * wrong. Two costs, both observed in the field:
+     *
+     *  - It rewrites the security descriptor of a directory that already has
+     *    the right one, and Windows propagates that to children. #1601 counted
+     *    ELEVEN "Security change" USN records against a single _config.db in
+     *    one day, none of which changed anything.
+     *  - Every rewrite is a window. #1620 loses an atomic publish to exactly
+     *    this: MoveFileEx needs DELETE on the destination, and a concurrent
+     *    re-protect of the parent is a chance to be refused for a state that is
+     *    about to be correct again anyway.
+     *
+     * The repair is what matters, not the ritual. If the owner is already the
+     * exact current user and the DACL already passes the private-directory
+     * check, there is nothing to fix and the correct action is to leave it
+     * alone. When it IS wrong we still repair exactly as before. */
     DWORD secure_result = ERROR_ACCESS_DENIED;
-    if (valid_handle && owner_ok) {
+    bool already_correct =
+        valid_handle && owner_exact &&
+        win_file_security_secure(&security, directory, true, win_private_mutation_rights(), false);
+    if (already_correct) {
+        secure_result = ERROR_SUCCESS;
+    } else if (valid_handle && owner_ok) {
         secure_result = security.set_security_info(
             directory, SE_FILE_OBJECT,
             (owner_exact ? 0U : (DWORD)OWNER_SECURITY_INFORMATION) | DACL_SECURITY_INFORMATION |


### PR DESCRIPTION
fix(windows): re-stamp the runtime DACL only when it is actually wrong

win_runtime_directory_secure called set_security_info with
PROTECTED_DACL_SECURITY_INFORMATION on every process start, whether or not
anything needed repairing. Line 4126 computes `created`, but it only guards the
ERROR_ALREADY_EXISTS check - the re-stamp itself ran unconditionally.

Two costs, both observed rather than theorised:

#1601 counted ELEVEN "Security change" USN records against a single _config.db
in one day. Windows propagates a directory's security descriptor to its
children, so a rewrite that changes nothing still churns every file underneath.

#1620 loses its atomic publish to this. MoveFileEx needs DELETE on the
destination, and a concurrent re-protect of the parent is a window in which it
can be refused - for a state that was about to be correct anyway. That reporter
proved the interaction by running a background icacls loop during indexing and
watching the identical index succeed.

The repair is what matters, not the ritual. When the owner is already the exact
current user AND the DACL already passes the private-directory check, there is
nothing to fix and the right action is to leave it alone. When it IS wrong, the
repair is byte-for-byte what it was before.

This does not fix the underlying ACL damage on already-broken installs - files
created under the pre-v0.10.3 flagless regime still carry empty DACLs and need
a child repair, which is a separate change. It stops us from making it worse and
from creating a failure window on every start.

Costs one extra GetSecurityInfo to avoid a SetSecurityInfo, which is the cheap
direction.

Builds clean; daemon_ipc 48 passed. The changed region is Windows-only, so the
real verification is the Windows CI leg.
