### PR TITLE
feat(extract): discover Blazor .razor components and emit Route nodes for @page

### DIFF
--- a/internal/cbm/extract_defs.c
+++ b/internal/cbm/extract_defs.c
@@ -7902,6 +7902,89 @@ void cbm_extract_definitions_without_module(CBMExtractCtx *ctx) {
     extract_variables(ctx, ctx->root, spec);
 }
 
+/* True when rel_path names a Blazor component file. */
+static bool cbm_path_is_razor(const char *rel_path) {
+    if (!rel_path) {
+        return false;
+    }
+    size_t len = strlen(rel_path);
+    static const char suffix[] = ".razor";
+    size_t slen = sizeof(suffix) - 1U;
+    return len > slen && strcmp(rel_path + (len - slen), suffix) == 0;
+}
+
+/* Match `@page "/route"` on ONE line; returns the route text or NULL.
+ *
+ * Deliberately strict: the directive must be the first token on the line and be
+ * followed by whitespace and a double-quoted path beginning with '/', so
+ * neither `@pageSize` nor a `@page` mentioned in markup prose can match.
+ *
+ * A blank line is rejected up front rather than falling through the length
+ * check, which keeps every later comparison reachable on some path — the
+ * all-whitespace case would otherwise leave `line_end - p` provably zero. */
+static const char *razor_page_route_on_line(CBMArena *a, const char *line, const char *line_end) {
+    static const char directive[] = "@page";
+    const size_t dlen = sizeof(directive) - 1U;
+
+    const char *p = line;
+    while (p < line_end && (*p == ' ' || *p == '\t')) {
+        p++;
+    }
+    if (p == line_end) {
+        return NULL; /* blank line — nothing can follow */
+    }
+    if ((size_t)(line_end - p) <= dlen || strncmp(p, directive, dlen) != 0) {
+        return NULL;
+    }
+    p += dlen;
+    if (*p != ' ' && *p != '\t') {
+        return NULL; /* `@pageSize` and friends */
+    }
+    while (p < line_end && (*p == ' ' || *p == '\t')) {
+        p++;
+    }
+    if (p == line_end || *p != '"') {
+        return NULL;
+    }
+    p++;
+    const char *route = p;
+    while (p < line_end && *p != '"') {
+        p++;
+    }
+    if (p == line_end || p == route || *route != '/') {
+        return NULL; /* unterminated, empty, or not a rooted path */
+    }
+    return cbm_arena_strndup(a, route, (size_t)(p - route));
+}
+
+/* Blazor route directive: `@page "/counter"` lives in MARKUP above the `@code`
+ * block. Tree-sitter's C# grammar recovers `@code` but never parses the
+ * directive, so there is no AST node to read it from — this scans the raw
+ * source instead. That is why routes need no Razor grammar.
+ *
+ * A component may declare several routes; the first is taken, because
+ * CBMDefinition carries a single route_path. */
+static const char *cbm_razor_page_route(CBMArena *a, const char *source, int source_len) {
+    if (!source || source_len <= 0) {
+        return NULL;
+    }
+    const char *end = source + source_len;
+    const char *line = source;
+
+    while (line < end) {
+        const char *nl = memchr(line, '\n', (size_t)(end - line));
+        const char *route = razor_page_route_on_line(a, line, nl ? nl : end);
+        if (route) {
+            return route;
+        }
+        if (!nl) {
+            break;
+        }
+        line = nl + 1;
+    }
+    return NULL;
+}
+
 void cbm_extract_definitions(CBMExtractCtx *ctx) {
     const CBMLangSpec *spec = cbm_lang_spec(ctx->language);
     if (!spec) {
@@ -7923,6 +8006,17 @@ void cbm_extract_definitions(CBMExtractCtx *ctx) {
     mod.is_test = ctx->result->is_test_file;
     // #519: index what a config file declares itself to be, not only its path.
     mod.docstring = extract_config_module_description(ctx);
+    /* A routable Blazor component carries its route on the module def: the
+     * component's class is implicit in a .razor file, so there is no class node
+     * to hang it on, and the module QN already is the component's identity.
+     * insert_def_into_gbuf creates Route+HANDLES for any def with route_path. */
+    if (ctx->language == CBM_LANG_CSHARP && cbm_path_is_razor(ctx->rel_path)) {
+        const char *route = cbm_razor_page_route(a, ctx->source, ctx->source_len);
+        if (route) {
+            mod.route_path = route;
+            mod.route_method = "GET"; /* a routable page is reached by navigation */
+        }
+    }
     cbm_defs_push(&ctx->result->defs, a, mod);
 
     cbm_extract_definitions_without_module(ctx);

--- a/src/discover/language.c
+++ b/src/discover/language.c
@@ -50,6 +50,11 @@ static const ext_entry_t EXT_TABLE[] = {
 
     /* C# */
     {".cs", CBM_LANG_CSHARP},
+    /* Blazor components. The C# grammar recovers the @code block; the
+     * surrounding markup parses as ERROR regions and is reported via
+     * parse_partial, which is why this is a best-effort mapping rather
+     * than a dedicated grammar. */
+    {".razor", CBM_LANG_CSHARP},
 
     /* Clojure */
     {".clj", CBM_LANG_CLOJURE},

--- a/src/pipeline/pass_route_nodes.c
+++ b/src/pipeline/pass_route_nodes.c
@@ -480,10 +480,19 @@ static int ensure_one_decorator_route(cbm_gbuf_t *gb, const cbm_gbuf_node_t *fun
 
 /* Phase 2a: Ensure all functions with route_path properties have Route+HANDLES edges. */
 static void ensure_decorator_routes(cbm_gbuf_t *gb) {
-    const char *labels[] = {"Function", "Method"};
+    /* "Module" is here for Blazor: a .razor component's class is implicit, so
+     * its @page route is carried by the file's Module def. Extraction's own
+     * insert_def_into_gbuf is label-agnostic and creates the Route either way —
+     * this backstop is what runs on an INCREMENTAL re-index, so leaving Module
+     * out would make a component's Route appear on a full index and vanish the
+     * next time that one file changed.
+     * Bound comes from the array, not the unrelated RN_STRIP_PASSES it used to
+     * borrow, so adding a label cannot silently skip it. */
+    const char *labels[] = {"Function", "Method", "Module"};
+    const int label_count = (int)(sizeof(labels) / sizeof(labels[0]));
     int created = 0;
 
-    for (int li = 0; li < RN_STRIP_PASSES; li++) {
+    for (int li = 0; li < label_count; li++) {
         const cbm_gbuf_node_t **nodes = NULL;
         int count = 0;
         if (cbm_gbuf_find_by_label(gb, labels[li], &nodes, &count) != 0) {

--- a/tests/test_extraction.c
+++ b/tests/test_extraction.c
@@ -3906,6 +3906,75 @@ TEST(extract_java_jaxrs_path_composition_issue1005) {
     PASS();
 }
 
+/* Return the file's Module definition (extraction pushes it first), or NULL. */
+static const CBMDefinition *find_module_def(CBMFileResult *r) {
+    for (int i = 0; i < r->defs.count; i++) {
+        if (r->defs.items[i].label && strcmp(r->defs.items[i].label, "Module") == 0) {
+            return &r->defs.items[i];
+        }
+    }
+    return NULL;
+}
+
+/* Blazor: a routable component declares its route with a `@page` directive in
+ * MARKUP, above the `@code` block. The C# grammar recovers `@code` (that is why
+ * .razor already yields methods via extra_extensions) but never sees the
+ * directive, so a routable page contributes no Route node and
+ * get_architecture(routes) is empty for a whole Blazor app.
+ *
+ * The route hangs off the file's Module definition, not off a class: a .razor
+ * component's class is implicit — it is never written in the source — so there
+ * is no class node to carry it. The Module's qualified name already IS the
+ * component's identity (t.Pages.Counter), and insert_def_into_gbuf creates
+ * Route+HANDLES for any definition carrying route_path, whatever its label. */
+TEST(extract_blazor_page_directive_routes_component) {
+    CBMFileResult *r = extract("@page \"/counter\"\n"
+                               "@inject NavigationManager Nav\n"
+                               "\n"
+                               "<h1>Counter</h1>\n"
+                               "<button @onclick=\"Increment\">Click</button>\n"
+                               "\n"
+                               "@code {\n"
+                               "    private int count;\n"
+                               "    private void Increment() { count++; }\n"
+                               "}\n",
+                               CBM_LANG_CSHARP, "t", "Pages/Counter.razor");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+    /* The markup must not cost us the @code block we already extract today. */
+    ASSERT_NOT_NULL(find_def_by_name(r, "Increment"));
+    const CBMDefinition *mod = find_module_def(r);
+    ASSERT_NOT_NULL(mod);
+    ASSERT_NOT_NULL(mod->route_path);
+    ASSERT_STR_EQ(mod->route_path, "/counter");
+    /* A routable Blazor page is reached by navigation, i.e. GET. */
+    ASSERT_NOT_NULL(mod->route_method);
+    ASSERT_STR_EQ(mod->route_method, "GET");
+    cbm_free_result(r);
+    PASS();
+}
+
+/* The directive scan must not fire on every .razor file. A non-routable
+ * component (no @page) has to stay route-free, or every shared component in the
+ * tree becomes a bogus Route node. */
+TEST(extract_blazor_component_without_page_has_no_route) {
+    CBMFileResult *r = extract("@inject IJSRuntime JS\n"
+                               "\n"
+                               "<div class=\"card\">@Title</div>\n"
+                               "\n"
+                               "@code {\n"
+                               "    private void Refresh() { }\n"
+                               "}\n",
+                               CBM_LANG_CSHARP, "t", "Shared/Card.razor");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+    const CBMDefinition *mod = find_module_def(r);
+    ASSERT_NOT_NULL(mod);
+    ASSERT_NULL(mod->route_path);
+    cbm_free_result(r);
+    PASS();
+}
+
 /* A comment between decorators must not drop the decorators above it.
  * Comments are NAMED tree-sitter nodes, so the prev-sibling walk used to stop
  * at one — a documented route (@Post + @HttpCode above an explanatory comment)
@@ -6291,16 +6360,6 @@ TEST(iris_export_xml_multi_class) {
  * question asked in words could not reach either. Both now carry the prose in
  * `docstring`, which is what nodes_fts indexes into its `body` column. */
 
-/* First Module-labelled definition, or NULL. */
-static const CBMDefinition *find_module_def(CBMFileResult *r) {
-    for (int i = 0; i < r->defs.count; i++) {
-        if (strcmp(r->defs.items[i].label, "Module") == 0) {
-            return &r->defs.items[i];
-        }
-    }
-    return NULL;
-}
-
 TEST(markdown_section_body_becomes_docstring_issue518) {
     CBMFileResult *r = extract("# Installation\n"
                                "Run the bootstrap script to provision a workstation.\n"
@@ -6808,6 +6867,8 @@ SUITE(extraction) {
     RUN_TEST(arkts_lazy_import);
     RUN_TEST(arkts_ts_compat);
     RUN_TEST(extract_java_jaxrs_path_composition_issue1005);
+    RUN_TEST(extract_blazor_page_directive_routes_component);
+    RUN_TEST(extract_blazor_component_without_page_has_no_route);
     RUN_TEST(extract_ts_template_string_url_issue1006);
     RUN_TEST(extract_go_binary_concat_url_issue1249);
     RUN_TEST(extract_go_binary_concat_url_no_literal_suffix_issue1249);

--- a/tests/test_language.c
+++ b/tests/test_language.c
@@ -89,6 +89,14 @@ TEST(lang_ext_csharp) {
     ASSERT_EQ(cbm_language_for_extension(".cs"), CBM_LANG_CSHARP);
     PASS();
 }
+/* Blazor components were unmapped, so a .razor file was never discovered at
+ * all: indexing a Blazor app produced no nodes for any component, and reaching
+ * them required an undocumented extra_extensions entry in a per-project
+ * .codebase-memory.json. */
+TEST(lang_ext_razor) {
+    ASSERT_EQ(cbm_language_for_extension(".razor"), CBM_LANG_CSHARP);
+    PASS();
+}
 TEST(lang_ext_php) {
     ASSERT_EQ(cbm_language_for_extension(".php"), CBM_LANG_PHP);
     PASS();
@@ -1197,6 +1205,7 @@ SUITE(language) {
     RUN_TEST(lang_ext_h);
     RUN_TEST(lang_ext_ixx);
     RUN_TEST(lang_ext_csharp);
+    RUN_TEST(lang_ext_razor);
     RUN_TEST(lang_ext_php);
     RUN_TEST(lang_ext_lua);
     RUN_TEST(lang_ext_scala);


### PR DESCRIPTION
## What does this PR do?

Makes Blazor `.razor` components visible to the indexer, and turns their
`@page` directives into `Route` nodes.

Two changes, in dependency order:

**1. `feat(discover): map .razor to C#`** — `.razor` had no entry in
`EXT_TABLE`, so discovery skipped it and a Blazor application produced no
graph nodes for any component. The only way in was an undocumented
`extra_extensions` entry in a per-project `.codebase-memory.json`. This maps
`.razor` to `CBM_LANG_CSHARP`.

It is best-effort by design: the C# grammar recovers the `@code` block, while
the surrounding markup lands in ERROR regions and is reported through
`parse_partial`. That is still strictly more than the Module-and-imports the
other markup-hosted languages extract today, and it needs no new grammar.

**2. `feat(extract): emit Route nodes for Blazor @page directives`** —
`get_architecture`'s `routes` aspect returned nothing for a Blazor
application: the entry surface of the app was invisible even though every
`@page` names one.

`@page` lives in markup above the `@code` block, which tree-sitter's C#
grammar never parses, so there is no AST node to read it from. This scans the
raw source instead. The match is deliberately strict — the directive must be
the first token on its line, followed by whitespace and a double-quoted path
beginning with `/` — so `@pageSize` and prose mentions cannot match.

The route is attached to the file's **module** def. A `.razor` component's
class is implicit, so there is no class node to carry it, and the module QN
already is the component's identity. `insert_def_into_gbuf` is label-agnostic
and creates `Route` + `HANDLES` from `route_path`.

`pass_route_nodes.c`'s `ensure_decorator_routes` gains `"Module"` for the
same reason. Extraction covers the full-index path on its own; this backstop
is what runs on an **incremental** re-index, so without it a component's
`Route` would appear on a full index and vanish the next time that one file
changed. Its loop bound now derives from the labels array rather than
borrowing the unrelated `RN_STRIP_PASSES`, so adding a label cannot silently
skip it. Verified there is no double-creation when both paths can fire (60
files: 60 Routes and 60 HANDLES either way).

Diff vs `main`: 5 files, 190 insertions, 12 deletions.

### Measured

Rebased onto `main` at `5fbab7bb` and re-measured from scratch. **Arm A is now
`main` itself — the exact merge base — rather than a release**, so the only
difference between the two binaries is this PR and there is no upstream drift
to disclaim.

Paired control on a real Blazor application (36 `.razor`, 302 `.cs`, 11
`@page`), both binaries run against **one** checkout, isolated caches, one
container each:

| metric   | A (`main` 5fbab7bb) | B (this branch) |
|---|---|---|
| nodes    | 5113 | 5124 (+11) |
| Route    | no such label | 11 |
| HANDLES  | no such label | 11 |
| total edges | 24402 | 24413 (+11) |
| SEMANTICALLY_RELATED | 365 | 365 (unchanged) |
| Class    | 404  | 404  |
| Method   | 2023 | 2023 |
| CALLS    | 4504 | 4504 |
| Module   | 393  | 393  |
| `.razor` Modules | 36 | 36 |

`+11` nodes is exactly the 11 `Route` nodes; `+11` edges is exactly the 11
`HANDLES`. Nothing else moves. `get_architecture(routes)` went from the aspect
being absent to 11 entries. No store schema change.

Repeated independently on a **second** checkout of the same commit, same
result: 24327 → 24338 edges, 5113 → 5124 nodes, `SEMANTICALLY_RELATED` 290 →
290.

<details>
<summary>Why "both binaries on one checkout" is stated so insistently</summary>

An earlier version of this control gave each binary its own checkout of the
same commit, and reported a `-75` swing in `SEMANTICALLY_RELATED` that looked
like a regression in this branch. It was not. `SEMANTICALLY_RELATED` depends
on the **absolute path** of the checkout: `cbm_project_name_from_path`
(`src/pipeline/fqn.c:416`) maps the whole path to the project name, that name
prefixes every `qualified_name`, and `pass_semantic_edges.c:469-470` tokenizes
`qualified_name` into the vector that becomes the LSH signature. The
unmodified `main` binary reproduces the entire `-75` on its own, just by
reading a second, content-identical checkout at a different path.

So the two rows above are measured with the path held constant, which removes
the effect entirely — hence `365 → 365` and `290 → 290` rather than a delta
needing explanation. I intend to file this separately once I have a clean
public reproduction; it is not caused by this PR and does not affect it.

</details>

End-to-end on a dedicated fixture, with a negative control:

```
Route /counter          <- HANDLES <- Module Pages/Counter.razor
Route /weather/forecast <- HANDLES <- Module Pages/Weather.razor
NoRoute.razor (no @page)  ->  Module, and NO Route
```

Stable across a re-index.

### What this does not claim

- `@code` methods are **not** reliably extracted from `.razor`. Real markup
  (`class=`, `role=` attributes) defeats recovery and the file comes back
  `parse_partial` as a whole. Bare `@code` fields remain a separate gap.
- Two pre-existing gaps are untouched and are **not** caused by this change —
  they reproduce on the unmodified binary too: routes report `handler:""`
  although the `HANDLES` edge exists, and the language census counts `.razor`
  as C# rather than as its own surface.
- Only the first `@page` on a component is taken, because `CBMDefinition`
  carries a single `route_path`.

## Checklist

- [X] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [X] Tests pass locally (`make -f Makefile.cbm test`)
- [X] Lint passes (`make -f Makefile.cbm lint-ci`)
- [X] New behavior is covered by a test (reproduce-first for bug fixes)

Full suite on this branch rebased onto `5fbab7bb`: **7626 passed / 0 failed /
7 skipped**, 141 suites, via `scripts/test.sh`. The branch itself adds 3 of
those tests — `extract_blazor_page_directive_routes_component`,
`extract_blazor_component_without_page_has_no_route` and `lang_ext_razor`, the
middle one being the negative control.

This PR has now been rebased twice rather than shipped with stale numbers:
first from `49d928be` to `010569fa` (7415/0/8, 139 suites), and now to
`5fbab7bb`. The extra 211 tests and 2 suites between those last two are
upstream's, not this branch's.

The second rebase needed two conflict resolutions in
`internal/cbm/extract_defs.c` (main's new
`cbm_extract_definitions_without_module`, and #519's
`mod.docstring = extract_config_module_description(ctx)` — both sides kept),
plus one collision that auto-merged cleanly and then did not compile:
`tests/test_extraction.c` grew a second `find_module_def`, since main added
its own for the #518/#519 work while this branch has carried one since August.
Textually disjoint, semantically a redefinition. I kept the earlier
definition — it precedes every call site and has a `label &&` null guard the
other lacks — and removed the duplicate, leaving the #518/#519 comment block
intact. Main's eight call sites and this branch's two now share one definition.

### On lint, stated plainly

`make -f Makefile.cbm lint-ci` — the gate this checklist names — passes: exit
0, run in a clean container against this branch rebased onto `5fbab7bb`.

`scripts/lint.sh` in **full** mode does not pass, and I do not believe any of
it is mine. Full mode adds clang-tidy, which fails repo-wide on rules like
`readability-magic-numbers`, `readability-braces-around-statements` and
`misc-no-recursion`. The same run flags 22 diagnostics on **untouched `main`
code**, including `internal/cbm/extract_defs.c` at lines 281, 588, 601 and
1257 — while this branch's hunks in that file are at 7905-7987 and 8009-8019.

Two diagnostics do land on this branch's added lines: `readability-magic-
numbers` at 7912 (`1U`) and 7983 (`1`). Both are idiomatic and match the
surrounding style in that file. Happy to change them if you would rather.

### One scope question I would rather raise than assume

CONTRIBUTING.md asks for prior design discussion on "new pipeline passes or
indexing algorithms — anything that changes what gets extracted or how", and
this does change what gets extracted. What I took as the go-ahead was #1667
being open and labelled `bug` / `language-request` / `priority/high`, plus the
standing exception for focused bug fixes. If you would rather this went
through a design discussion first, say so and I will close it and move the
conversation back to the issue — no hard feelings.

Fixes #1667

---

*Built and measured with Claude Code; all numbers above are from real runs on
a real application, not generated.*
