### PR TITLE
fix(swift): index protocol method requirements as Method nodes

### DIFF
--- a/internal/cbm/extract_defs.c
+++ b/internal/cbm/extract_defs.c
@@ -745,9 +745,14 @@ TSNode cbm_resolve_func_name(TSNode node, CBMLanguage lang) {
         }
 
         /* Swift and newer tree-sitter-kotlin: function_declaration has no `name`
-         * field; the function name is a `simple_identifier` child. */
+         * field; the function name is a `simple_identifier` child. A Swift
+         * protocol requirement (a bodyless `func` inside a protocol) is a
+         * separate node type with the same shape; it is named here as well as in
+         * resolve_method_name because swift_func_types now admits it, so it can
+         * reach the free-function path too and would otherwise land unnamed. */
         if ((lang == CBM_LANG_SWIFT || lang == CBM_LANG_KOTLIN) &&
-            strcmp(kind, "function_declaration") == 0) {
+            (strcmp(kind, "function_declaration") == 0 ||
+             strcmp(kind, "protocol_function_declaration") == 0)) {
             TSNode si = cbm_find_child_by_kind(node, "simple_identifier");
             if (!ts_node_is_null(si)) {
                 return si;
@@ -4579,6 +4584,7 @@ static TSNode find_class_body(TSNode class_node, CBMLanguage lang) {
     static const char *body_types[] = {"class_body",
                                        "interface_body",
                                        "enum_body",
+                                       "protocol_body",
                                        "template_body",
                                        "interface_type",
                                        "struct_type",
@@ -4699,7 +4705,8 @@ static TSNode resolve_method_name(TSNode child, CBMLanguage lang) {
     }
 
     if ((lang == CBM_LANG_SWIFT || lang == CBM_LANG_KOTLIN) &&
-        strcmp(ck, "function_declaration") == 0) {
+        (strcmp(ck, "function_declaration") == 0 ||
+         strcmp(ck, "protocol_function_declaration") == 0)) {
         return cbm_find_child_by_kind(child, "simple_identifier");
     }
 

--- a/internal/cbm/lang_specs.c
+++ b/internal/cbm/lang_specs.c
@@ -547,7 +547,16 @@ static const char *objc_var_types[] = {"declaration", NULL};
 static const char *objc_assign_types[] = {"assignment_expression", NULL};
 
 // ==================== SWIFT ====================
-static const char *swift_func_types[] = {"function_declaration", "macro_declaration", NULL};
+// protocol_function_declaration: a protocol's method requirements. Needed here as
+// well as in the name resolvers — extract_class_methods gates on this set, so
+// without the entry the requirement is walked and then discarded.
+static const char *swift_func_types[] = {"function_declaration", "protocol_function_declaration",
+                                         "macro_declaration", NULL};
+// KNOWN GAP: struct_declaration and enum_declaration are not node types in the
+// vendored tree-sitter-swift grammar — it models both as class_declaration — so
+// these two entries never match anything, and a bare Swift `enum` is labeled
+// Class rather than Enum. Left in place deliberately: they are the only marker
+// of that modelling gap, and deleting them would hide it. Tracked separately.
 static const char *swift_class_types[] = {"class_declaration", "protocol_declaration",
                                           "struct_declaration", "enum_declaration", NULL};
 static const char *swift_field_types[] = {"property_declaration", NULL};

--- a/tests/test_extraction.c
+++ b/tests/test_extraction.c
@@ -655,6 +655,21 @@ TEST(swift_class) {
     PASS();
 }
 
+TEST(swift_protocol) {
+    /* A protocol requirement is a bodyless func inside a protocol body. Swift
+     * codebases are heavily protocol-driven, so the requirement is very often
+     * the declaration a reader is actually looking for — before this it was
+     * absent from the graph entirely. */
+    CBMFileResult *r = extract("protocol StudyRunning {\n    func generate() -> String\n}\n",
+                               CBM_LANG_SWIFT, "t", "StudyRunning.swift");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+    ASSERT(has_def(r, "Interface", "StudyRunning"));
+    ASSERT(has_def(r, "Method", "generate"));
+    cbm_free_result(r);
+    PASS();
+}
+
 /* --- Kotlin --- */
 TEST(kotlin_function) {
     CBMFileResult *r = extract("fun greet(name: String): String = \"Hello $name\"\nfun main() { "
@@ -5451,6 +5466,7 @@ SUITE(extraction) {
     RUN_TEST(csharp_class);
     RUN_TEST(csharp_interface);
     RUN_TEST(swift_class);
+    RUN_TEST(swift_protocol);
     RUN_TEST(kotlin_function);
     RUN_TEST(kotlin_class);
     RUN_TEST(scala_function);


### PR DESCRIPTION
# fix(swift): index protocol method requirements as Method nodes

Advances #43. Distilled from #613 by @xbsjason, credited via `Co-authored-by`.

## The gap

A Swift protocol requirement — a bodyless `func generate() -> String` inside a `protocol` — produced **no node at all**. Swift codebases are heavily protocol-driven, so the requirement is frequently the declaration a reader actually wants, and "who declares `generate()`" simply had no answer.

## What delivers it

Three edits, and I verified each is load-bearing by removing it and watching the test fail:

1. **`protocol_body`** joins the class-body types in `find_class_body` — without it, a protocol's members are never walked.
2. **`protocol_function_declaration`** joins `swift_func_types` — `extract_class_methods` gates on that set, so without the entry the requirement gets walked and then discarded.
3. **Both name resolvers** accept the node. It has the same `simple_identifier` shape as `function_declaration`, and since it now reaches the free-function path too, naming it in only one place would leave a latent unnamed-def bug.

## What I dropped from #613, and why

**The enum/struct half.** #613 also tried to make bare `struct`/`enum` produce `Class`/`Enum` nodes, and both of its assertions fail on CI (`lsan-macos`, `test-unix`, and Windows alike). The cause is worth recording: **tree-sitter-swift has no `struct_declaration` or `enum_declaration` node type** — it models both as `class_declaration`:

```
class_declaration:             2
protocol_declaration:          1
protocol_function_declaration: 1
protocol_body:                 1
struct_declaration:            0   ← not a symbol
enum_declaration:              0   ← not a symbol
```

So those two entries in `swift_class_types` have been inert since they were written, `class_label_for_kind`'s `enum_declaration → "Enum"` branch never fires for Swift, and a bare Swift `enum` is labeled `Class`. That is a genuine pre-existing modelling gap. I've left the dead entries in place with a comment naming the problem — deleting them would tidy the code while erasing the only marker that the gap exists — and it stays out of this PR.

**A `find_first_descendant_by_kind` rescue** in `extract_class_methods`. Removing it changes no test outcome once the function-type entry is present, so it was carrying nothing.

The result is three production edits instead of six, with no behaviour left unproven.

## Tests

`swift_protocol` asserts `Interface:StudyRunning` + `Method:generate`. It is **binding**: applied against unmodified `main`, it fails on exactly `ASSERT(has_def(r, "Method", "generate"))`.

## Verification

macOS ASan/UBSan: extraction, grammar_labels, grammar_probe_g, grammar_regression, lang_contract, parse_coverage — **384 passed, 0 failed**. `lint-ci` green.
