### PR TITLE
fix(mem): restore mimalloc's Linux arena-commit default (#1654)

### DIFF
--- a/src/foundation/mem.c
+++ b/src/foundation/mem.c
@@ -291,7 +291,36 @@ void cbm_mem_init_with_cap(double ram_fraction, size_t hard_cap_bytes) {
     }
 #endif
 
+    /* Lazy arena commit costs address-space FRAGMENTATION, and on Linux we now
+     * pay it for every allocation in the process. mimalloc commits a range with
+     * mprotect(PROT_READ|PROT_WRITE) over a sub-range of a PROT_NONE reservation
+     * (prim/unix/prim.c), and each partial commit SPLITS the reserved VMA. While
+     * mimalloc only served the bound populations (sqlite, tree_sitter) that was a
+     * handful of mappings. Since #1360 routed ordinary malloc/new through
+     * mimalloc on Linux, an index worker peaked at ~22k mappings against
+     * v0.9.0's 10 (Go corpus, 18 workers). The count tracks CONCURRENCY, not
+     * corpus size — sampled mid-run it was 999 at 1 worker, 8460 at 4 and 11965
+     * at 18, while v0.9.0 stayed at 10 regardless — so every worker thread
+     * fragments the address space independently.
+     *
+     * Two consequences, both reported as #1654 on a 96-CPU/376 GB host: the
+     * mmap/mprotect churn serialises on the kernel's per-process mmap_lock (the
+     * reporter saw 1.2% of extraction in 45 minutes, where v0.9.0 finished the
+     * tree in ~13), and the VMA count climbs toward vm.max_map_count, after
+     * which mmap fails for ANY size — hence mimalloc reporting it "cannot
+     * allocate" 10 KB while `free -g` still showed 246 GB available.
+     *
+     * mimalloc's own default is 2, meaning "eager-commit arenas only on an OS
+     * with overcommit (i.e. linux)" — precisely because commit is free there
+     * until the pages are touched. Overriding it to 0 opted Linux out of the
+     * default written for it. Restore the default on Linux; keep the lazy
+     * setting everywhere else, where commit is NOT free and the upfront-memory
+     * reason for it still holds (Windows especially — see #581). */
+#if defined(__linux__)
+    mem_option_set_verified(mi_option_arena_eager_commit, 2, "arena_eager_commit");
+#else
     mem_option_set_verified(mi_option_arena_eager_commit, 0, "arena_eager_commit");
+#endif
     mem_option_set_verified(mi_option_purge_decommits, SKIP_ONE, "purge_decommits");
     mem_option_set_verified(mi_option_purge_delay, 0, "purge_delay"); /* immediate */
     /* v3 (#832): reclaim abandoned pages on ANY thread's free (=1), restoring the

--- a/tests/test_mem.c
+++ b/tests/test_mem.c
@@ -41,6 +41,32 @@
 
 /* ── mem basic tests ──────────────────────────────────────────── */
 
+/* Since #1360 routed ordinary malloc/new through mimalloc on Linux, the arena
+ * policy governs EVERY allocation in the process, not just the bound
+ * sqlite/tree_sitter populations. With lazy arena commit (0), mimalloc commits
+ * sub-ranges via mprotect(PROT_READ|PROT_WRITE) over a PROT_NONE reservation,
+ * and each partial commit SPLITS the reserved VMA: an index worker on the Go
+ * corpus held ~22k mappings where v0.9.0 held 10, growing with worker count.
+ * That is how #1654's 96-CPU host reached vm.max_map_count, after which mmap
+ * fails for ANY size — 10 KB allocations failing while `free -g` still showed
+ * 246 GB available. mimalloc's own default is 2, meaning "eager-commit arenas
+ * only on an OS that overcommits (i.e. linux)", where commit is free until the
+ * pages are touched; overriding it to 0 opted Linux out of the default written
+ * for Linux. Measured: 22450 -> 17312 mappings, wall time and peak RSS
+ * unchanged. Pin the platform split so the Linux default cannot be silently
+ * opted out again — and keep the lazy setting where commit is NOT free
+ * (Windows especially, see #581). */
+TEST(mem_arena_eager_commit_follows_platform_commit_cost) {
+    cbm_mem_init(0.5);
+    long eager = mi_option_get(mi_option_arena_eager_commit);
+#if defined(__linux__)
+    ASSERT_EQ(eager, 2);
+#else
+    ASSERT_EQ(eager, 0);
+#endif
+    PASS();
+}
+
 TEST(mem_rss_tracking) {
     cbm_mem_init(0.5);
 
@@ -1253,6 +1279,7 @@ TEST(mem_map_attributes_a_known_allocation) {
 
 SUITE(mem) {
     /* mem API */
+    RUN_TEST(mem_arena_eager_commit_follows_platform_commit_cost);
     RUN_TEST(mem_map_attributes_a_known_allocation);
     RUN_TEST(mem_rss_tracking);
     RUN_TEST(mem_collect_reclaims);


### PR DESCRIPTION
## What does this PR do?

Restores mimalloc's own Linux default for `arena_eager_commit`, which cbm had overridden to `0`.

Since #1360 routed ordinary `malloc`/`new` through mimalloc on Linux, the arena policy governs every allocation in the process rather than just the bound sqlite/tree-sitter populations. With lazy arena commit, mimalloc commits sub-ranges via `mprotect(PROT_READ|PROT_WRITE)` over a `PROT_NONE` reservation, and **each partial commit splits the reserved VMA**.

Measured on the Go corpus (Linux arm64, shipped binaries):

| | mimalloc mappings | peak RSS |
|---|---|---|
| v0.9.0, any worker count | **10** | 13.73 GB |
| v0.10.5, 1 worker | 999 | 4.11 GB |
| v0.10.5, 4 workers | 8,460 | 15.99 GB |
| v0.10.5, 18 workers | **11,965** (peak ~22k) | 18.87 GB |

The count tracks **concurrency**, not corpus size. That produces both symptoms reported in #1654 from a 96-CPU/376 GB host: the `mmap`/`mprotect` churn serialises on the kernel's per-process `mmap_lock` (they saw 1.2% of extraction in 45 minutes, where v0.9.0 finished the tree in ~13), and the VMA count climbs toward `vm.max_map_count`, after which `mmap` fails for **any** size — hence mimalloc reporting it could not allocate 10 KB while `free -g` still showed 246 GB available.

mimalloc's default for this option is `2`, meaning *"eager-commit arenas only on an OS that has overcommit (i.e. linux)"* — precisely because commit is free there until pages are touched. Overriding it to `0` opted Linux out of the default written for Linux. Every other platform keeps the lazy setting, where commit is **not** free and the upfront-memory reason still holds (Windows especially, #581).

## Measured effect

Baseline build vs this build, same corpus and host:

| | mappings | wall | peak RSS |
|---|---|---|---|
| baseline | 22,450 | 92.4 s | 19.14 GB |
| this PR | **17,312 (−23%)** | 92.6 s | 19.22 GB |

## Scope — this is a mitigation, not a cure

Deliberately narrow. The remaining ~17k mappings are individual 64 KB–3 MB extraction buffers, each taking its own `mmap`; the worker reserves ~40 GB of address space for ~19 GB of RSS. Pooling those is the durable fix and is **not** attempted here.

Also measured and **rejected** for this PR: additionally raising `purge_delay` cuts mappings to 6,362 (−72%) and wall time by 40%, but raises peak RSS ~16% and OOM-killed a 24 GB host on a corpus the baseline completed. That trade is wrong for exactly the memory-pressured users hitting #1654, and would need a memory-headroom guard.

## Verification

- Linux arm64 full leg (ASan + LeakSanitizer): **176 suites, 0 failing, `=== All tests passed ===`**
- **Revert-check**: with the fix reverted the new guard goes RED (`51 passed, 1 failed`); re-applied, green (`52 passed`). The test binds to the fix.
- macOS `mem` suite: 52 passed.
- Windows: not run locally; the change is `#if defined(__linux__)` so Windows takes the unchanged branch, but CI is the check.

## Checklist

- [x] Every commit is signed off (`git commit -s`)
- [x] Tests pass locally (full Linux leg + macOS mem)
- [x] Lint passes (`make -f Makefile.cbm lint-ci`) — cppcheck + clang-format + NOLINT check all clean
- [x] New behavior is covered by a test (reproduce-first, RED-on-revert proven)

Refs #1654.