### PR TITLE
feat(build): add a macOS cross-architecture Nix dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,57 @@
     let
       systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+
+      # Cross dev shell (macOS only): build the *other* darwin arch locally.
+      # The native clang already cross-emits object code via -arch (scripts/env.sh
+      # exports ARCHFLAGS), so the only thing missing for a cross link is zlib:
+      # it is the product's single link-time dependency (`-lz`), and the host-arch
+      # copy cannot satisfy an x86_64 link on arm64 or vice versa. This shell puts
+      # the TARGET-arch zlib on the include and link paths, and nothing else.
+      #
+      # Building needs no Rosetta; *running* an x86_64 binary on Apple Silicon
+      # does. The target-arch libs come from prebuilt substitutes, so entering the
+      # shell is a download rather than a cross-build of the dependency tree.
+      #
+      # Returns {} off macOS, where there is no second darwin arch to target.
+      crossDevShells = pkgs:
+        let
+          inherit (nixpkgs) lib;
+          crossTarget =
+            {
+              "aarch64-darwin" = "x86_64-darwin";
+              "x86_64-darwin" = "aarch64-darwin";
+            }
+            .${pkgs.system} or null;
+          mkCrossShell =
+            targetSystem:
+            let
+              tpkgs = nixpkgs.legacyPackages.${targetSystem};
+              targetArch = if targetSystem == "x86_64-darwin" then "x86_64" else "arm64";
+            in
+            pkgs.mkShell {
+              # Host toolchain only — clang comes from the shell stdenv. Deliberately
+              # NOT inputsFrom the default package: that would put the HOST-arch zlib
+              # on the link path, which is exactly the wrong-arch copy this shell
+              # exists to displace.
+              nativeBuildInputs = [ pkgs.gnumake ];
+              shellHook = ''
+                # zlib is consumed as a bare `-lz` / `#include <zlib.h>`, so its
+                # include dir (the header is arch-independent) and lib dir are
+                # supplied by hand. NIX_LDFLAGS is searched ahead of the link's own
+                # -L, so the target-arch slice wins; a host-arch copy that still
+                # reaches ld is skipped as "wrong architecture" rather than
+                # producing a silently mislinked binary.
+                export NIX_CFLAGS_COMPILE="-I${lib.getDev tpkgs.zlib}/include ''${NIX_CFLAGS_COMPILE:-}"
+                export NIX_LDFLAGS="-L${lib.getLib tpkgs.zlib}/lib ''${NIX_LDFLAGS:-}"
+                echo "[cross] target ${targetSystem} — build with: scripts/build.sh --arch ${targetArch}"
+              '';
+            };
+        in
+        lib.optionalAttrs (crossTarget != null) {
+          # `nix develop .#cross` then `scripts/build.sh --arch <target>`.
+          cross = mkCrossShell crossTarget;
+        };
     in
     {
       packages = forAllSystems (pkgs: {
@@ -45,6 +96,6 @@
         default = pkgs.mkShell {
           inputsFrom = [ self.packages.${pkgs.system}.default ];
         };
-      });
+      } // crossDevShells pkgs);
     };
 }


### PR DESCRIPTION
# feat(build): add a macOS cross-architecture Nix dev shell

Addresses #705. Distilled from #724 by @kriswill, credited via `Co-authored-by`.

## What

`nix develop .#cross` on macOS exposes the **other** darwin architecture's zlib, so `scripts/build.sh --arch <target>` can link an x86_64 binary on Apple Silicon and vice versa.

The native clang already cross-*emits* object code via `-arch` (that's what `scripts/env.sh`'s `ARCHFLAGS` does, fixed in #723). The only remaining gap is the link: zlib is the product's single link-time dependency (`-lz`), and the host-arch copy cannot satisfy a cross link. This shell puts the target-arch zlib on the include and link paths, and nothing else.

## Cost

Close to zero:

- **Darwin-gated and opt-in** — `crossDevShells` returns `{}` on Linux, so the attribute doesn't exist there.
- **`flake.lock` untouched, no new flake input.** The target-arch packages resolve through the same pinned nixpkgs, and come from prebuilt substitutes, so entering the shell is a download rather than a cross-build of a dependency tree.
- **The default shell is unchanged.**
- No CI leg exercises it, as @kriswill disclosed on the original PR and I agree with — it's developer tooling, and gating it in CI would cost more than it protects.

One deliberate design point: the cross shell does **not** use `inputsFrom` the default package. Doing so would put the host-arch zlib back on the link path, which is exactly the wrong-arch copy the shell exists to displace.

## What changed from #724

The original also wired `libgit2` through `pkg-config`. That's now dead weight: libgit2 was removed project-wide for GPL-licensing reasons, and I verified it appears nowhere in the tree — not in `flake.nix`, not in any Makefile. Carrying it forward would have reintroduced a GPL-adjacent reference for a library we no longer link. Both it and `pkg-config` are dropped, leaving zlib as the only library the cross shell needs to place, which also makes the shell hook considerably smaller.

## Verification, stated honestly

There is no Nix toolchain on this machine, so I validated by parsing the flake with `nix-instantiate --parse` inside a `nixos/nix` container. That confirms the syntax and — the part most likely to break — that the shell hook's `''${...}` escaping resolves to literal shell expansions rather than Nix interpolations.

What that does **not** cover: actually evaluating the derivation or entering the shell, which needs a macOS host with Nix installed. @kriswill validated the original shell end-to-end and posted a transcript; this version is that shell minus the libgit2/pkg-config wiring, so the untested delta is a deletion. If anyone with Nix on macOS wants to confirm `nix develop .#cross` before this merges, I'd welcome it.
