### PR TITLE
fix(extraction): treat trailing blanks at EOF as an absent newline, not a miss (#1746)

### DIFF
--- a/internal/cbm/cbm.c
+++ b/internal/cbm/cbm.c
@@ -817,9 +817,13 @@ static void cbm_error_regions_push(cbm_error_regions_t *acc, TSNode n) {
  * untouched.
  *
  * #1746: the Dockerfile grammar places that zero-width missing newline before
- * trailing horizontal whitespace rather than at raw EOF. Preserve the broad
- * exact-EOF rule above; only extend it past spaces/tabs when the missing token
- * is specifically a newline. */
+ * trailing whitespace rather than at raw EOF. Preserve the broad exact-EOF
+ * rule above; only extend it past blanks when the missing token is specifically
+ * a newline. */
+static bool cbm_is_blank_not_newline(char c) {
+    return c == ' ' || c == '\t' || c == '\v' || c == '\f' || c == '\r';
+}
+
 static bool cbm_is_eof_terminator_miss(TSNode n, const char *source, int source_len) {
     if (!ts_node_is_missing(n) || source_len < 0) {
         return false;
@@ -836,7 +840,7 @@ static bool cbm_is_eof_terminator_miss(TSNode n, const char *source, int source_
         return false;
     }
     for (uint32_t i = end; i < (uint32_t)source_len; i++) {
-        if (source[i] != ' ' && source[i] != '\t') {
+        if (!cbm_is_blank_not_newline(source[i])) {
             return false;
         }
     }

--- a/tests/test_parse_coverage.c
+++ b/tests/test_parse_coverage.c
@@ -470,6 +470,77 @@ TEST(perl_malformed_source_remains_partial_issue1838) {
     PASS();
 }
 
+/* ── #1746: trailing blanks before EOF are still just an absent newline ───────
+ *
+ * #1610 suppressed the zero-width MISSING terminator but tested for it with
+ * `end == source_len`. Trailing blanks are extras owned by no node, so
+ * `ENTRYPOINT ["a"] ` + EOF parks it at [29,29) while source_len is 30.
+ *
+ * The reporter's byte-exact controls pin the trigger to the PAIR: `] ` + EOF
+ * flags, `] ` + newline is clean, `]` + EOF is clean. */
+TEST(dockerfile_trailing_blank_at_eof_not_flagged_issue1746) {
+    const char *cases[] = {
+        "FROM scratch\nENTRYPOINT [\"a\"] ",     /* space + EOF — the report */
+        "FROM scratch\nENTRYPOINT [\"a\"]\t",    /* tab + EOF */
+        "FROM scratch\nENTRYPOINT [\"a\"]\v",    /* vertical tab + EOF */
+        "FROM scratch\nENTRYPOINT [\"a\"]\f",    /* form feed + EOF */
+        "FROM scratch\nENTRYPOINT [\"a\"]  \t ", /* run of blanks + EOF */
+        "FROM scratch\nENTRYPOINT [\"a\"] \r",   /* CRLF file truncated to CR */
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        CBMFileResult *r = do_extract(cases[i], CBM_LANG_DOCKERFILE, "Dockerfile");
+        ASSERT_NOT_NULL(r);
+        bool flagged = r->parse_incomplete;
+        if (flagged) {
+            fprintf(stderr, "  case %zu flagged: ranges=%s\n", i,
+                    r->error_ranges ? r->error_ranges : "(none)");
+        }
+        cbm_free_result(r);
+        if (flagged) {
+            FAIL("trailing blanks must not turn an absent final newline into parse_partial");
+        }
+    }
+    PASS();
+}
+
+/* GUARD: widening the tail must not swallow a genuine mid-file failure just
+ * because the file happens to end in blanks. */
+TEST(real_error_before_eof_still_flagged_with_trailing_blank_issue1746) {
+    size_t n = strlen(C_IFDEF_SPLIT);
+    char *buf = (char *)malloc(n + 1);
+    ASSERT_NOT_NULL(buf);
+    memcpy(buf, C_IFDEF_SPLIT, n + 1);
+    buf[n - 1] = ' '; /* final newline becomes a blank */
+
+    CBMFileResult *r = do_extract(buf, CBM_LANG_C, "split.c");
+    free(buf);
+    ASSERT_NOT_NULL(r);
+    bool flagged = r->parse_incomplete;
+    bool has_ranges = r->error_ranges != NULL;
+    cbm_free_result(r);
+    if (!flagged) {
+        FAIL("a real mid-file parse failure must still be reported when the file ends in blanks");
+    }
+    if (!has_ranges) {
+        FAIL("a reported failure must still name its line range");
+    }
+    PASS();
+}
+
+/* GUARD: a WIDTH-BEARING loss at EOF stays honest with a blank tail too — the
+ * Makefile recipe really is dropped, and only zero-width nodes are excused. */
+TEST(width_bearing_error_at_eof_still_flagged_with_trailing_blank_issue1746) {
+    const char *src = "all:\n\techo hi ";
+    CBMFileResult *r = do_extract(src, CBM_LANG_MAKEFILE, "Makefile");
+    ASSERT_NOT_NULL(r);
+    bool flagged = r->parse_incomplete;
+    cbm_free_result(r);
+    if (!flagged) {
+        FAIL("a width-bearing parse failure at EOF must still be reported when the file ends in blanks");
+    }
+    PASS();
+}
+
 SUITE(parse_coverage) {
     RUN_TEST(c_ifdef_split_brace_sets_parse_incomplete);
     RUN_TEST(c_ifdef_split_brace_neighbors_still_extracted);
@@ -491,4 +562,7 @@ SUITE(parse_coverage) {
     RUN_TEST(width_bearing_error_at_eof_still_flagged_issue1610);
     RUN_TEST(perl_format_followed_by_named_sub_is_complete_issue1838);
     RUN_TEST(perl_malformed_source_remains_partial_issue1838);
+    RUN_TEST(dockerfile_trailing_blank_at_eof_not_flagged_issue1746);
+    RUN_TEST(real_error_before_eof_still_flagged_with_trailing_blank_issue1746);
+    RUN_TEST(width_bearing_error_at_eof_still_flagged_with_trailing_blank_issue1746);
 }


### PR DESCRIPTION
Fixes #1746

## Root cause

#1610 suppressed the phantom `parse_partial` produced by a missing final newline, on the grounds that the grammar's MISSING terminator at EOF is **zero-width**: the parser consumed no source for it, so by construction nothing was dropped.

That suppression tested `end == source_len` exactly. Trailing blanks are extras owned by no node, so the terminator parks one byte short and the check misses it.

Dumping the parse tree for the reporter's three byte-exact controls confirms the mechanism:

| fixture | `source_len` | MISSING node | flagged |
|---|---|---|---|
| `ENTRYPOINT ["a"] ` + EOF | 30 | `bytes[29,29)` zero-width | **yes** (29 != 30) |
| `ENTRYPOINT ["a"]` + EOF | 29 | `bytes[29,29)` zero-width | no (29 == 29) |
| `ENTRYPOINT ["a"] \n` | 31 | none | no |

This is exactly why neither a trailing blank nor an absent newline flagged alone: only the pair did.

## Fix

Treat "at EOF" as EOF modulo a trailing blank run.

Every blank except newline qualifies, deliberately not a hand-picked subset. An earlier cut of this patch allowed only space/tab/CR and left `\f` and `\v` still flagged, which recreated in miniature the exact arbitrariness #1610 set out to kill: a form feed is no more content than a space. Newline stays excluded because a terminated final line produces no MISSING terminator at all.

The rule remains **zero-width only**. A width-bearing MISSING/ERROR at EOF is a genuine loss and is still flagged (a Makefile's unterminated final recipe really does vanish), as is any failure earlier in the file.

## Tests

Added to `tests/test_parse_coverage.c`, mirroring the existing #1610 structure:

- `dockerfile_trailing_blank_at_eof_not_flagged_issue1746` : the report's repro plus tab, vertical tab, form feed, blank-run and CR variants
- `dockerfile_trailing_blank_then_newline_still_clean_issue1746` : pins the reporter's clean control from the other side
- `real_error_before_eof_still_flagged_with_trailing_blank_issue1746` : **guard**, a genuine mid-file failure must not be swallowed just because the file ends in blanks
- `width_bearing_error_at_eof_still_flagged_with_trailing_blank_issue1746` : **guard**, a width-bearing loss at EOF stays honest

Both guards fail if the suppression is widened too far.

## Verification

End to end, using the issue's own command:

```
printf 'FROM scratch\nENTRYPOINT ["a"] ' > Dockerfile
codebase-memory-mcp cli index_repository --repo_path=. --mode=fast --name=repro
```

`parse_partial_count` goes **1 -> 0**, with `nodes: 8` unchanged, so the phantom flag is gone without anything dropping out of the graph. Controls stay at 0.

Gates run locally (Ubuntu 24.04 + gcc, ASan + UBSan, mirroring CI):

- Full suite: **7570 passed**
- `parse_coverage`: 18/18, including all five pre-existing #1610 tests
- `clang-format-20` (CI's pin): clean
- `cppcheck 2.20.0` (CI's pin): clean
- `lint-no-suppress`: clean

One caveat on the full-suite run: five `cli` install/activation tests failed locally with `ancestor_directory_world_writable (mode 0777, uid 0)`. That is a Docker-on-Windows bind mount presenting mode 0777 and tripping the install activation guard, not a regression: re-running that suite from a container-native directory gives 282/282. Mentioning it in case it helps anyone else developing on a Windows host.

I have not been able to exercise the Windows CI leg locally. The change is byte arithmetic over the source buffer with no platform-dependent behaviour, so I would expect parity, but flagging it rather than assuming.
