### PR TITLE
fix(cli): never read stdin for a tool that declares no arguments (#1359)

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ codebase-memory-mcp cli --progress index_repository --repo-path /path/to/repo
 codebase-memory-mcp cli search_graph --project my-project --label Function | jq '.results[].name'
 ```
 
-JSON arguments can also be piped on stdin. Inline JSON remains accepted for backward compatibility but is deprecated in favor of flags, `--args-file`, or stdin.
+JSON arguments can also be piped on stdin, for tools that take arguments. A tool whose input schema declares none — `list_projects` — never reads stdin, so it stays responsive when it inherits a pipe the caller never closes (the default for `child_process.spawn` and similar wrappers). Inline JSON remains accepted for backward compatibility but is deprecated in favor of flags, `--args-file`, or stdin.
 
 ## MCP Tools
 

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -12273,6 +12273,49 @@ static void cli_add_typed(yyjson_mut_doc *out, yyjson_mut_val *obj, const char *
     yyjson_mut_obj_add(obj, yyjson_mut_strcpy(out, key), vv);
 }
 
+bool cbm_cli_args_from_stdin_allowed(const char *tool_name, bool stdin_is_tty) {
+    /* An interactive run has nothing piped to read: consulting the terminal
+     * would just sit waiting for the user to type JSON. Unchanged by #1359 —
+     * this is why the hang was only ever reachable from automation. */
+    if (stdin_is_tty) {
+        return false;
+    }
+
+    /* WHY the schema gate (#1359): a non-interactive stdin used to be accepted
+     * as piped arguments unconditionally, and cli_slurp_stream reads to EOF. An
+     * ordinary non-interactive caller never sends that EOF — Node's
+     * child_process.spawn defaults to stdio:['pipe','pipe','pipe'] and the
+     * parent must call child.stdin.end() explicitly, which almost nobody does
+     * for a command they are not writing to. fd 0 then stays open with no
+     * writer and the read never returns; the reporter's shell script was still
+     * parked in fread(0) fourteen minutes later. For a tool whose input_schema
+     * declares no properties (list_projects) stdin cannot carry anything the
+     * tool would accept, so that read is pure deadlock with nothing to gain:
+     * never start it, and let the caller fall through to `{}` exactly as an
+     * interactive run already did. Tools that DO declare properties keep the
+     * documented `echo '<json>' | cli <tool>` channel untouched. */
+    const char *schema_str = cbm_mcp_tool_input_schema(tool_name);
+    if (!schema_str) {
+        /* Unknown tool: dispatch rejects it by name and no stdin content can
+         * change that verdict, so do not block for input we would discard. */
+        return false;
+    }
+
+    yyjson_doc *schema_doc = yyjson_read(schema_str, strlen(schema_str), 0);
+    if (!schema_doc) {
+        /* The schemas are compile-time constants, so a parse failure means a
+         * malformed literal rather than caller input. Keep the documented stdin
+         * channel rather than silently narrowing it on a schema we could not
+         * read — the gate must only ever fire on positive evidence that the
+         * tool takes no arguments. */
+        return true;
+    }
+    yyjson_val *props = yyjson_obj_get(yyjson_doc_get_root(schema_doc), "properties");
+    bool accepts_arguments = props && yyjson_is_obj(props) && yyjson_obj_size(props) > 0;
+    yyjson_doc_free(schema_doc);
+    return accepts_arguments;
+}
+
 char *cbm_cli_build_args_json(const char *tool_name, int argc, char **argv, char **err_out) {
     if (err_out) {
         *err_out = NULL;

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -34,6 +34,14 @@ const char *cbm_cli_get_version(void);
  * must free. Caller frees the returned JSON string. */
 char *cbm_cli_build_args_json(const char *tool_name, int argc, char **argv, char **err_out);
 
+/* Decide whether `cli <tool>` may take its JSON arguments from stdin, given
+ * that no --args-file, raw-JSON positional and no --flag form was supplied.
+ * stdin_is_tty is the caller's isatty(0) result. True only for a non-terminal
+ * stdin AND a tool whose input_schema declares at least one property; a
+ * zero-argument tool such as list_projects must never read stdin, because an
+ * inherited-but-never-closed pipe makes that read block forever (#1359). */
+bool cbm_cli_args_from_stdin_allowed(const char *tool_name, bool stdin_is_tty);
+
 /* Print per-tool help (usage + the tool's flags with type/description/required)
  * derived from its input_schema, to stdout. Returns 0 if the tool is known,
  * non-zero (and prints nothing) if it is not. */

--- a/src/main.c
+++ b/src/main.c
@@ -756,8 +756,10 @@ static int run_cli(int argc, char **argv, cbm_project_lock_manager_t *project_lo
             return SKIP_ONE;
         }
         args_json = heap_args;
-    } else if (!cli_isatty(0)) {
-        /* piped stdin (UTF-8 clean, no shell quoting): cli <tool> < args.json */
+    } else if (cbm_cli_args_from_stdin_allowed(tool_name, cli_isatty(0) != 0)) {
+        /* piped stdin (UTF-8 clean, no shell quoting): cli <tool> < args.json.
+         * Gated (#1359): a tool that declares no arguments must not read a pipe
+         * nobody is going to write to or close — see the WHY on the predicate. */
         heap_args = cli_slurp_stream(stdin);
         if (heap_args && heap_args[0]) {
             args_json = heap_args;

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -12110,6 +12110,63 @@ TEST(cli_print_tool_help_issue680) {
     PASS();
 }
 
+/* #1359: `cli <tool>` with no argument-bearing token used to slurp stdin to EOF
+ * for ANY non-terminal stdin. The ordinary automation caller never sends that
+ * EOF — Node's child_process.spawn defaults to stdio:['pipe','pipe','pipe'] and
+ * the parent must call child.stdin.end() explicitly — so `cli list_projects`
+ * parked in fread(0) with no writer and never returned (the reporter's script
+ * was still stuck fourteen minutes later). list_projects declares no schema
+ * properties, so stdin could never have carried anything it accepts: the read
+ * was pure deadlock. Gate the read on the tool actually declaring arguments. */
+TEST(cli_zero_argument_tool_never_reads_stdin_issue1359) {
+    /* The reported hang: zero-argument tool + non-terminal stdin. */
+    ASSERT_FALSE(cbm_cli_args_from_stdin_allowed("list_projects", false));
+
+    /* The documented `echo '<json>' | cli <tool>` channel must survive. */
+    ASSERT_TRUE(cbm_cli_args_from_stdin_allowed("index_status", false));
+    ASSERT_TRUE(cbm_cli_args_from_stdin_allowed("search_graph", false));
+    ASSERT_TRUE(cbm_cli_args_from_stdin_allowed("index_repository", false));
+
+    /* Interactive runs never read the terminal for arguments — unchanged. */
+    ASSERT_FALSE(cbm_cli_args_from_stdin_allowed("index_status", true));
+    ASSERT_FALSE(cbm_cli_args_from_stdin_allowed("list_projects", true));
+
+    /* An unknown tool is rejected by name; blocking for input first can only
+     * delay that verdict, never change it. */
+    ASSERT_FALSE(cbm_cli_args_from_stdin_allowed("nope_not_a_tool", false));
+    ASSERT_FALSE(cbm_cli_args_from_stdin_allowed(NULL, false));
+    PASS();
+}
+
+/* The gate must track the advertised input_schema for the WHOLE tool table, not
+ * carry a special case for list_projects: a future zero-argument tool would
+ * otherwise reintroduce #1359 silently. Expectation is derived independently
+ * from the schema the MCP tools/list publishes. */
+TEST(cli_stdin_args_gate_tracks_tool_schema_issue1359) {
+    int zero_argument_tools = 0;
+    for (int i = 0; i < cbm_mcp_tool_count(); i++) {
+        const char *name = cbm_mcp_tool_name(i);
+        ASSERT_NOT_NULL(name);
+        const char *schema = cbm_mcp_tool_input_schema(name);
+        ASSERT_NOT_NULL(schema);
+
+        yyjson_doc *doc = yyjson_read(schema, strlen(schema), 0);
+        ASSERT_NOT_NULL(doc);
+        yyjson_val *props = yyjson_obj_get(yyjson_doc_get_root(doc), "properties");
+        bool declares_properties = props && yyjson_is_obj(props) && yyjson_obj_size(props) > 0;
+        yyjson_doc_free(doc);
+
+        if (!declares_properties) {
+            zero_argument_tools++;
+        }
+        ASSERT_EQ(cbm_cli_args_from_stdin_allowed(name, false), declares_properties);
+        ASSERT_FALSE(cbm_cli_args_from_stdin_allowed(name, true));
+    }
+    /* list_projects at minimum; without one the sweep above proves nothing. */
+    ASSERT_GTE(zero_argument_tools, 1);
+    PASS();
+}
+
 /* The self-update path verifies a downloaded archive against a published
  * checksum. That check is only meaningful if the digest is actually computed —
  * a broken hash command (it once invoked `shasum -a CBM_SZ_256`, an invalid
@@ -12827,4 +12884,8 @@ SUITE(cli) {
     RUN_TEST(cli_build_args_json_key_equals_value_issue680);
     RUN_TEST(cli_build_args_json_bad_positional_errors_issue680);
     RUN_TEST(cli_print_tool_help_issue680);
+
+    /* Stdin argument gate (#1359) */
+    RUN_TEST(cli_zero_argument_tool_never_reads_stdin_issue1359);
+    RUN_TEST(cli_stdin_args_gate_tracks_tool_schema_issue1359);
 }


### PR DESCRIPTION
Fixes #1359.

## Mechanism (verified on `origin/main`, not just from the report)

`run_cli` (`src/main.c`) resolves tool arguments in precedence order: `--args-file`, raw-JSON positional, `--flag` form, then piped stdin. The last branch was reached whenever *nothing* remained after the tool name:

```c
} else if (!cli_isatty(0)) {
    heap_args = cli_slurp_stream(stdin);   /* reads to EOF */
```

Two things make this bite harder than the original report suggested:

* `--json` and `--progress` are stripped by `cli_strip_flag` **before** this chain, so `cli list_projects --json` also lands here — the reporter's correction was right that "no flags" is not the trigger.
* `cli_slurp_stream` loops on `fread` until EOF. An ordinary automation caller never sends that EOF: Node's `child_process.spawn` defaults to `stdio: ['pipe','pipe','pipe']` and the parent must call `child.stdin.end()` explicitly, which almost nobody does for a command it is not writing to. fd 0 stays open with no writer and the read never returns.

`list_projects` advertises `"properties":{}` — stdin could never have carried anything it accepts. The read was pure deadlock with nothing to gain.

## Repro on the pre-fix binary

Built `build/c/codebase-memory-mcp` at `origin/main`, stdin held open by a writer that never writes, 15-second watchdog, isolated `$HOME`:

| invocation | stdin | result |
|---|---|---|
| `cli list_projects` | open pipe, no data | **killed at 15s, 0 bytes** |
| `cli list_projects` | `/dev/null` | exit 0, 3s, 90 bytes |
| `cli index_status` (`--project` omitted) | open pipe, no data | **killed at 15s, 0 bytes** |
| `cli index_status` (`--project` omitted) | `/dev/null` | exit 1, 3s, `missing required argument: project` |

## The fix

Gate the stdin branch on the tool's `input_schema` actually declaring properties, via a seam `cbm_cli_args_from_stdin_allowed(tool_name, stdin_is_tty)` that `run_cli` calls in place of the bare `!cli_isatty(0)`.

* A tool that declares no arguments never reads stdin, and falls through to `{}` exactly as an interactive run already did.
* An unknown tool also stops blocking: dispatch rejects it by name and no stdin content can change that verdict.
* Tools that **do** declare properties keep the documented `echo '<json>' | cli <tool>` channel untouched — no timeout, no readiness probe, no behaviour change on that path.
* Interactive runs are unchanged; `isatty(0)` already short-circuited them, which is why this only ever bit automation.
* A schema we cannot parse keeps the stdin channel: the gate fires only on positive evidence that the tool takes no arguments.

**MCP stdio server behaviour is untouched** — this branch is inside `run_cli`, reached only via the `cli` subcommand. The server path reads stdin because that is its transport, and it is not routed through here.

Same repro against the rebuilt binary: `cli list_projects` with the open, never-written pipe now exits 0 in 9s (cold daemon start) with 90 bytes, matching the `/dev/null` control.

## Tests and revert-check

Two tests in `tests/test_cli.c`, registered in the `cli` suite:

* `cli_zero_argument_tool_never_reads_stdin_issue1359` — the reported hang, the piped-argument channel that must survive (`index_status`, `search_graph`, `index_repository`), the interactive path, and unknown/`NULL` tool names.
* `cli_stdin_args_gate_tracks_tool_schema_issue1359` — sweeps the whole tool table, deriving the expectation independently from the schema `tools/list` publishes, so a future zero-argument tool cannot reintroduce this silently. Asserts at least one zero-argument tool exists, so the sweep can never pass vacuously.

Revert-check — schema gate reverted to the pre-fix `return !stdin_is_tty`, everything else identical:

```
  cli_zero_argument_tool_never_reads_stdin_issue1359    FAIL tests/test_cli.c:12123: ASSERT(!(cbm_cli_args_from_stdin_allowed("list_projects", 0)))
  cli_stdin_args_gate_tracks_tool_schema_issue1359      FAIL tests/test_cli.c:12162: cbm_cli_args_from_stdin_allowed(name, false) == 1, expected declares_properties == 0

  270 passed, 2 failed
```

With the gate applied: **272 passed, 0 failed** (`./build/c/test-runner cli`). `make -f Makefile.cbm lint-ci` clean; changed files run through the Homebrew LLVM `clang-format` (no drift).

## Known limit — a maintainer decision, deliberately not forced here

A tool that **does** declare properties, invoked with its required flag omitted (`cli index_status` without `--project`), still blocks on an open pipe. That is the reporter's ask #3, and it is not a mechanical fix: piped stdin is the documented arguments channel for such a tool, so "arguments are coming" and "nobody will ever write" are indistinguishable without a bounded wait. Bounding it is a public-surface decision — the deadline value, whether expiry errors or silently defaults to `{}` (silent-wrong-args risk for a slow producer), and the `PeekNamedPipe` polling loop Windows would need where POSIX gets `poll(2)`. Nondeterministic startup on a loaded machine is the failure mode to avoid. Happy to do it as a follow-up once the shape is chosen.

Two incidental findings, not touched:

* A bare non-flag positional (`cli list_projects foo`) also falls into the stdin branch instead of reaching the existing `unexpected argument 'foo'` error, so it hangs the same way and silently drops the token when stdin does deliver. Restricting the branch to `rem_argc == 0` would close it.
* `cli list_projects --help` still advertises `echo '<json>' | ... cli list_projects` under an empty `Flags:` section, which is now a channel that tool does not have.
