### PR TITLE
fix(release,ci): cover ui-* aliases in checksums.txt, and stop the licence gate depending on a live fetch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,14 @@ jobs:
             release-selection.tsv \
             > checksums.txt
 
+      # The legacy ui-* aliases are byte-identical copies published after verify
+      # (scripts/ci/publish-legacy-aliases.sh), so they were absent from
+      # checksums.txt and 0.9.x updaters refused to install them (#1134). Their
+      # digests are added here, BEFORE attestation, so the attested artifact
+      # covers both names.
+      - name: Cover legacy ui-* aliases in checksums
+        run: scripts/ci/append-legacy-alias-checksums.sh checksums.txt
+
       - name: Attest checksum provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:

--- a/scripts/audit-license-provenance.py
+++ b/scripts/audit-license-provenance.py
@@ -10,6 +10,7 @@ Verdicts:
   ERROR              upstream fetch failed
 """
 import base64
+import hashlib
 import json
 import os
 import re
@@ -159,13 +160,24 @@ def main():
         check_upstream(rel, os.path.join(ROOT, rel), repo, exact_path=exact)
 
     # Special: nomic = canonical Apache-2.0 text; sqlite3 = first-party notice
+    #
+    # This used to `curl` https://www.apache.org/licenses/LICENSE-2.0.txt at
+    # gate time and byte-compare. A gating verdict must not depend on a live
+    # HTTP request: any fetch failure yielded an empty string, compared unequal,
+    # and reported DIFFERS -- indistinguishable from a real licence change. That
+    # is what reddened `security / license-gate` on PR #1337 for over two weeks,
+    # on a branch touching three CLI files and no licence at all.
+    #
+    # The canonical Apache-2.0 text is immutable and versioned, so it is pinned
+    # by digest instead. Verified byte-identical to the upstream text at the time
+    # of pinning (11358 bytes). A mismatch now means our vendored copy changed --
+    # which is exactly, and only, what this audit is meant to detect.
+    APACHE_2_0_SHA256 = "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"
     fname, ours = local_license(os.path.join(ROOT, "vendored/nomic"))
-    apache = subprocess.run(
-        ["curl", "-fsSL", "https://www.apache.org/licenses/LICENSE-2.0.txt"],
-        capture_output=True, text=True).stdout
+    ours_digest = hashlib.sha256(ours.encode("utf-8")).hexdigest() if ours is not None else None
     results["vendored/nomic"] = (
-        "IDENTICAL" if ours == apache else "DIFFERS",
-        "apache.org canonical LICENSE-2.0.txt")
+        "IDENTICAL" if ours_digest == APACHE_2_0_SHA256 else "DIFFERS",
+        "canonical Apache-2.0 text, pinned by sha256")
     results["vendored/sqlite3"] = ("FIRST-PARTY-NOTICE",
                                    "own public-domain notice (sqlite has no upstream LICENSE)")
 

--- a/scripts/ci/append-legacy-alias-checksums.sh
+++ b/scripts/ci/append-legacy-alias-checksums.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Add the legacy ui-* names to checksums.txt, carrying the canonical digest.
+#
+# publish-legacy-aliases.sh publishes byte-identical ui-*-named copies of the
+# release archives so already-released 0.9.x updaters stop 404ing (#1538). It
+# runs after verify, so those copies inherit the hash-bound VirusTotal verdicts
+# — and it therefore left them out of checksums.txt entirely, on the reasoning
+# that the file "covers the canonical names current installers request".
+#
+# That reasoning has a hole. The aliases exist ONLY for 0.9.x updaters, and
+# those verify the NAME they asked for. So the alias fixed the 404 and moved the
+# failure one step later: the updater downloads the archive, cannot find its name
+# in checksums.txt, and refuses to install it (#1134):
+#
+#   warning: codebase-memory-mcp-ui-darwin-arm64.tar.gz not found in checksums.txt
+#   error: refusing to install an unverified download
+#
+# An alias is a copy, so its sha256 is by construction the digest already
+# computed for the canonical archive. Emitting that digest under the legacy name
+# introduces no new bytes and no new scan surface. This runs BEFORE the
+# attestation step so the attested artifact covers both names.
+#
+# The alias rule MUST stay in step with publish-legacy-aliases.sh: .tar.gz and
+# .zip only, never an already-ui-* name. A name here with no published asset is
+# as broken as an asset with no name, so this fails closed when it matches
+# nothing.
+#
+# Usage: append-legacy-alias-checksums.sh <checksums-file>
+set -euo pipefail
+
+CHECKSUMS="${1:?usage: append-legacy-alias-checksums.sh <checksums-file>}"
+
+if [ ! -s "$CHECKSUMS" ]; then
+  echo "error: $CHECKSUMS is missing or empty" >&2
+  exit 1
+fi
+
+aliases="$(mktemp)"
+trap 'rm -f "$aliases"' EXIT
+
+awk '
+  $2 ~ /^codebase-memory-mcp-/ &&
+  $2 !~ /^codebase-memory-mcp-ui-/ &&
+  ($2 ~ /\.tar\.gz$/ || $2 ~ /\.zip$/) {
+    alias = $2
+    sub(/^codebase-memory-mcp-/, "codebase-memory-mcp-ui-", alias)
+    print $1 "  " alias
+  }
+' "$CHECKSUMS" > "$aliases"
+
+if [ ! -s "$aliases" ]; then
+  echo "error: no canonical archives matched the ui-* alias rule in $CHECKSUMS;" >&2
+  echo "       publish-legacy-aliases.sh would then publish assets that" >&2
+  echo "       checksums.txt does not cover (#1134)." >&2
+  exit 1
+fi
+
+cat "$aliases" >> "$CHECKSUMS"
+echo "added $(wc -l < "$aliases" | tr -d ' ') legacy alias checksum line(s); $CHECKSUMS now covers $(wc -l < "$CHECKSUMS" | tr -d ' ') names"


### PR DESCRIPTION
Two independent CI/release-gate correctness fixes. Both were found while sweeping open reports; both had already cost real people real time.

## 1. `checksums.txt` does not cover the legacy `ui-*` aliases (#1134)

The `ui-*` archives are byte-identical copies published after `verify`, so they inherit the hash-bound VirusTotal verdicts. They were absent from `checksums.txt`, and `publish-legacy-aliases.sh` documented that as deliberate — "checksums.txt covers the canonical names current installers request."

That reasoning has a hole: the aliases exist **only** for 0.9.x updaters (#1538), and those verify the name they asked for. We fixed the 404 and moved the failure to verification:

```
warning: codebase-memory-mcp-ui-darwin-arm64.tar.gz not found in checksums.txt
error: refusing to install an unverified download
```

**Confirmed on the live v0.10.4 release: 8 `ui-*` archives published, 0 listed in `checksums.txt`.** Every pre-0.10 user who answered the old chooser with "ui" is hard-blocked from updating by any path.

The fix emits the same digest under the legacy name **before** the attestation step, so the attested artifact covers both names. No new bytes and no new scan surface — an alias is a copy, so its sha256 is by construction the one already computed.

**Validation:** run against the real v0.10.4 `checksums.txt`, the generated set is *exactly* the eight `ui-*` assets that release published — no phantom names, none missing. The rule mirrors `publish-legacy-aliases.sh` (`.tar.gz`/`.zip`, never an already-`ui-*` name) and fails closed if it matches nothing, because a name with no asset is as broken as an asset with no name.

## 2. The licence gate's verdict depended on a live HTTP fetch

`audit-license-provenance.py` `curl`ed `apache.org` whenever the gate ran and byte-compared, with `capture_output` and no error check. A failed fetch produced an empty string → unequal → `DIFFERS`, indistinguishable from a real licence change.

This is the O9 pattern: a gating verdict must be a pure function of the tree, not of whether a web server answered. It reddened `security / license-gate` on **PR #1337** — a branch touching `cli.h`, `hook_augment.c`, `test_cli.c` and no licence at all — leaving that contributor blocked for **over two weeks** on a signal unrelated to their change.

Verified before pinning: our vendored copy is byte-identical to the upstream canonical text (11358 bytes both sides, `diff` clean). The Apache-2.0 text is immutable and versioned, so a digest expresses "this is that text" honestly. A mismatch now means our vendored copy changed — exactly, and only, what this audit exists to detect.

The audit passes locally with no network access on the nomic entry.

## Risk review

Every consumer of `checksums.txt` was checked before touching it:

- `attest-build-provenance` — runs *after* generation, so the added lines are inside the attested subject (this is the point).
- `cosign sign-blob` — signs the file as a whole; unaffected.
- `gen-mcpb-registry-entries.sh` — filters for `.mcpb` lines and validates sha256 shape; the added `.tar.gz`/`.zip` lines are well-formed and ignored.
- `smoke-test.sh` — `grep`s for a specific archive name; `codebase-memory-mcp-darwin-arm64.tar.gz` is **not** a substring of `codebase-memory-mcp-ui-darwin-arm64.tar.gz`, so no ambiguous match is introduced.
- Nothing does `sha256sum -c` against `checksums.txt`, so listing a name whose asset is uploaded later does not break any step.

Fixes #1134. Unblocks #1337.
