### PR TITLE
test.sh: refuse the cli suite against a real HOME

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -121,6 +121,35 @@ if [ "$TSAN" -eq 1 ] && [ -n "$SUITES" ]; then
     echo "test.sh: --tsan and --suites are separate modes (the TSan leg has its own suite set). Please consult --help." >&2
     exit 2
 fi
+
+# The cli suite drives the real install and uninstall paths. HOME isolation is
+# per-test (tests/test_cli.c sets it 58 times; this script sets it none), so the
+# suite installs and uninstalls agent configurations against whatever HOME it
+# inherits. Its results are also unreliable outside isolation: against a real
+# HOME it reports different failure counts run to run, all in the agent-config
+# install/uninstall tests, where an isolated HOME is stable. Refuse rather than
+# touch the machine's agent configuration. Default mode (no --suites) runs every
+# suite, so it is covered too.
+cbm_cli_suite_selected=0
+if [ -z "$SUITES" ]; then
+    cbm_cli_suite_selected=1
+else
+    for cbm_suite in $SUITES; do
+        if [ "$cbm_suite" = "cli" ]; then
+            cbm_cli_suite_selected=1
+        fi
+    done
+fi
+if [ "$cbm_cli_suite_selected" -eq 1 ] && [ "${CBM_ALLOW_REAL_HOME:-0}" != "1" ] &&
+   { [ -e "$HOME/.claude.json" ] || [ -d "$HOME/.claude" ]; }; then
+    echo "test.sh: refusing to run the cli suite against a real HOME ($HOME)." >&2
+    echo "  That suite installs and uninstalls agent configurations for real, against" >&2
+    echo "  whatever HOME it inherits, and its results are unreliable outside isolation." >&2
+    echo "  Run it isolated instead:" >&2
+    echo "    HOME=\"\$(mktemp -d)\" CCACHE_DIR=\"$HOME/.ccache\" scripts/test.sh $*" >&2
+    echo "  Set CBM_ALLOW_REAL_HOME=1 to override, accepting that it edits your config." >&2
+    exit 2
+fi
 prev_arg=""
 
 # Also support --arch=value


### PR DESCRIPTION
## Why

The `cli` suite installs and uninstalls agent configurations **for real** — it calls `cbm_cmd_install` and `cbm_cmd_uninstall`, not mocks, across 53 call sites.

`HOME` isolation is per-test rather than global: `tests/test_cli.c` calls `cbm_setenv("HOME", tmpdir, 1)` 58 separate times, and `scripts/test.sh` sets `HOME` zero times. So the suite acts on whatever `HOME` it inherits, and the safety of a run depends on every individual test remembering — including the ones that fail partway.

The observable consequence is that results outside isolation are not trustworthy. Running the suite against a real `$HOME` on my machine gave different failure counts on consecutive runs, and the tests that moved were exactly the agent-config ones — OpenClaw, VS Code, Gemini, Augment, CodeBuddy/Pochi. The same tree under `HOME=$(mktemp -d)` was stable at the baseline every time.

I am not claiming a specific test damages a real config — I tried to reproduce that and could not, twice, against increasingly faithful copies of the home directory in question. The argument here is narrower and I think uncontroversial: a suite that installs and uninstalls agent configurations should not be pointed at a developer's own one by default, and its results there are unreliable regardless.

## What this does

`scripts/test.sh` exits 2 when the `cli` suite is selected and `$HOME` contains `.claude` or `.claude.json`, printing the isolated command to use. Default mode (no `--suites`) is covered too, since it runs every suite. `CBM_ALLOW_REAL_HOME=1` overrides for anyone who wants the current behaviour.

CI is unaffected in the normal case: a runner whose `$HOME` has no `.claude` never trips it, and the override is available if yours does.

Verified in this tree: refuses `--suites cli` on a real HOME with exit 2, permits `--suites discover` there, and permits `--suites cli` under an isolated HOME.

Happy to gate it differently — a warning instead of a refusal, or a different env var name — if you would rather.