### PR TITLE
test(java): pin enum constants surviving alongside enum methods

### DIFF
--- a/tests/test_extraction.c
+++ b/tests/test_extraction.c
@@ -472,6 +472,15 @@ TEST(java_enum_dedup_preserves_calls_issue1234) {
     ASSERT(has_def(r, "Enum", "Day"));
     ASSERT(has_def(r, "Method", "isWeekend"));
     ASSERT(has_def(r, "Method", "label"));
+    /* The enum CONSTANTS must survive alongside the methods. Reaching the
+     * methods means descending into enum_body_declarations, and the tempting
+     * way to do that -- redirecting the shared find_class_body -- also makes
+     * the constants unreachable, because they are siblings of that node rather
+     * than children. find_class_member_body exists to descend for members only
+     * and leave find_class_body (which extract_enum_members uses) alone; these
+     * two assertions are what stop that distinction being collapsed again. */
+    ASSERT(has_def(r, "Variable", "MON"));
+    ASSERT(has_def(r, "Variable", "SUN"));
     ASSERT(has_def(r, "Class", "DayUtil"));
     ASSERT(has_def(r, "Method", "describe"));
     ASSERT_EQ(count_defs_with_label(r, "Function"), 0);


### PR DESCRIPTION
Closes the gap that #984 by @sahil-mangla exposed. Credited via `Co-authored-by`.

### The feature already works

Java enum methods resolve correctly on `main` today: `find_class_member_body` descends into `enum_body_declarations` (Java-gated) while `find_class_body` keeps returning `enum_body`, which is what `extract_enum_members` needs to reach the constants — they are **siblings** of `enum_body_declarations`, not children. I verified that empirically with a probe asserting the enum label, its methods **and** its constants together; it passes unmodified.

### But the distinction was unguarded

`java_enum_dedup_preserves_calls_issue1234` asserted the methods and the absence of duplicate `Function` defs — but never asserted the **constants**. So collapsing those two lookups into one would have passed the entire suite while silently dropping every enum constant from the graph.

That is exactly what #984 proposed: redirecting the shared `find_class_body`. Its own `Method` assertion would have gone green, and the loss would have shipped invisibly.

### The guard

Two assertions added to the existing test rather than a near-duplicate test, since the fixture already has the right shape.

**Verified binding**: pointing `extract_enum_members` at `find_class_member_body` — the collapse #984 proposed — reddens exactly the new `Variable` assertions and nothing else.

The comment at the assertions names *why* the two lookups differ, so the next person to touch enum extraction finds the reasoning rather than rediscovering it through a silent regression.