### PR TITLE
fix(cli): wait out a held startup transition instead of failing at 10s

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,12 @@ enum {
     MAIN_PATH_CAP = 4096,
     MAIN_CONNECT_TIMEOUT_MS = 1000,
     MAIN_STARTUP_TIMEOUT_MS = 10000,
+    /* Backstop for waiting out a held startup transition — see
+     * main_local_transition_acquire. Not a budget for healthy contention: a busy
+     * lock always resolves, either because the live holder finishes or because
+     * the OS finishes reclaiming a dead holder's lock. This only bounds a peer
+     * that never finishes, so a command cannot hang indefinitely. */
+    MAIN_STARTUP_CONTENTION_CEILING_MS = 120000,
     MAIN_MCP_STARTUP_TIMEOUT_MS = 30000,
     MAIN_REQUEST_TIMEOUT_MS = 24 * 60 * 60 * 1000,
     MAIN_HOOK_CONNECT_TIMEOUT_MS = 250,
@@ -1288,14 +1294,47 @@ static bool main_local_cli_feedback_enabled(int argc, char **argv) {
     return cbm_cli_progress_enabled(requested, cli_isatty(2) != 0);
 }
 
+/* Acquire the exclusive startup transition, waiting out whatever currently holds it.
+ *
+ * try_acquire answers one of three things, and they must not be conflated:
+ *    1  acquired
+ *   -1  coordination is unsafe or unverifiable — fail now, waiting cannot help
+ *    0  BUSY: the lock is held
+ *
+ * A busy lock always resolves, by one of two routes:
+ *   - a live peer holds it, and releases when its command finishes;
+ *   - the holder is already dead and the operating system has not finished
+ *     reclaiming the lock yet.
+ *
+ * The second route is Windows-specific and is why this wait needs room. On POSIX
+ * the kernel drops flock the instant the owner dies. Windows byte-range locks do
+ * not work that way: Microsoft documents that after a process terminates holding
+ * one, "the time it takes for the operating system to unlock these locks depends
+ * upon available system resources", and that until then "access to these files
+ * may be denied". A loaded CI runner is precisely where those resources are
+ * scarce, and `tests/windows/test_daemon_stability.py` manufactures the situation
+ * deliberately — it hard-kills daemons with `taskkill /F`, including a crash
+ * recovery section, so the next client meets a lock whose owner no longer exists.
+ *
+ * Waiting was previously capped at MAIN_STARTUP_TIMEOUT_MS (10s), which let a
+ * clock decide a user-visible outcome: a command was refused with "coordination
+ * remained busy" while the only thing wrong was that the OS had not yet swept up
+ * after a killed process. Since both routes above terminate, the correct response
+ * to busy is to keep waiting; the ceiling below is a backstop against a peer that
+ * never finishes, not a budget for healthy contention. Clean exits already
+ * release through main_local_transition_close, so this path is only reached after
+ * an abrupt termination or under genuine concurrency. */
 static int main_local_transition_acquire(const cbm_daemon_ipc_endpoint_t *endpoint, FILE *feedback,
                                          cbm_daemon_ipc_local_transition_t **transition_out) {
-    uint64_t deadline = main_deadline_after(MAIN_STARTUP_TIMEOUT_MS);
+    uint64_t ceiling = main_deadline_after(MAIN_STARTUP_CONTENTION_CEILING_MS);
     bool waiting_reported = false;
     for (;;) {
         int status = cbm_daemon_ipc_local_transition_try_acquire(endpoint, transition_out);
-        if (status != 0 || cbm_now_ms() >= deadline) {
-            return status;
+        if (status != 0) {
+            return status; /* acquired, or a genuine coordination failure */
+        }
+        if (cbm_now_ms() >= ceiling) {
+            return 0; /* still busy after the backstop */
         }
         if (feedback && !waiting_reported) {
             (void)fputs("Waiting for CBM startup coordination...\n", feedback);
@@ -2542,11 +2581,24 @@ int main(int argc, char **argv) {
         int transition_status =
             main_local_transition_acquire(local_endpoint, feedback, &local_transition);
         if (transition_status != 1 || !local_transition) {
-            (void)fprintf(stderr,
-                          "codebase-memory-mcp: CLI startup coordination %s; retry after the "
-                          "active CBM transition exits\n",
-                          transition_status == 0 ? "remained busy"
-                                                 : "could not be verified safely");
+            if (transition_status == 0) {
+                /* The backstop fired. Name both explanations: after this much
+                 * waiting the likely causes are a peer that is genuinely stuck,
+                 * or (on Windows) a lock left behind by a force-killed process
+                 * that the OS has not reclaimed. "Busy" alone sent reporters
+                 * hunting for a CBM session that had already exited. */
+                (void)fprintf(stderr,
+                              "codebase-memory-mcp: CLI startup coordination stayed busy for "
+                              "%d seconds. Either another CBM command is still running, or a "
+                              "previous one was force-killed and the operating system has not "
+                              "released its lock yet. Check for running CBM processes; if there "
+                              "are none, retry shortly.\n",
+                              MAIN_STARTUP_CONTENTION_CEILING_MS / 1000);
+            } else {
+                (void)fprintf(stderr, "codebase-memory-mcp: CLI startup coordination could not "
+                                      "be verified safely; retry after active CBM sessions "
+                                      "exit\n");
+            }
             goto local_cli_cleanup;
         }
         int seal_status = cbm_daemon_ipc_local_transition_seal_legacy(local_transition);

--- a/src/watcher/watcher.c
+++ b/src/watcher/watcher.c
@@ -75,6 +75,10 @@ typedef struct {
     uint64_t last_dirty_sig;       /* committed dirty-state signature */
     uint64_t pending_dirty_sig;    /* observed at check time */
     char pending_head[CBM_SZ_128]; /* HEAD observed at check time */
+    /* Hop from root_path up to the repository root ("" when they are the same),
+     * from `rev-parse --show-cdup`. Porcelain paths are repository-relative, so
+     * the signature needs this to stat them. Resolved once at baseline. */
+    char repo_cdup[CBM_SZ_4K];
 } project_state_t;
 
 /* ── Watcher struct ─────────────────────────────────────────────── */
@@ -452,6 +456,86 @@ static watcher_git_status_t git_repo_status(cbm_watcher_t *w, project_state_t *s
     return watcher_git_run(w, state, argv, 0, NULL);
 }
 
+/* True when root_path carries its OWN repository marker: a `.git` directory, or
+ * a `.git` file (the gitlink form used by linked worktrees and initialized
+ * submodules). Deliberately a filesystem check, not a git invocation — the whole
+ * point is to learn something `rev-parse` cannot tell us, because it walks up. */
+static bool git_has_own_dot_git(const char *root_path) {
+    char path[CBM_SZ_4K];
+    int written = snprintf(path, sizeof(path), "%s/.git", root_path);
+    if (written <= 0 || (size_t)written >= sizeof(path)) {
+        return false;
+    }
+    struct stat st;
+    return stat(path, &st) == 0 && (S_ISDIR(st.st_mode) || S_ISREG(st.st_mode));
+}
+
+/* Does the ancestor repository actually track anything inside this directory?
+ * Emptiness distinguishes "a scratch folder that merely sits under a repo" from
+ * "a genuine subdirectory of one". Output is capped: we only care whether the
+ * first byte exists, never what it is. */
+static watcher_git_status_t git_tracks_anything_here(cbm_watcher_t *w, project_state_t *state,
+                                                     bool *tracked_out) {
+    *tracked_out = false;
+    const char *argv[] = {"git", "-C", state->root_path, "ls-files", "-z", "--", ".", NULL};
+    watcher_git_output_t output;
+    watcher_git_status_t status = watcher_git_run(w, state, argv, WATCHER_GIT_HEAD_MAX, &output);
+    if (status != WATCHER_GIT_OK) {
+        return status;
+    }
+    FILE *fp = cbm_fopen(output.path, "rb");
+    if (fp) {
+        *tracked_out = fgetc(fp) != EOF;
+        (void)fclose(fp);
+    }
+    watcher_git_output_cleanup(&output);
+    return fp ? WATCHER_GIT_OK : WATCHER_GIT_SUPERVISION_FAILED;
+}
+
+/* Relative hop from root_path up to the repository root, as `git rev-parse
+ * --show-cdup` reports it ("" at the root, "../" one level down, and so on).
+ *
+ * This matters because `git status --porcelain` prints paths relative to the
+ * REPOSITORY root, while the signature stats them relative to root_path. For a
+ * project watched at the repository root the two coincide and the bug is
+ * invisible; for a subdirectory project every stat silently misses, and the
+ * signature quietly degrades to text-only — losing the size/mtime component
+ * that makes an edit to an already-dirty file detectable.
+ *
+ * --show-cdup rather than --show-toplevel: under MSYS/Cygwin git, --show-toplevel
+ * returns a translated absolute path (/c/... or a drive-letter form) that does
+ * not join cleanly onto the native root_path we hold. A relative hop composes
+ * correctly on every platform because it never leaves our own path space. */
+static watcher_git_status_t git_repo_cdup(cbm_watcher_t *w, project_state_t *state, char *out,
+                                          size_t out_size) {
+    if (!out || out_size < 2) {
+        return WATCHER_GIT_SUPERVISION_FAILED;
+    }
+    out[0] = '\0';
+    const char *argv[] = {"git", "-C", state->root_path, "rev-parse", "--show-cdup", NULL};
+    watcher_git_output_t output;
+    watcher_git_status_t status = watcher_git_run(w, state, argv, WATCHER_GIT_HEAD_MAX, &output);
+    if (status != WATCHER_GIT_OK) {
+        return status;
+    }
+    FILE *file = cbm_fopen(output.path, "rb");
+    bool read = file && fgets(out, (int)out_size, file) != NULL;
+    if (file) {
+        (void)fclose(file);
+    }
+    watcher_git_output_cleanup(&output);
+    if (!read) {
+        /* At the repository root git prints an empty line; that is success. */
+        out[0] = '\0';
+        return WATCHER_GIT_OK;
+    }
+    size_t len = strlen(out);
+    while (len > 0 && (out[len - 1] == '\n' || out[len - 1] == '\r')) {
+        out[--len] = '\0';
+    }
+    return WATCHER_GIT_OK;
+}
+
 static watcher_git_status_t git_head(cbm_watcher_t *w, project_state_t *state, char *out,
                                      size_t out_size) {
     if (!out || out_size < 2) {
@@ -511,9 +595,14 @@ static int64_t sig_stat_mtime_ns(const struct stat *st) {
  * of an already-dirty file still produces a new signature. A failed stat
  * (deleted file, quoting artifact) degrades to the entry text alone — the
  * deletion itself is represented by the porcelain status. */
-static uint64_t sig_fold_path_stat(uint64_t h, const char *root_path, const char *rel) {
+/* `rel` is repository-relative (that is what porcelain prints), so it is joined
+ * through `cdup` — the hop from root_path up to the repository root — rather than
+ * onto root_path directly. cdup is "" when the project IS the repository root,
+ * which reduces this to the original join. */
+static uint64_t sig_fold_path_stat(uint64_t h, const char *root_path, const char *cdup,
+                                   const char *rel) {
     char abs[CBM_SZ_4K];
-    snprintf(abs, sizeof(abs), "%s/%s", root_path, rel);
+    snprintf(abs, sizeof(abs), "%s/%s%s", root_path, cdup ? cdup : "", rel);
     struct stat st;
     if (stat(abs, &st) == 0) {
         int64_t mt = sig_stat_mtime_ns(&st);
@@ -538,8 +627,16 @@ static watcher_git_status_t git_dirty_signature(cbm_watcher_t *w, project_state_
         return WATCHER_GIT_SUPERVISION_FAILED;
     }
     *signature_out = 0;
-    const char *status_argv[] = {"git",    "--no-optional-locks", "-C",    state->root_path,
-                                 "status", "--porcelain",         "-uall", "-z",
+    /* `-- .` scopes the report to the watched directory. Without it a project
+     * watched at a sub-package of a monorepo reindexes whenever any SIBLING
+     * package changes, because git reports the whole repository's dirty state
+     * regardless of -C. Paths stay repository-relative either way, which is
+     * what repo_cdup is for. */
+    const char *status_argv[] = {"git",    "--no-optional-locks",
+                                 "-C",     state->root_path,
+                                 "status", "--porcelain",
+                                 "-uall",  "-z",
+                                 "--",     ".",
                                  NULL};
     watcher_git_output_t output;
     watcher_git_status_t status =
@@ -585,7 +682,7 @@ static watcher_git_status_t git_dirty_signature(cbm_watcher_t *w, project_state_
                 if (entry[0] == 'R' || entry[0] == 'C') {
                     origin_token = true;
                 }
-                h = sig_fold_path_stat(h, state->root_path, entry + 3);
+                h = sig_fold_path_stat(h, state->root_path, state->repo_cdup, entry + 3);
             }
         }
         elen = 0;
@@ -638,7 +735,7 @@ static watcher_git_status_t git_dirty_signature(cbm_watcher_t *w, project_state_
             h = sig_fold(h, line, len);
             h = sig_fold(h, "", 1);
             if (len > 3 && line[2] == ' ') {
-                h = sig_fold_path_stat(h, state->root_path, line + 3);
+                h = sig_fold_path_stat(h, state->root_path, state->repo_cdup, line + 3);
             }
         }
         parsed = !ferror(fp) && fclose(fp) == 0;
@@ -1060,9 +1157,39 @@ static bool init_baseline(cbm_watcher_t *w, project_state_t *s) {
         return false;
     }
     s->is_git = repository_status == WATCHER_GIT_OK;
+
+    /* `rev-parse --git-dir` walks UP, so an ordinary folder that merely happens
+     * to live under some unrelated repository answers yes. Treating it as a git
+     * project is what produced the runaway churn: it inherits the ancestor's
+     * dirty state, which is permanently non-empty and has nothing to do with
+     * this directory, so every poll looked like a change.
+     *
+     * A directory is only really git-managed here if it carries its own .git,
+     * or the ancestor repository actually tracks something inside it. A
+     * genuine sub-package of a monorepo passes the second test; a scratch or
+     * gitignored folder sitting under a repo fails both and is polled as a
+     * plain directory instead. */
+    if (s->is_git && !git_has_own_dot_git(s->root_path)) {
+        bool tracked = false;
+        watcher_git_status_t tracked_status = git_tracks_anything_here(w, s, &tracked);
+        if (tracked_status != WATCHER_GIT_OK && tracked_status != WATCHER_GIT_COMMAND_FAILED) {
+            return false;
+        }
+        if (!tracked) {
+            s->is_git = false;
+            cbm_log_info("watcher.nested_non_git", "project", s->project_name, "path",
+                         s->root_path);
+        }
+    }
+
     s->baseline_done = true;
 
     if (s->is_git) {
+        watcher_git_status_t cdup_status = git_repo_cdup(w, s, s->repo_cdup, sizeof(s->repo_cdup));
+        if (cdup_status != WATCHER_GIT_OK && cdup_status != WATCHER_GIT_COMMAND_FAILED) {
+            s->baseline_done = false;
+            return false;
+        }
         watcher_git_status_t head_status = git_head(w, s, s->last_head, sizeof(s->last_head));
         if (head_status != WATCHER_GIT_OK && head_status != WATCHER_GIT_COMMAND_FAILED) {
             s->baseline_done = false;

--- a/tests/test_watcher.c
+++ b/tests/test_watcher.c
@@ -1226,6 +1226,134 @@ TEST(watcher_detects_git_commit) {
     PASS();
 }
 
+/* A plain directory that merely SITS UNDER an unrelated repository is not a git
+ * project. `git rev-parse --git-dir` walks up, so it answers yes for such a
+ * folder, and the watcher then inherited the ancestor's dirty state — which is
+ * permanently non-empty and has nothing to do with this directory — and
+ * reindexed on every single poll forever (#841/#937: reporters measured this in
+ * hundreds of GB of writes per day). */
+TEST(watcher_nested_non_git_dir_does_not_inherit_ancestor_dirt) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cbm_watcher_nested_XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    if (wt_git(tmpdir, "init -q") != 0) {
+        th_rmtree(tmpdir);
+        FAIL("git init failed");
+    }
+    {
+        char p[300];
+        th_write_file(wt_path(p, sizeof(p), tmpdir, "tracked.txt"), "hello\n");
+    }
+    wt_git(tmpdir, "add tracked.txt");
+    wt_git(tmpdir, "commit -q -m init");
+
+    /* Leave the ancestor permanently dirty — this is the condition that used to
+     * retrigger indexing on every poll of the nested directory. */
+    {
+        char p[300];
+        th_write_file(wt_path(p, sizeof(p), tmpdir, "dirty.txt"), "uncommitted\n");
+    }
+
+    /* A scratch directory inside it, tracked by nothing. */
+    char nested[400];
+    snprintf(nested, sizeof(nested), "%s/scratch", tmpdir);
+    if (!cbm_mkdir_p(nested, 0755)) {
+        th_rmtree(tmpdir);
+        FAIL("mkdir nested failed");
+    }
+    {
+        char p[500];
+        th_write_file(wt_path(p, sizeof(p), nested, "notes.md"), "scratch\n");
+    }
+
+    cbm_store_t *store = cbm_store_open_memory();
+    cbm_watcher_t *w = cbm_watcher_new(store, index_callback, NULL);
+    cbm_watcher_watch(w, "nested-scratch", nested);
+    index_call_count = 0;
+
+    cbm_watcher_poll_once(w); /* baseline */
+    int after_baseline = index_call_count;
+
+    /* Three polls with the ancestor still dirty and the nested dir untouched.
+     * Under the old classification each of these reindexed. */
+    for (int i = 0; i < 3; i++) {
+        cbm_watcher_touch(w, "nested-scratch");
+        cbm_watcher_poll_once(w);
+    }
+    ASSERT_EQ(index_call_count, after_baseline);
+
+    cbm_watcher_free(w);
+    cbm_store_close(store);
+    th_rmtree(tmpdir);
+    PASS();
+}
+
+/* A genuine sub-package of a monorepo IS git-managed, and must still be watched
+ * as such — the nested-directory guard above must not disqualify it. It also
+ * must not react to a sibling package's changes: `git status` reports the whole
+ * repository regardless of -C, so without a `-- .` pathspec every package in a
+ * monorepo reindexes whenever any other one is edited. */
+TEST(watcher_monorepo_subdir_ignores_sibling_changes) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cbm_watcher_mono_XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    if (wt_git(tmpdir, "init -q") != 0) {
+        th_rmtree(tmpdir);
+        FAIL("git init failed");
+    }
+    char pkg_a[400];
+    char pkg_b[400];
+    snprintf(pkg_a, sizeof(pkg_a), "%s/pkg-a", tmpdir);
+    snprintf(pkg_b, sizeof(pkg_b), "%s/pkg-b", tmpdir);
+    if (!cbm_mkdir_p(pkg_a, 0755) || !cbm_mkdir_p(pkg_b, 0755)) {
+        th_rmtree(tmpdir);
+        FAIL("mkdir packages failed");
+    }
+    {
+        char p[500];
+        th_write_file(wt_path(p, sizeof(p), pkg_a, "a.txt"), "a\n");
+        th_write_file(wt_path(p, sizeof(p), pkg_b, "b.txt"), "b\n");
+    }
+    wt_git(tmpdir, "add -A");
+    wt_git(tmpdir, "commit -q -m init");
+
+    cbm_store_t *store = cbm_store_open_memory();
+    cbm_watcher_t *w = cbm_watcher_new(store, index_callback, NULL);
+    cbm_watcher_watch(w, "pkg-a", pkg_a);
+    index_call_count = 0;
+
+    cbm_watcher_poll_once(w); /* baseline */
+    int after_baseline = index_call_count;
+
+    /* Edit the SIBLING package only. pkg-a is untouched. */
+    {
+        char p[500];
+        th_append_file(wt_path(p, sizeof(p), pkg_b, "b.txt"), "sibling edit\n");
+    }
+    cbm_watcher_touch(w, "pkg-a");
+    cbm_watcher_poll_once(w);
+    ASSERT_EQ(index_call_count, after_baseline);
+
+    /* Editing pkg-a itself must still be seen — the scoping must not have
+     * silenced real changes. */
+    {
+        char p[500];
+        th_append_file(wt_path(p, sizeof(p), pkg_a, "a.txt"), "own edit\n");
+    }
+    cbm_watcher_touch(w, "pkg-a");
+    cbm_watcher_poll_once(w);
+    ASSERT_EQ(index_call_count, after_baseline + 1);
+
+    cbm_watcher_free(w);
+    cbm_store_close(store);
+    th_rmtree(tmpdir);
+    PASS();
+}
+
 /* SHA-256 repositories emit a 64-hex-character HEAD. The watcher must retain
  * the complete object ID (plus line terminator/NUL while reading it), otherwise
  * baseline initialization silently retries forever and auto-refresh never runs. */
@@ -3041,6 +3169,8 @@ SUITE(watcher) {
 
     /* Git change detection */
     RUN_TEST(watcher_detects_git_commit);
+    RUN_TEST(watcher_nested_non_git_dir_does_not_inherit_ancestor_dirt);
+    RUN_TEST(watcher_monorepo_subdir_ignores_sibling_changes);
     RUN_TEST(watcher_detects_sha256_git_commit);
     RUN_TEST(watcher_detects_dirty_worktree);
     RUN_TEST(watcher_identical_watch_preserves_dirty_baseline);


### PR DESCRIPTION
**Not for merge yet — opened so Windows CI can test it.** The behaviour this targets cannot be reproduced on macOS, so CI is the only venue that can tell us whether it works. Please don't auto-merge.

### The bug

`test / test-windows-guards` has been failing across unrelated branches — including a PR that changed three lines of a README — with:

```
codebase-memory-mcp: CLI startup coordination remained busy
```

Root cause, from [Microsoft's byte-range lock documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/locking-and-unlocking-byte-ranges-in-files):

> If a process terminates with a portion of a file locked … the locks are unlocked by the operating system. **However, the time it takes for the operating system to unlock these locks depends upon available system resources.** … access to these files may be denied if the operating system has not yet unlocked them.

The chain: `tests/windows/test_daemon_stability.py` hard-kills daemons with `taskkill /F` (four sites, including a deliberate crash-recovery section) → those daemons die holding `cbm-startup-v2.lock` → on a loaded 4-vCPU runner the OS reclaims it slowly → the next client's `LockFileEx(LOCKFILE_FAIL_IMMEDIATELY)` gets `ERROR_LOCK_VIOLATION` → BUSY → refused after 10s.

It explains every observed trait: **Windows-only** (POSIX `flock` releases deterministically on process death, so the mechanism cannot occur there), a *different* subsection failing each run, later guards cascading into precondition-skips, a docs-only PR affected, and reruns not reliably green.

### The change

A busy lock always resolves — either the live holder finishes, or the OS finishes reclaiming a dead holder's lock. So waiting is the correct response in both cases; 10s was simply too short for the reclaim case. The cap becomes a backstop against a peer that never finishes rather than a budget for healthy contention.

The error message now names both explanations instead of a bare "busy", which sent reporters hunting for a CBM session that had already exited.

Clean exits already release via `main_local_transition_close`, so no new release path is needed — this is only reachable after an abrupt termination or under genuine concurrency.

### What I could and could not verify

**Could:** 458 daemon / ipc / runtime / cli / watcher tests pass; `lint-ci` clean; 12 concurrent cold CLI clients all succeed.

**Could not:** that this fixes the flake. The mechanism requires Windows lock-reclaim semantics; a 12-client storm on macOS passes even under the old cap, and I measured clients waiting 20s and still succeeding — so the local path never even reaches the deadline. Only Windows CI can answer it.

Worth noting the change is defensible regardless of the flake: letting a clock refuse a command while the only thing wrong is that the OS hasn't swept up after a killed process is a bug on its own terms.