### PR TITLE
test(cli): clean up before failing the install-plan receipt fixture

### DIFF
--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -4447,24 +4447,55 @@ TEST(cli_install_plan_receipt_no_mutation_issue388) {
     test_mkdirp(dir);
 
     char *json = cbm_build_install_plan_json(tmpdir, "/usr/local/bin/codebase-memory-mcp");
-    ASSERT_NOT_NULL(json);
-    ASSERT(strstr(json, "agent.install.plan.v1") != NULL);
-    ASSERT(strstr(json, "writes_started") != NULL);
-    ASSERT(strstr(json, "next_safe_command") != NULL);
-    ASSERT(strstr(json, "cursor") != NULL);
-    ASSERT(strstr(json, ".cursor/mcp.json") != NULL);
-    ASSERT(strstr(json, ".codex/config.toml") != NULL);
+
+    /* WHY the failures are deferred: asserting inline returns before the free
+     * and the rmdir below, so every red run leaked the receipt and left a
+     * stray /tmp/cli-plan-* directory behind. That makes the next debugging
+     * session harder than the failure it is reporting. Record what went wrong,
+     * release everything, then fail -- and name the specific marker, because
+     * "a marker was missing" costs a reader a bisect that "next_safe_command
+     * was missing" does not. */
+    const char *missing = NULL;
+    if (!json) {
+        missing = "receipt was NULL";
+    } else {
+        static const char *const required[] = {
+            "agent.install.plan.v1", "writes_started",     "next_safe_command", "cursor",
+            ".cursor/mcp.json",      ".codex/config.toml",
+        };
+        for (size_t i = 0; i < sizeof(required) / sizeof(required[0]); i++) {
+            if (!strstr(json, required[i])) {
+                missing = required[i];
+                break;
+            }
+        }
+    }
     free(json);
 
     /* Critical: building the plan must NOT have created any config file. */
     char cfg[512];
     struct stat st;
+    const char *created = NULL;
     snprintf(cfg, sizeof(cfg), "%s/.cursor/mcp.json", tmpdir);
-    ASSERT(stat(cfg, &st) != 0); /* must not exist */
+    if (stat(cfg, &st) == 0) {
+        created = ".cursor/mcp.json";
+    }
     snprintf(cfg, sizeof(cfg), "%s/.codex/config.toml", tmpdir);
-    ASSERT(stat(cfg, &st) != 0); /* must not exist */
+    if (!created && stat(cfg, &st) == 0) {
+        created = ".codex/config.toml";
+    }
 
     test_rmdir_r(tmpdir);
+
+    char reason[256];
+    if (missing) {
+        snprintf(reason, sizeof(reason), "install plan receipt is missing %s", missing);
+        FAIL(reason);
+    }
+    if (created) {
+        snprintf(reason, sizeof(reason), "building an install plan created %s", created);
+        FAIL(reason);
+    }
     PASS();
 }
 


### PR DESCRIPTION
`cli_install_plan_receipt_no_mutation_issue388` asserted inline, so any failure returned before `free(json)` and `test_rmdir_r(tmpdir)`. A red run therefore leaked the receipt **and** left a stray `/tmp/cli-plan-*` directory behind — the failure report came with exactly the noise that makes the next debugging session harder than the failure itself.

## What changed

Record what went wrong, release everything, then fail:

- the marker checks become a loop over the required strings, recording the **first** one that is missing
- the two "must not exist" stats record which config file was wrongly created
- `free(json)` and `test_rmdir_r(tmpdir)` now run unconditionally
- the failure message names the specific marker (`install plan receipt is missing next_safe_command`) instead of reporting that some marker was absent

That last point is deliberate: folding the checks into one boolean would have kept the cleanup fix while losing which `strstr` failed. Naming the marker is the difference between reading a failure and bisecting one.

## What is deliberately *not* carried over

The original PR also saved, unset and restored `CODEX_HOME` around the test. That is redundant on current `main`: `tf_setup_cache_sentinel` in `tests/test_main.c` already unsets `CODEX_HOME` along with every other entry in `tf_client_home_overrides[]` at suite setup. Adding a per-test save/restore now would be dead code.

## Verification

`build/c/test-runner cli` — **281 passed, 0 failed**, with the restructured test passing. `git clang-format` clean against the Homebrew LLVM build.

## Credit

Distilled from #1149 by **@aaiyer**. That PR was correct when written, but its sequencing depended on the companion PR #1150 landing first — and #1150 was closed unmerged, so the plan it was waiting on no longer existed. The contributor also correctly diagnosed the 4,976-byte "leak" as an assertion aborting before the frees rather than a production leak, which is the harder and more useful call.