### PR TITLE
fix(ci): release gates fail closed on cancelled jobs + refuse malformed version input

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -11,7 +11,10 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 15 min proved too tight on a slow runner day and a timed-out lint reads
+    # as "cancelled", which the release graph must treat as a hard stop; keep
+    # a bound, but one only a genuine hang can hit (normal runtime ~5 min).
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,29 @@ jobs:
     uses: ./.github/workflows/_security.yml
     secrets: inherit
 
+  # ── 0. Preflight: refuse malformed dispatch inputs ──────────────
+  # The tag is inputs.version VERBATIM. A bare "0.10.7" publishes a release the
+  # installers can never resolve (they fetch releases/download/v<version>/...),
+  # and with immutable releases the mis-named tag cannot be retagged, deleted,
+  # or its name reused — the name is burned permanently (2026-08-18 incident).
+  preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Enforce v-prefixed semver version input
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$ ]]; then
+            echo "version OK: $VERSION"
+          else
+            echo "::error::version must be v-prefixed semver (vX.Y.Z), got '$VERSION'"
+            exit 1
+          fi
+
   # ── 1. Lint (cppcheck + clang-format) ───────────────────────────
   lint:
+    needs: [preflight]
     uses: ./.github/workflows/_lint.yml
 
   # ── 2. Tests (all platforms, full suite for release) ────────────
@@ -65,11 +86,19 @@ jobs:
       shard_suites: true
 
   # ── 3. Build all platforms ──────────────────────────────────────
-  # !cancelled() && !failure(): run when `test` is deliberately skipped, but
-  # never when lint or test actually failed.
+  # `test` may be skipped ONLY by the skip_tests input. A skipped `test` is
+  # also what a cancelled/timed-out lint produces (needs-cascade), and the
+  # bare !cancelled() && !failure() form cannot tell those apart: failure()
+  # does not cover a needed job that was CANCELLED, so a lint timeout let the
+  # whole pipeline publish with the test matrix silently skipped
+  # (v0.10.7 incident, 2026-08-18). Require the explicit results.
   build:
-    if: ${{ !cancelled() && !failure() }}
-    needs: [test]
+    if: >-
+      ${{ !cancelled()
+      && needs.lint.result == 'success'
+      && (needs.test.result == 'success'
+          || (inputs.skip_tests && needs.test.result == 'skipped')) }}
+    needs: [lint, test]
     permissions:
       contents: read
       id-token: write
@@ -92,7 +121,7 @@ jobs:
   # an optional phase needs this override, or the phase being optional silently
   # makes the phases after it optional as well.
   smoke:
-    if: ${{ !cancelled() && !failure() }}
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     needs: [build]
     uses: ./.github/workflows/_smoke.yml
     with:
@@ -100,7 +129,7 @@ jobs:
 
   # ── 5. Soak tests ──────────────────────────────────────────────
   soak:
-    if: ${{ !cancelled() && !failure() }}
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     needs: [build]
     uses: ./.github/workflows/_soak.yml
     with:

--- a/tests/test_release_gate_chain_contract.sh
+++ b/tests/test_release_gate_chain_contract.sh
@@ -63,19 +63,46 @@ def cond(job):
         return ""
     return " ".join(m.group(2).split())
 
-# 1. Downstream-of-optional jobs must tolerate a deliberately skipped ancestor.
-#    `test` is the optional phase (if: !inputs.skip_tests); everything after it
-#    in the chain has to survive that.
-TOLERATE = ["build", "smoke", "soak", "release-draft"]
-for job in TOLERATE:
+# 1. Gate conditions: tolerate ONLY the sanctioned skip, fail closed otherwise.
+#    `test` is the optional phase (if: !inputs.skip_tests). The old contract
+#    required the bare `!cancelled() && !failure()` idiom — but failure() does
+#    NOT cover a needed job that was CANCELLED (e.g. a lint timeout), so that
+#    idiom let a cancelled gate cascade test into 'skipped' and publish with
+#    the whole test matrix silently gone (v0.10.7 incident, 2026-08-18).
+#    Each gate must name the results it accepts explicitly.
+GATE_REQUIREMENTS = {
+    "build": [
+        "!cancelled()",
+        "needs.lint.result == 'success'",
+        "needs.test.result == 'success'",
+        "inputs.skip_tests && needs.test.result == 'skipped'",
+    ],
+    "smoke": ["!cancelled()", "needs.build.result == 'success'"],
+    "soak": ["!cancelled()", "needs.build.result == 'success'"],
+    "release-draft": ["!cancelled()", "!failure()"],
+}
+for job, required in GATE_REQUIREMENTS.items():
     if job not in blocks:
         failures.append(f"{job}: job missing from release.yml — update this contract")
         continue
     c = cond(job)
-    if "!cancelled()" not in c or "!failure()" not in c:
-        failures.append(
-            f"{job}: `if:` lacks `!cancelled() && !failure()` (got: {c or '<none>'}).\n"
-            f"      With skip_tests=true a skipped ancestor SKIPS this job silently.")
+    for fragment in required:
+        if fragment not in c:
+            failures.append(
+                f"{job}: `if:` must contain `{fragment}` (got: {c or '<none>'}).\n"
+                f"      Explicit results only: failure() misses CANCELLED needed\n"
+                f"      jobs, and a bare tolerate-skip idiom is fail-open.")
+
+# 1b. The preflight input guard must exist and gate the whole chain: the tag is
+#     inputs.version verbatim, and a bare (non-v-prefixed) version publishes a
+#     release installers can never resolve — unrecoverable under immutability.
+if "preflight" not in blocks:
+    failures.append("preflight: job missing — the version-input guard must exist")
+lint_needs = re.search(r"^    needs:\s*(.*)$", blocks.get("lint", ""), re.M)
+if not lint_needs or "preflight" not in lint_needs.group(1):
+    failures.append(
+        "lint: must `needs: [preflight]` so a malformed version stops the\n"
+        "      chain before any gate runs.")
 
 # 2. The draft must require both runtime gates to have genuinely succeeded.
 draft = cond("release-draft")


### PR DESCRIPTION
The three root causes of the v0.10.7 release incident, closed at the pipeline level (details in the commit message): cancelled-job cascade published with tests skipped; bare version input burned an immutable tag name; lint timeout too tight.

Scope flags (CI-change sensitivity): release workflow_dispatch path only — no PR-CI gating changes, +one 5-second preflight job, no new flake surface (lint bound loosened 15→30m), trigger scope unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RiRAw9RQhvCoshqe7eZHV