### PR TITLE
fix(mcp): release path filter on search launch failure

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -9813,6 +9813,9 @@ static char *handle_search_code(cbm_mcp_server_t *srv, const char *args) {
         FILE *fp = cbm_popen(cmd, "r");
         if (!fp) {
             search_scratch_close(&scratch);
+            if (has_path_filter) {
+                cbm_regfree(&path_regex);
+            }
             free(root_path);
             free(pattern);
             free(project);


### PR DESCRIPTION
## Summary
- free the compiled search_code path_filter regex when the POSIX grep subprocess cannot be opened
- keep the launch-failure cleanup path ownership-complete

This is the unrelated leak identified during review of #1608, split out as requested.

## Testing
- not run (small cleanup-only error-path change; CI will cover the normal search_code suite)