### PR TITLE
fix(installer): forward selected clients

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,7 @@ main() {
 REPO="DeusData/codebase-memory-mcp"
 INSTALL_DIR="$HOME/.local/bin"
 SKIP_CONFIG=false
+CLIENTS=""
 CBM_DOWNLOAD_URL="${CBM_DOWNLOAD_URL:-https://github.com/${REPO}/releases/latest/download}"
 
 # Security: every remote hop must remain HTTPS. Plain HTTP is accepted only
@@ -79,25 +80,38 @@ download_file() {
     fi
 }
 
-for arg in "$@"; do
-    case "$arg" in
-        --dir=*)        INSTALL_DIR="${arg#--dir=}" ;;
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --dir=*)        INSTALL_DIR="${1#--dir=}" ;;
+        --dir)
+            [ "$#" -ge 2 ] || { echo "error: --dir requires a path" >&2; exit 1; }
+            shift
+            INSTALL_DIR="$1"
+            ;;
+        --clients=*)    CLIENTS="${1#--clients=}" ;;
+        --clients)
+            [ "$#" -ge 2 ] || { echo "error: --clients requires a comma-separated list" >&2; exit 1; }
+            shift
+            CLIENTS="$1"
+            ;;
         --skip-config)  SKIP_CONFIG=true ;;
         --help|-h)
-            echo "Usage: install.sh [--dir=<path>] [--skip-config]"
+            echo "Usage: install.sh [--dir=<path>] [--clients=<list>] [--skip-config]"
             echo "  --dir PATH     Install directory (default: ~/.local/bin)"
+            echo "  --clients LIST Configure only comma-separated clients"
             echo "  --skip-config  Skip automatic agent configuration"
             exit 0
             ;;
+        --*)
+            echo "error: unknown option: $1" >&2
+            exit 1
+            ;;
+        *)
+            echo "error: unexpected argument: $1" >&2
+            exit 1
+            ;;
     esac
-done
-# Handle --dir <path> (space-separated)
-prev=""
-for arg in "$@"; do
-    if [ "$prev" = "--dir" ]; then
-        INSTALL_DIR="$arg"
-    fi
-    prev="$arg"
+    shift
 done
 
 detect_os() {
@@ -316,6 +330,9 @@ DEST="$INSTALL_DIR/codebase-memory-mcp"
 INSTALL_ARGS=(-y --force "--dir=$INSTALL_DIR")
 if [ "$SKIP_CONFIG" = true ]; then
     INSTALL_ARGS+=(--skip-config)
+fi
+if [ -n "$CLIENTS" ]; then
+    INSTALL_ARGS+=("--clients=$CLIENTS")
 fi
 "$DLBIN" install "${INSTALL_ARGS[@]}"
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -3487,11 +3487,12 @@ if [ "$DL_OS" != "windows" ] && [ -f "$REPO_ROOT/install.sh" ]; then
   INSTALL_TEST_HOME=$(smoke_mktemp_dir)
   INSTALL_TEST_DIR=$(smoke_mktemp_dir)
   mkdir -p "$INSTALL_TEST_HOME/.claude"
+  mkdir -p "$INSTALL_TEST_HOME/.codex"
   mkdir -p "$INSTALL_TEST_HOME/.local/bin"
 
   # 13a: run install.sh with local URL + isolated HOME
   HOME="$INSTALL_TEST_HOME" CBM_DOWNLOAD_URL="$SMOKE_DOWNLOAD_URL" \
-    "$REPO_ROOT/install.sh" --dir="$INSTALL_TEST_DIR" 2>&1 || true
+    "$REPO_ROOT/install.sh" --dir="$INSTALL_TEST_DIR" --clients=claude 2>&1 || true
 
   # 13b: binary placed
   if [ ! -f "$INSTALL_TEST_DIR/codebase-memory-mcp" ]; then
@@ -3531,17 +3532,25 @@ if [ "$DL_OS" != "windows" ] && [ -f "$REPO_ROOT/install.sh" ]; then
     exit 1
   fi
 
-  # 13f: PATH setup — verify shell rc file was modified
+  # 13f: --clients is forwarded by install.sh, so detected but unselected
+  # clients must remain untouched.
+  if [ -f "$INSTALL_TEST_HOME/.codex/config.toml" ]; then
+    echo "FAIL 13f: install.sh ignored --clients=claude and configured Codex"
+    exit 1
+  fi
+  echo "OK 13f: --clients selection forwarded"
+
+  # 13g: PATH setup — verify shell rc file was modified
   RC_FILE=""
   if [ -f "$INSTALL_TEST_HOME/.zshrc" ]; then RC_FILE="$INSTALL_TEST_HOME/.zshrc"; fi
   if [ -f "$INSTALL_TEST_HOME/.bashrc" ]; then RC_FILE="$INSTALL_TEST_HOME/.bashrc"; fi
   if [ -f "$INSTALL_TEST_HOME/.profile" ]; then RC_FILE="$INSTALL_TEST_HOME/.profile"; fi
   if [ -n "$RC_FILE" ] && grep -q '.local/bin' "$RC_FILE" 2>/dev/null; then
-    echo "OK 13f: PATH added to shell rc file"
+    echo "OK 13g: PATH added to shell rc file"
   elif echo "$PATH" | grep -q "$INSTALL_TEST_DIR"; then
-    echo "OK 13f: install dir already on PATH"
+    echo "OK 13g: install dir already on PATH"
   else
-    echo "OK 13f: PATH setup (rc file may not have been modified if already present)"
+    echo "OK 13g: PATH setup (rc file may not have been modified if already present)"
   fi
 
   smoke_rmtree "$INSTALL_TEST_HOME" "$INSTALL_TEST_DIR"


### PR DESCRIPTION
## What does this PR do?

Fixes #1753 by forwarding `install.sh --clients` selections to the downloaded binary's installer.

- Supports both `--clients=claude,codex` and `--clients claude,codex`.
- Preserves `--skip-config` behavior.
- Rejects unknown options and unexpected positional arguments instead of silently ignoring them.
- Extends the installer smoke test with detected Claude and Codex clients, selects only Claude, and verifies Codex remains untouched.

## Validation

- `bash -n install.sh`
- `bash -n scripts/smoke-test.sh`
- `install.sh --help` exposes `--clients`
- Unknown-option parser check rejects unsupported flags
- `git diff --check`

Full release-artifact smoke test was not run locally because it requires the repository's built release fixture.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Tests pass locally (`make -f Makefile.cbm test`)
- [ ] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test (reproduce-first for bug fixes)
