### PR TITLE
fix(kotlin): resolve member calls through typed properties instead of by name

### DIFF
--- a/internal/cbm/cbm.h
+++ b/internal/cbm/cbm.h
@@ -770,4 +770,15 @@ bool cbm_label_is_relation(const char *label);
 // `label` may be NULL (returns false). Defined in helpers.c.
 bool cbm_label_is_registry_symbol(const char *label);
 
+// True for labels that can be the target of an invocation: Function, Method,
+// Constructor, and Class (a class name in call position is a construction).
+// Registry membership is deliberately wider than this — Variable and Field are
+// admitted so that reads and writes can resolve — which also makes every
+// property name a bare-name candidate during call resolution. Consumers
+// resolving a CALL use this predicate to narrow the candidate pool to
+// declarations that can actually be called, so a property that merely shares a
+// function's name does not win the name race. `label` may be NULL (returns
+// false). Defined in helpers.c.
+bool cbm_label_is_callable_target(const char *label);
+
 #endif // CBM_H

--- a/internal/cbm/extract_defs.c
+++ b/internal/cbm/extract_defs.c
@@ -195,6 +195,9 @@ static void extract_variables(CBMExtractCtx *ctx, TSNode root, const CBMLangSpec
 static void extract_var_names(CBMExtractCtx *ctx, TSNode node, const CBMLangSpec *spec);
 static void extract_class_variables(CBMExtractCtx *ctx, TSNode class_node, const char *class_qn,
                                     const CBMLangSpec *spec);
+static void push_var_def_typed(CBMExtractCtx *ctx, const char *name, TSNode node,
+                               const char *type_text);
+static const char *resolve_kotlin_var_type(CBMArena *a, TSNode node, const char *source);
 static void extract_rust_impl(CBMExtractCtx *ctx, TSNode node, const CBMLangSpec *spec);
 static void extract_class_methods(CBMExtractCtx *ctx, TSNode class_node, const char *class_qn,
                                   const CBMLangSpec *spec);
@@ -4482,6 +4485,51 @@ static void extract_class_def(CBMExtractCtx *ctx, TSNode node, const CBMLangSpec
     // Extract class-level variables (field declarations)
     extract_class_variables(ctx, node, class_qn, spec);
 
+    // Kotlin primary-constructor properties: `class Foo(private val bar: Bar)`
+    // declares bar as a member, reachable from every instance method, but it
+    // lives on the class line rather than in the class body — so
+    // extract_class_variables never sees it. Without these defs a member call
+    // through an injected dependency has no receiver type to resolve against.
+    if (ctx->language == CBM_LANG_KOTLIN) {
+        TSNode pc = cbm_find_child_by_kind(node, "primary_constructor");
+        if (!ts_node_is_null(pc)) {
+            // Older grammars wrap the params in a `class_parameters` node;
+            // newer ones put `class_parameter` directly under the constructor.
+            TSNode wrapped = cbm_find_child_by_kind(pc, "class_parameters");
+            TSNode container = ts_node_is_null(wrapped) ? pc : wrapped;
+            uint32_t pcount = ts_node_named_child_count(container);
+            for (uint32_t k = 0; k < pcount; k++) {
+                TSNode p = ts_node_named_child(container, k);
+                if (ts_node_is_null(p) || strcmp(ts_node_type(p), "class_parameter") != 0) {
+                    continue;
+                }
+                // Only `val`/`var` parameters become properties; a plain
+                // constructor parameter is scoped to the initializer. Matched
+                // on text because the binding keyword's node kind differs
+                // across tree-sitter-kotlin versions.
+                const char *ptext = cbm_node_text(a, p, ctx->source);
+                if (!ptext || (!strstr(ptext, "val ") && !strstr(ptext, "var "))) {
+                    continue;
+                }
+                TSNode name_node = ts_node_child_by_field_name(p, TS_FIELD("name"));
+                if (ts_node_is_null(name_node)) {
+                    name_node = cbm_find_child_by_kind(p, "simple_identifier");
+                }
+                if (ts_node_is_null(name_node)) {
+                    continue;
+                }
+                const char *pname = cbm_node_text(a, name_node, ctx->source);
+                if (!pname || !pname[0]) {
+                    continue;
+                }
+                const char *saved_parent = ctx->var_parent_class;
+                ctx->var_parent_class = class_qn;
+                push_var_def_typed(ctx, pname, p, resolve_kotlin_var_type(a, p, ctx->source));
+                ctx->var_parent_class = saved_parent;
+            }
+        }
+    }
+
     // C# 12 primary-constructor parameters: declared on the class line
     // (`class Foo(IBar bar, IBaz baz) : Base { ... }`) and bound to implicit
     // captured fields accessible from any instance member. Tree-sitter c-sharp
@@ -5185,9 +5233,16 @@ static void extract_elixir_call(CBMExtractCtx *ctx, TSNode node, const CBMLangSp
 /* `qn_name` is the name as it should appear in the qualified name, which differs
  * from `name` only where a language scopes a variable below the module — Nix,
  * whose binding names are attrpaths (`a.b.c = …` is name `c`, QN suffix `a.b.c`).
- * Pass NULL to use `name` for both. */
-static void push_var_def_qn(CBMExtractCtx *ctx, const char *name, const char *qn_name,
-                            TSNode node) {
+ * Pass NULL to use `name` for both.
+ *
+ * `type_text` is the declared type as written, or NULL where the language
+ * extractor has none to hand. Cross-file resolution needs it: a property whose
+ * type is unknown registers as a bare placeholder on its receiver, so member
+ * calls through that property miss the typed lookup and fall to name-only
+ * matching. Carried as return_type, which is the single type slot every
+ * registrar already reads. */
+static void push_var_def_qn(CBMExtractCtx *ctx, const char *name, const char *qn_name, TSNode node,
+                            const char *type_text) {
     if (!name || !name[0] || strcmp(name, "_") == 0) {
         return;
     }
@@ -5195,6 +5250,9 @@ static void push_var_def_qn(CBMExtractCtx *ctx, const char *name, const char *qn
     CBMDefinition def;
     memset(&def, 0, sizeof(def));
     def.name = name;
+    if (type_text && type_text[0]) {
+        def.return_type = type_text;
+    }
     /* Java/Go: directory-based module (package), so a Go package-level var in
      * myapp/db/conn.go is proj.myapp.db.Var, matching its siblings. */
     def.qualified_name = cbm_fqn_compute_source_lang(a, ctx->project, ctx->rel_path,
@@ -5213,7 +5271,13 @@ static void push_var_def_qn(CBMExtractCtx *ctx, const char *name, const char *qn
 }
 
 static void push_var_def(CBMExtractCtx *ctx, const char *name, TSNode node) {
-    push_var_def_qn(ctx, name, NULL, node);
+    push_var_def_qn(ctx, name, NULL, node, NULL);
+}
+
+/* As push_var_def, for extractors that can see the declaration's type. */
+static void push_var_def_typed(CBMExtractCtx *ctx, const char *name, TSNode node,
+                               const char *type_text) {
+    push_var_def_qn(ctx, name, NULL, node, type_text);
 }
 
 // Helper: extract name from a declarator chain (C/C++/ObjC)
@@ -5704,6 +5768,40 @@ static TSNode resolve_kotlin_var_name(TSNode node) {
     return null_node;
 }
 
+/* Declared type of a Kotlin `val`/`var`, as written. The annotation hangs off
+ * the variable_declaration (`val x: T`), so a property_declaration has to be
+ * unwrapped first. Returns NULL for an inferred type (`val x = f()`) — the
+ * initializer is an expression, and inferring through it is the type pass's
+ * job, not the extractor's. */
+static const char *resolve_kotlin_var_type(CBMArena *a, TSNode node, const char *source) {
+    TSNode holder = cbm_find_child_by_kind(node, "variable_declaration");
+    if (ts_node_is_null(holder)) {
+        holder = node;
+    }
+    static const char *type_kinds[] = {"type", "user_type", "nullable_type", NULL};
+    for (const char **k = type_kinds; *k; k++) {
+        TSNode t = cbm_find_child_by_kind(holder, *k);
+        if (!ts_node_is_null(t)) {
+            return cbm_node_text(a, t, source);
+        }
+    }
+    /* Unannotated but directly constructed (`val logger = Logger()`) — by far
+     * the most common inferred property in practice. Only a bare capitalized
+     * callee is taken: anything else is a factory or a chain whose result type
+     * the extractor has no business guessing. */
+    TSNode init = cbm_find_child_by_kind(node, "call_expression");
+    if (!ts_node_is_null(init) && ts_node_named_child_count(init) > 0) {
+        TSNode callee = ts_node_named_child(init, 0);
+        if (!ts_node_is_null(callee) && strcmp(ts_node_type(callee), "simple_identifier") == 0) {
+            const char *text = cbm_node_text(a, callee, source);
+            if (text && text[0] >= 'A' && text[0] <= 'Z') {
+                return text;
+            }
+        }
+    }
+    return NULL;
+}
+
 static void extract_vars_jvm(CBMExtractCtx *ctx, TSNode node, CBMArena *a) {
     switch (ctx->language) {
     case CBM_LANG_SCALA: {
@@ -5721,7 +5819,8 @@ static void extract_vars_jvm(CBMExtractCtx *ctx, TSNode node, CBMArena *a) {
     case CBM_LANG_KOTLIN: {
         TSNode name_node = resolve_kotlin_var_name(node);
         if (!ts_node_is_null(name_node)) {
-            push_var_def(ctx, cbm_node_text(a, name_node, ctx->source), node);
+            push_var_def_typed(ctx, cbm_node_text(a, name_node, ctx->source), node,
+                               resolve_kotlin_var_type(a, node, ctx->source));
         }
         break;
     }
@@ -5926,7 +6025,7 @@ static void extract_vars_nix(CBMExtractCtx *ctx, TSNode node, CBMArena *a) {
     cbm_nix_strip_attr_quotes(name);
     const char *scope = cbm_nix_attrpath_scope(a, attrpath, ctx->source);
     const char *qn_name = scope ? cbm_arena_sprintf(a, "%s.%s", scope, name) : name;
-    push_var_def_qn(ctx, name, qn_name, node);
+    push_var_def_qn(ctx, name, qn_name, node, NULL);
 }
 
 /* Mint every direct binding of one Nix binding container. */

--- a/internal/cbm/helpers.c
+++ b/internal/cbm/helpers.c
@@ -195,6 +195,17 @@ bool cbm_label_is_registry_symbol(const char *label) {
            strcmp(label, "Field") == 0 || cbm_label_is_relation(label);
 }
 
+// True when `label` can be invoked (see cbm.h). Narrower than
+// cbm_label_is_registry_symbol on purpose: that predicate answers "may this
+// declaration be found by name", this one answers "may a call bind to it".
+bool cbm_label_is_callable_target(const char *label) {
+    if (!label) {
+        return false;
+    }
+    return strcmp(label, "Function") == 0 || strcmp(label, "Method") == 0 ||
+           strcmp(label, "Constructor") == 0 || strcmp(label, "Class") == 0;
+}
+
 bool cbm_is_keyword(const char *name, CBMLanguage lang) {
     if (!name || !name[0]) {
         return true;

--- a/internal/cbm/lsp/kotlin_lsp.c
+++ b/internal/cbm/lsp/kotlin_lsp.c
@@ -5166,15 +5166,14 @@ typedef struct {
     const CBMLSPDef *def;
 } KotlinSignatureParseContext;
 
-static const CBMType *kt_signature_parse_type(CBMArena *arena, const char *text, void *parser_ctx) {
-    const KotlinSignatureParseContext *ctx = (const KotlinSignatureParseContext *)parser_ctx;
-    const CBMLSPDef *def = ctx ? ctx->def : NULL;
+/* Normalize a type as written to a bare name: trim, drop nullability, drop
+ * type arguments. Returns NULL when nothing is left. */
+static char *kt_clean_type_text(CBMArena *arena, const char *text) {
     if (!text || !text[0])
-        return cbm_type_unknown();
-
+        return NULL;
     char *clean = cbm_arena_strdup(arena, text);
     if (!clean)
-        return cbm_type_unknown();
+        return NULL;
     while (*clean && isspace((unsigned char)*clean))
         clean++;
     char *end = clean + strlen(clean);
@@ -5185,7 +5184,14 @@ static const CBMType *kt_signature_parse_type(CBMArena *arena, const char *text,
     char *generic = strchr(clean, '<');
     if (generic)
         *generic = '\0';
-    if (!clean[0])
+    return clean[0] ? clean : NULL;
+}
+
+static const CBMType *kt_signature_parse_type(CBMArena *arena, const char *text, void *parser_ctx) {
+    const KotlinSignatureParseContext *ctx = (const KotlinSignatureParseContext *)parser_ctx;
+    const CBMLSPDef *def = ctx ? ctx->def : NULL;
+    char *clean = kt_clean_type_text(arena, text);
+    if (!clean)
         return cbm_type_unknown();
 
     const char *qualified = kt_cross_builtin_return_qn(clean);
@@ -5201,6 +5207,58 @@ static const CBMType *kt_signature_parse_type(CBMArena *arena, const char *text,
         }
     }
     return cbm_type_named(arena, qualified);
+}
+
+/* Resolve a property's declared type to a project type QN.
+ *
+ * A property annotation is written unqualified whether the type is same-package
+ * or imported, and the def carries no import list of its own — so joining the
+ * declaring package is right for the first case and wrong for the second.
+ * Prefer the same-package QN when such a type actually exists, then fall back
+ * to the project-wide short-name index. `type_short` maps an ambiguous short
+ * name to "" so a name owned by two packages resolves to nothing rather than
+ * to an arbitrary winner. */
+static const CBMType *kt_property_type(CBMArena *arena, const CBMLSPDef *d,
+                                       const CBMHashTable *type_qns,
+                                       const CBMHashTable *type_short) {
+    if (!d || !d->return_types || !d->return_types[0])
+        return NULL;
+    const char *first = d->return_types;
+    const char *bar = strchr(first, '|');
+    if (bar)
+        first = cbm_arena_strndup(arena, first, (size_t)(bar - first));
+    char *clean = kt_clean_type_text(arena, first);
+    if (!clean)
+        return NULL;
+
+    const char *builtin = kt_cross_builtin_return_qn(clean);
+    if (builtin)
+        return cbm_type_named(arena, builtin);
+    if (strchr(clean, '.'))
+        return cbm_type_named(arena, clean);
+
+    const char *ns = (d->namespace_name && d->namespace_name[0])
+                         ? d->namespace_name
+                         : (d->def_module_qn && d->def_module_qn[0] ? d->def_module_qn : NULL);
+    if (ns) {
+        const char *same_pkg = kt_join_dot(arena, ns, clean);
+        if (type_qns && same_pkg && cbm_ht_get((CBMHashTable *)type_qns, same_pkg)) {
+            return cbm_type_named(arena, same_pkg);
+        }
+    }
+    if (type_short) {
+        const char *hit = (const char *)cbm_ht_get((CBMHashTable *)type_short, clean);
+        if (hit && hit[0]) {
+            return cbm_type_named(arena, hit);
+        }
+        if (hit) {
+            return NULL; /* ambiguous short name — fail closed */
+        }
+    }
+    if (ns) {
+        return cbm_type_named(arena, kt_join_dot(arena, ns, clean));
+    }
+    return cbm_type_named(arena, clean);
 }
 
 static const CBMType *kt_cross_return_type(CBMArena *arena, const CBMLSPDef *d) {
@@ -5307,6 +5365,31 @@ static void kt_register_cross_def(CBMTypeRegistry *reg, CBMArena *arena, const C
 
 void cbm_kotlin_register_lsp_defs(CBMArena *arena, CBMTypeRegistry *reg, const CBMLSPDef *defs,
                                   int def_count, CBMHashTable **out_field_map) {
+    /* Pass 0: index the project's type QNs, plus a short-name -> QN map used to
+     * qualify a property annotation that names an imported type. Ambiguous
+     * short names are pinned to "" so they resolve to nothing. */
+    CBMHashTable *type_qns = cbm_ht_create(64);
+    CBMHashTable *type_short = cbm_ht_create(64);
+    if (type_qns && type_short) {
+        for (int i = 0; i < def_count; i++) {
+            const CBMLSPDef *d = &defs[i];
+            if (!d->qualified_name || !d->short_name || !d->label) {
+                continue;
+            }
+            if (strcmp(d->label, "Class") != 0 && strcmp(d->label, "Interface") != 0 &&
+                strcmp(d->label, "Enum") != 0 && strcmp(d->label, "Type") != 0) {
+                continue;
+            }
+            cbm_ht_set(type_qns, d->qualified_name, (void *)d->qualified_name);
+            const char *prev = (const char *)cbm_ht_get(type_short, d->short_name);
+            if (!prev) {
+                cbm_ht_set(type_short, d->short_name, (void *)d->qualified_name);
+            } else if (strcmp(prev, d->qualified_name) != 0) {
+                cbm_ht_set(type_short, d->short_name, (void *)"");
+            }
+        }
+    }
+
     /* Pass 1: bucket property (Variable) defs by receiver type, so a class
      * registers WITH its fields. Cross registration previously dropped
      * properties entirely (pxc_map_label filtered the label), which left
@@ -5353,7 +5436,10 @@ void cbm_kotlin_register_lsp_defs(CBMArena *arena, CBMTypeRegistry *reg, const C
                 fl->qns = nq;
                 fl->cap = new_cap;
             }
-            const CBMType *ft = kt_cross_return_type(arena, d);
+            /* A property's declared type arrives as written, so it needs
+             * cleaning (generics, nullability) and qualification against the
+             * project's types before it can be looked up. */
+            const CBMType *ft = kt_property_type(arena, d, type_qns, type_short);
             fl->names[fl->count] = d->short_name;
             /* The declared type when the def carries one; a generic named type
              * otherwise, so the field's EXISTENCE is still visible to
@@ -5369,6 +5455,11 @@ void cbm_kotlin_register_lsp_defs(CBMArena *arena, CBMTypeRegistry *reg, const C
     for (int i = 0; i < def_count; i++) {
         kt_register_cross_def(reg, arena, &defs[i], field_map);
     }
+    /* The type indexes only qualify property annotations in pass 1; nothing
+     * downstream holds a reference. Values are borrowed def strings, so
+     * freeing the tables frees no payload. */
+    cbm_ht_free(type_qns);
+    cbm_ht_free(type_short);
     if (out_field_map) {
         /* Ownership transfers: the caller keeps the map alive for the resolve
          * walk (property references need each field's real def QN). */

--- a/src/pipeline/lsp_resolve.h
+++ b/src/pipeline/lsp_resolve.h
@@ -201,11 +201,10 @@ static inline bool cbm_pipeline_usage_allows_semantic_reference(const CBMUsage *
  * rows are joined before either rule. This label check keeps sequential and
  * fused resolution aligned. */
 static inline bool cbm_pipeline_node_is_callable_target(const cbm_gbuf_node_t *node) {
-    if (!node || !node->label) {
+    if (!node) {
         return false;
     }
-    return strcmp(node->label, "Function") == 0 || strcmp(node->label, "Method") == 0 ||
-           strcmp(node->label, "Constructor") == 0 || strcmp(node->label, "Class") == 0;
+    return cbm_label_is_callable_target(node->label);
 }
 
 static inline int cbm_pipeline_qn_class_method_tail_eq(const char *qn, const char *tail) {

--- a/src/pipeline/pass_calls.c
+++ b/src/pipeline/pass_calls.c
@@ -651,6 +651,27 @@ static int resolve_single_call(cbm_pipeline_ctx_t *ctx, CBMCall *call,
     if (cbm_suppress_cross_language_suffix_match(lang, target_node->file_path, res.strategy)) {
         return 0;
     }
+    /* A weak short-name match that landed on a Kotlin property is calling
+     * something that cannot be called. Re-resolve against callable candidates
+     * only rather than dropping outright: a property name often shadows a real
+     * function name (a `comment` property on one class, `fun comment(...)` on
+     * another), and the genuine target is in the same candidate pool. Drop only
+     * when narrowing finds nothing callable. The re-check below re-applies every
+     * guard the new target must also satisfy. */
+    if (cbm_kotlin_weak_match_is_uncallable(lang, res.strategy, target_node->label)) {
+        cbm_resolution_t cres = cbm_registry_resolve_callable(
+            ctx->registry, call->callee_name, module_qn, imp_keys, imp_vals, imp_count);
+        const cbm_gbuf_node_t *cnode = (cres.qualified_name && cres.qualified_name[0])
+                                           ? cbm_gbuf_find_by_qn(ctx->gbuf, cres.qualified_name)
+                                           : NULL;
+        if (!cnode || source_node->id == cnode->id ||
+            cbm_suppress_cross_language_suffix_match(lang, cnode->file_path, cres.strategy) ||
+            cbm_kotlin_weak_match_is_uncallable(lang, cres.strategy, cnode->label)) {
+            return 0;
+        }
+        res = cres;
+        target_node = cnode;
+    }
     emit_classified_edge(ctx, call, source_node, target_node, &res, module_qn, imp_keys, imp_vals,
                          imp_count, tsjs_drop_plain_call);
     return SKIP_ONE;

--- a/src/pipeline/pass_parallel.c
+++ b/src/pipeline/pass_parallel.c
@@ -2542,6 +2542,26 @@ static void resolve_file_calls(resolve_ctx_t *rc, resolve_worker_state_t *ws, CB
              * CALLS edge across a language boundary. */
             continue;
         }
+        if (target_node && source_node->id != target_node->id &&
+            cbm_kotlin_weak_match_is_uncallable(lang, res.strategy, target_node->label)) {
+            /* Same recovery as pass_calls.c — a weak short-name match onto a
+             * Kotlin property is calling something that cannot be called, so
+             * re-resolve against callable candidates only and drop only when
+             * narrowing finds nothing. */
+            cbm_resolution_t cres = cbm_registry_resolve_callable(
+                rc->registry, call->callee_name, module_qn, imp_keys, imp_vals, imp_count);
+            const cbm_gbuf_node_t *cnode =
+                (cres.qualified_name && cres.qualified_name[0])
+                    ? cbm_gbuf_find_by_qn(rc->main_gbuf, cres.qualified_name)
+                    : NULL;
+            if (!cnode || source_node->id == cnode->id ||
+                cbm_suppress_cross_language_suffix_match(lang, cnode->file_path, cres.strategy) ||
+                cbm_kotlin_weak_match_is_uncallable(lang, cres.strategy, cnode->label)) {
+                continue;
+            }
+            res = cres;
+            target_node = cnode;
+        }
         if (!target_node || source_node->id == target_node->id) {
             /* HTTP/ASYNC calls to an EXTERNAL client library (`requests.get(url)`)
              * resolve to an unindexed QN (target_node == NULL), but their edge

--- a/src/pipeline/pipeline.h
+++ b/src/pipeline/pipeline.h
@@ -227,6 +227,22 @@ cbm_resolution_t cbm_registry_resolve_lineage(const cbm_registry_t *r, const cha
                                               const char *module_qn, const char **import_map_keys,
                                               const char **import_map_vals, int import_map_count);
 
+/* Callable-narrowed resolve for CALL consumers. Identical to the default
+ * variant except that the bare-name strategies (unique_name / qualified_suffix /
+ * suffix_match) see only candidates whose label can be invoked, so a property
+ * that merely shares a function's name cannot win the name race. The import-map
+ * and same-module strategies are NOT narrowed: a non-callable target under those
+ * is a deliberate binding, not a collision.
+ *
+ * Call this only after the default resolve produced a weak match on an
+ * uncallable target (cbm_kotlin_weak_match_is_uncallable) — it is the recovery
+ * path, not the primary one, and is uncached for the same reason as the lineage
+ * variant. Returns an empty result when no callable candidate exists, which the
+ * caller should treat as "drop the edge". */
+cbm_resolution_t cbm_registry_resolve_callable(const cbm_registry_t *r, const char *callee_name,
+                                               const char *module_qn, const char **import_map_keys,
+                                               const char **import_map_vals, int import_map_count);
+
 /* Per-file memoization cache for is_import_reachable. Thread-local —
  * each resolve worker owns its own cache. Call _begin at the start
  * of resolve_file_calls (or any per-file resolve loop) and _end at
@@ -282,6 +298,20 @@ bool cbm_tsjs_suppress_weak_method_match(bool is_tsjs, bool is_method, const cha
  * Pure; unit-tested in test_registry.c. */
 bool cbm_suppress_cross_language_suffix_match(CBMLanguage caller_lang, const char *target_file_path,
                                               const char *strategy);
+
+/* True when a weak short-name strategy pointed a Kotlin CALLS edge at a property
+ * (Variable / Field). Properties are in the registry for read/write resolution,
+ * which also exposes their names to bare-name call matching; a Kotlin property is
+ * not callable, so such a match is never the real target. lsp_* / import /
+ * same-module matches are kept.
+ *
+ * A true answer means "re-resolve", not "drop": the caller retries via
+ * cbm_registry_resolve_callable and drops only if that finds no callable
+ * candidate. A property name frequently shadows a real function name, in which
+ * case the genuine target is in the same candidate pool and merely lost the name
+ * race. Pure; unit-tested in test_registry.c. */
+bool cbm_kotlin_weak_match_is_uncallable(CBMLanguage caller_lang, const char *strategy,
+                                         const char *target_label);
 
 /* Get the label of a qualified name, or NULL if not found. */
 const char *cbm_registry_label_of(const cbm_registry_t *r, const char *qn);

--- a/src/pipeline/registry.c
+++ b/src/pipeline/registry.c
@@ -456,6 +456,43 @@ bool cbm_tsjs_suppress_weak_method_match(bool is_tsjs, bool is_method, const cha
            strcmp(strategy, "field_type_hint") == 0 || strcmp(strategy, "fuzzy") == 0;
 }
 
+/* Kotlin analogue of the guards above, keyed on the TARGET rather than the
+ * receiver, and reporting a fact rather than prescribing a drop. Properties are
+ * registry symbols so that reads and writes can resolve to them, which also
+ * makes every property name a candidate for bare-name call matching:
+ * `x.current()` with an unresolved receiver lands on any property named
+ * `current` anywhere in the project. A property is not callable, so such a match
+ * is never the real target.
+ *
+ * Callers do NOT drop the edge on a true answer — they re-resolve with the
+ * candidate pool narrowed to callable declarations
+ * (cbm_registry_resolve_callable) and drop only if that finds nothing. The
+ * distinction matters whenever a property name shadows a real function name: the
+ * genuine target is in the same candidate pool and merely lost the name race, so
+ * vetoing the weak winner outright would delete a real edge.
+ *
+ * Scoped to Kotlin because that is the language whose property coverage this
+ * change extends; the reasoning is not Kotlin-specific and would transfer to the
+ * other JVM languages unchanged. Pure + side-effect-free so the contract is
+ * unit-testable without a full pipeline. */
+bool cbm_kotlin_weak_match_is_uncallable(CBMLanguage caller_lang, const char *strategy,
+                                         const char *target_label) {
+    if (caller_lang != CBM_LANG_KOTLIN || !strategy || !strategy[0] || !target_label) {
+        return false;
+    }
+    if (cbm_label_is_callable_target(target_label)) {
+        return false;
+    }
+    if (strcmp(target_label, "Variable") != 0 && strcmp(target_label, "Field") != 0) {
+        return false;
+    }
+    /* Same explicit strategy list as the TS/JS guard, for the same reason: lsp_*
+     * and import/same-module strategies are receiver- or import-aware, so a
+     * non-callable target under them is a deliberate binding and is KEPT. */
+    return strcmp(strategy, "suffix_match") == 0 || strcmp(strategy, "unique_name") == 0 ||
+           strcmp(strategy, "field_type_hint") == 0 || strcmp(strategy, "fuzzy") == 0;
+}
+
 static bool js_ts_family(CBMLanguage lang) {
     return lang == CBM_LANG_JAVASCRIPT || lang == CBM_LANG_TYPESCRIPT || lang == CBM_LANG_TSX;
 }
@@ -824,17 +861,49 @@ static const char *qualified_suffix_match(const qn_array_t *arr, const char *cal
     return match;
 }
 
+/* Narrow `arr` to candidates that can actually be called, into caller-provided
+ * storage. Returns a qn_array_t view over `keep` (borrowed pointers, no
+ * ownership), or the original `arr` unchanged when narrowing would leave nothing
+ * to resolve against. Mirrors the stack-array pattern of
+ * resolve_multi_with_imports. */
+static qn_array_t narrow_to_callable(const cbm_registry_t *r, const qn_array_t *arr, char **keep,
+                                     int keep_cap) {
+    int kept = 0;
+    for (int i = 0; i < arr->count && kept < keep_cap; i++) {
+        if (cbm_label_is_callable_target(cbm_registry_label_of(r, arr->items[i]))) {
+            keep[kept++] = arr->items[i];
+        }
+    }
+    if (kept == 0) {
+        return *arr;
+    }
+    qn_array_t narrowed = {.items = keep, .count = kept, .cap = kept};
+    return narrowed;
+}
+
 /* Strategy 3+4: Name lookup + suffix match */
 static cbm_resolution_t resolve_name_lookup(const cbm_registry_t *r, const char *callee_name,
                                             const char *module_qn, const char **import_vals,
-                                            int import_count) {
+                                            int import_count, bool callable_only) {
     const char *lookup = simple_name(callee_name);
-    qn_array_t *arr = cbm_ht_get(r->by_name, lookup);
-    if (!arr || arr->count == 0) {
+    qn_array_t *found = cbm_ht_get(r->by_name, lookup);
+    if (!found || found->count == 0) {
         return empty_result();
     }
-    if (arr->count > REG_MAX_CANDIDATES) {
+    if (found->count > REG_MAX_CANDIDATES) {
         return empty_result(); /* unresolvably ambiguous — see REG_MAX_CANDIDATES */
+    }
+
+    /* When the consumer is resolving a CALL, drop the candidates that cannot be
+     * called BEFORE any strategy below picks a winner. Doing it here rather than
+     * vetoing the winner afterwards is what lets a genuine function still resolve
+     * when a same-named property is also in the pool. */
+    char *keep_ptrs[REG_MAX_CANDIDATES];
+    qn_array_t narrowed_storage;
+    const qn_array_t *arr = found;
+    if (callable_only) {
+        narrowed_storage = narrow_to_callable(r, found, keep_ptrs, REG_MAX_CANDIDATES);
+        arr = &narrowed_storage;
     }
 
     /* Strategy 3.5: a qualified callee disambiguates among multiple same-name
@@ -869,11 +938,18 @@ static cbm_resolution_t resolve_name_lookup(const cbm_registry_t *r, const char 
     return empty_result();
 }
 
-/* The strategy chain shared by both public resolve variants (no caching here —
- * cbm_registry_resolve owns the per-file cache). */
+/* The strategy chain shared by all public resolve variants (no caching here —
+ * cbm_registry_resolve owns the per-file cache).
+ *
+ * callable_only narrows ONLY the bare-name strategies (3/3.5/4). Strategies 1
+ * and 2 (import_map, same_module) are deliberately left unnarrowed: they resolve
+ * a specific imported or same-module declaration, so a non-callable target under
+ * them is a deliberate binding (a property holding a function value, an invoked
+ * local) rather than a name collision. */
 static cbm_resolution_t registry_resolve_chain(const cbm_registry_t *r, const char *callee_name,
                                                const char *module_qn, const char **import_map_keys,
-                                               const char **import_map_vals, int import_map_count) {
+                                               const char **import_map_vals, int import_map_count,
+                                               bool callable_only) {
     /* Split callee at the first path separator: "pkg.Func" → prefix="pkg",
      * suffix="Func".  Rust/C++ use "::" rather than ".", so honor whichever
      * separator appears first ("lib::square" → prefix="lib", suffix="square").
@@ -910,7 +986,8 @@ static cbm_resolution_t registry_resolve_chain(const cbm_registry_t *r, const ch
     }
     if (!(res.qualified_name && res.qualified_name[0])) {
         /* Strategy 3+4: name lookup */
-        res = resolve_name_lookup(r, callee_name, module_qn, import_map_vals, import_map_count);
+        res = resolve_name_lookup(r, callee_name, module_qn, import_map_vals, import_map_count,
+                                  callable_only);
     }
     return res;
 }
@@ -934,7 +1011,7 @@ cbm_resolution_t cbm_registry_resolve(const cbm_registry_t *r, const char *calle
     }
 
     cbm_resolution_t res = registry_resolve_chain(r, callee_name, module_qn, import_map_keys,
-                                                  import_map_vals, import_map_count);
+                                                  import_map_vals, import_map_count, false);
 
     /* Data relations (Table/View) are lineage-only registry members: common
      * table names (users, orders, config) collide with code identifiers across
@@ -977,7 +1054,32 @@ cbm_resolution_t cbm_registry_resolve_lineage(const cbm_registry_t *r, const cha
      * it would poison one variant with the other's semantics. SQL files hold
      * few distinct relation refs, so the chain walk stays cheap. */
     return registry_resolve_chain(r, callee_name, module_qn, import_map_keys, import_map_vals,
-                                  import_map_count);
+                                  import_map_count, false);
+}
+
+cbm_resolution_t cbm_registry_resolve_callable(const cbm_registry_t *r, const char *callee_name,
+                                               const char *module_qn, const char **import_map_keys,
+                                               const char **import_map_vals, int import_map_count) {
+    if (!r || !callee_name) {
+        return empty_result();
+    }
+    /* Callable-narrowed variant for CALL consumers whose default resolution
+     * landed on a declaration that cannot be invoked (see
+     * cbm_kotlin_weak_match_is_uncallable). Uncached for the same reason as the
+     * lineage variant: the per-file cache is keyed by bare callee_name and holds
+     * the default variant's answer, so sharing it would poison one variant with
+     * the other's semantics. Only reached on the rare shadowed-name path, so the
+     * extra chain walk is bounded by the number of such call sites, not by the
+     * total call count. */
+    cbm_resolution_t res = registry_resolve_chain(r, callee_name, module_qn, import_map_keys,
+                                                  import_map_vals, import_map_count, true);
+    /* The default variant's central relation veto applies here too — a narrowed
+     * pool must not reintroduce a Table/View target. */
+    if (res.qualified_name && res.qualified_name[0] &&
+        cbm_label_is_relation(cbm_registry_label_of(r, res.qualified_name))) {
+        return empty_result();
+    }
+    return res;
 }
 
 /* ── Fuzzy Resolve ──────────────────────────────────────────────── */

--- a/tests/test_registry.c
+++ b/tests/test_registry.c
@@ -811,6 +811,58 @@ TEST(cross_language_suffix_match_drops_py_vs_js) {
     PASS();
 }
 
+TEST(kotlin_weak_match_on_property_is_uncallable) {
+    /* A Kotlin property is a registry symbol so reads/writes can resolve to it,
+     * which also makes its name a bare-name call candidate. Nothing can call it,
+     * so a weak short-name match onto one is never the real target. A true answer
+     * tells the caller to re-resolve against callable candidates only, not to
+     * drop the edge — see cbm_registry_resolve_callable. */
+    ASSERT_TRUE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_KOTLIN, "unique_name", "Variable"));
+    ASSERT_TRUE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_KOTLIN, "suffix_match", "Variable"));
+    ASSERT_TRUE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_KOTLIN, "field_type_hint", "Field"));
+    ASSERT_TRUE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_KOTLIN, "fuzzy", "Field"));
+    /* Callable targets are untouched whatever the strategy. */
+    ASSERT_FALSE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_KOTLIN, "unique_name", "Function"));
+    ASSERT_FALSE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_KOTLIN, "suffix_match", "Method"));
+    ASSERT_FALSE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_KOTLIN, "unique_name", "Class"));
+    /* Receiver- and import-aware strategies are kept even onto a property. */
+    ASSERT_FALSE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_KOTLIN, "same_module", "Variable"));
+    ASSERT_FALSE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_KOTLIN, "import_map", "Variable"));
+    ASSERT_FALSE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_KOTLIN, "lsp_kt_method", "Variable"));
+    /* Other languages, and no-match inputs, are unaffected. */
+    ASSERT_FALSE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_JAVA, "unique_name", "Variable"));
+    ASSERT_FALSE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_PYTHON, "unique_name", "Variable"));
+    ASSERT_FALSE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_KOTLIN, NULL, "Variable"));
+    ASSERT_FALSE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_KOTLIN, "", "Variable"));
+    ASSERT_FALSE(cbm_kotlin_weak_match_is_uncallable(CBM_LANG_KOTLIN, "unique_name", NULL));
+    PASS();
+}
+
+TEST(callable_label_predicate_is_narrower_than_registry_membership) {
+    /* The narrowing in cbm_registry_resolve_callable is only safe if every label
+     * a call can legitimately bind to is admitted. Constructor calls arrive as a
+     * Class target, so Class must be callable. */
+    ASSERT_TRUE(cbm_label_is_callable_target("Function"));
+    ASSERT_TRUE(cbm_label_is_callable_target("Method"));
+    ASSERT_TRUE(cbm_label_is_callable_target("Constructor"));
+    ASSERT_TRUE(cbm_label_is_callable_target("Class"));
+    /* Registry members that are not invocable. Interface/Enum are type-like and
+     * registry-admitted, but a call never binds to them directly. */
+    ASSERT_FALSE(cbm_label_is_callable_target("Variable"));
+    ASSERT_FALSE(cbm_label_is_callable_target("Field"));
+    ASSERT_FALSE(cbm_label_is_callable_target("Interface"));
+    ASSERT_FALSE(cbm_label_is_callable_target("Enum"));
+    ASSERT_FALSE(cbm_label_is_callable_target("Table"));
+    ASSERT_FALSE(cbm_label_is_callable_target(NULL));
+    /* Callable ⊂ registry-admitted: narrowing can only ever shrink the pool, so
+     * it cannot introduce a target the default resolve would have rejected. */
+    const char *callable[] = {"Function", "Method", "Class"};
+    for (size_t i = 0; i < sizeof(callable) / sizeof(callable[0]); i++) {
+        ASSERT_TRUE(cbm_label_is_registry_symbol(callable[i]));
+    }
+    PASS();
+}
+
 TEST(tsjs_suppress_drops_weak_method_matches) {
     /* #592/#606: a TS/JS member call whose receiver the LSP could not type, that
      * landed via a WEAK short-name strategy, is generic-resolver noise → drop.
@@ -946,5 +998,7 @@ SUITE(registry) {
     RUN_TEST(perl_suppress_keeps_high_confidence_and_genuine_calls);
     RUN_TEST(cross_language_suffix_match_drops_py_vs_js);
     RUN_TEST(tsjs_suppress_drops_weak_method_matches);
+    RUN_TEST(kotlin_weak_match_on_property_is_uncallable);
+    RUN_TEST(callable_label_predicate_is_narrower_than_registry_membership);
     RUN_TEST(tsjs_suppress_keeps_high_confidence_and_non_methods);
 }


### PR DESCRIPTION
## What does this PR do?

Makes the declared receiver type available to Kotlin call resolution, so a member
call through a constructor-injected property resolves by type instead of by name.
Refs #1555 (partial — see *What this does not fix*).

Two separable commits: the first makes property types available, the second stops
properties from winning the name race for calls.

### Root cause

`push_var_def_qn` never populated `return_type`, so **every** Kotlin property
cross-registered as an untyped placeholder. `kotlin_lookup_method` then had no
receiver type to match, missed, and resolution fell through to the name-only
strategies (`suffix_match`, `unique_name`, `field_type_hint`, `fuzzy`).

Primary-constructor properties were missing entirely: `class Foo(private val bar: Bar)`
declares a member reachable from every instance method, but it sits on the class
line rather than in the class body, so `extract_class_variables` never saw it.
That is precisely the constructor-injected-port shape in #1555.

This matches your own reading on that issue — *"receiver/parameter type and
existing `OVERRIDE` relationships are not consistently part of that final
candidate decision"*. This PR addresses the receiver-type half.

### Why narrowing the candidate pool, not vetoing the winner

`cbm_label_is_registry_symbol` admits `Variable` and `Field` so that reads and
writes can resolve. A consequence is that every property name is also a bare-name
candidate during *call* resolution, so a property can outrank the function a call
actually meant.

My first attempt vetoed the edge when a weak strategy landed on a property. That
is wrong, and measurably so: wherever a property shadows a function name — common
in Kotlin, since a constructor `val` and the method that reads it share
vocabulary — it deletes a genuine edge. On JetBrains/Exposed the veto form cost
**96 real method-target edges** (e.g. `AbstractQuery.comment` 24 → 2 edges,
shadowed by `val comment` in `ColumnDiff`/`ColumnMetadata`; `Query.where` 625 →
598, shadowed by `AbstractQuery.where` and the statement classes' `val where`).

So the split is by question, not by strategy:

- `cbm_label_is_registry_symbol` — *may this declaration be found by name?*
- `cbm_label_is_callable_target` (new) — *may a call bind to it?* (`Function`,
  `Method`, `Constructor`, `Class`)

`cbm_registry_resolve_callable` applies the narrower predicate **before** a winner
is picked, and only to strategies 3/3.5/4 — `import_map` and `same_module` are
untouched, since those already have real evidence. If a weak match lands on a
property, resolution is retried against callable candidates only; the edge is
dropped only if that also finds nothing.

Uncached, for the same reason `cbm_registry_resolve_lineage` is: `_resolve_cache`
is keyed on `callee_name` alone, so it cannot hold two different label policies.
`cbm_pipeline_node_is_callable_target` now delegates rather than repeating the
label list.

### Measurements

`JetBrains/Exposed` (~800 `.kt` files), full index, v0.10.2 baseline at `010569f`:

| | baseline | veto (rejected) | this PR |
|---|---|---|---|
| `lsp_kt_method` edges | 472 | 650 | **650** |
| `CALLS` → `Variable` (fabricated) | 874 | 188 | **188** |
| total `CALLS` rows | 30772 | 29965 | **30378** |
| `AbstractQuery.comment` | 24 | 2 | **24** |
| `Query.where` | 625 | 598 | **625** |
| `substring` / `init` | 33 / 11 | 32 / 6 | **33 / 11** |

Typed resolution up ~38%, name-only fabrications down ~78%, and no genuine edge
lost. I verified retry *targets* against source rather than just counting:
`comment` → `AbstractQuery.comment` (`AbstractQuery.kt:195`), `where` →
`Query.where` (exposed-jdbc `Query.kt:118`).

The 13 remaining method-target drops are all `kotlin.Any.equals` via
`lsp_kt_operator`, and that is an upgrade rather than a loss: baseline put 14
edges on the synthetic `kotlin.Any.equals` placeholder, this PR puts 0 there
while real overrides gain (`Column.equals` 1 → 3, `ResultRow.get` 3 → 4, plus new
`LinkedIdentityHashSet.contains` and `EntityClass.get`). The node exists in both
graphs — receivers are now typed, so `==` binds to the class's own override.

Also run against a large private Kotlin monorepo (~13k nodes) to check the
behaviour holds off the benchmark repo: `lsp_kt_method` 74 → 801, `CALLS` →
`Variable` 739 → 159, zero genuine edges lost.

### Testing

- `scripts/test.sh` (ASan + UBSan, full suite): **8435 assertions, 0 failures**,
  exit 0. The three nonzero-rc suites in the log are
  `test_parallel_harness_contract.sh`'s deliberate hang fixtures.
- `make -f Makefile.cbm test-focused TEST_SUITES=registry`: 60/60.
- New: `TEST(callable_label_predicate_is_narrower_than_registry_membership)`
  asserts the callable set is a strict subset of the registry-admitted set, which
  is the invariant the whole change rests on.
- Renamed `kotlin_suppress_weak_call_to_property` →
  `kotlin_weak_match_is_uncallable`: it now reports a fact ("this match cannot be
  called") rather than prescribing a drop, since the caller re-resolves.

One gap to flag honestly: `make -f Makefile.cbm lint-format` and `lint-no-suppress`
both pass locally, but I could not run `lint-cppcheck` (cppcheck isn't installed
on this machine), so that gate is unverified until CI runs it.

### What this does not fix

- **`OVERRIDE`/`INHERITS`-based disambiguation**, the other suggestion in #1555.
  A call through an interface-typed property still resolves to the interface
  method, not the implementation.
- **Inferred types beyond direct construction.** `val x: T` and `val x = Foo()`
  are handled; a factory or call chain returns NULL and falls through as before.
  Inferring through an expression is the type pass's job, not the extractor's.
- **Java is unaffected** — it already resolves these via `lsp_type_dispatch` at
  0.95. This is Kotlin-only.
- Adjacent and untouched: #1557 (companion-object members produce no nodes;
  `interface` labelled `Class`), #1556, #1732.
- The honest ceiling: `unique_name` + `suffix_match` are still the majority of
  `CALLS` edges on a large Kotlin repo even with this patch. This closes a
  specific typing gap; it does not make the Light Semantic Pass a compiler
  frontend.

One observation while validating: `EVALUATION_PLAN.md` measures precision/recall
for cross-repo (X1) and semantic (S1/S2) edges, but not call-resolution
correctness — so neither the original bug nor the regression my first attempt
introduced would have been caught by the existing harness. The strategy-mix
before/after A/B above is the check I fell back on; a fixture-based version of it
might be worth adding as a gate. Happy to open a separate issue if useful.

## Checklist

- [x] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests pass locally (`scripts/test.sh`, ASan+UBSan — 8435 asserts, 0 failures)
- [ ] Lint passes (`make -f Makefile.cbm lint-ci`) — `lint-format` and
      `lint-no-suppress` pass; `lint-cppcheck` not run locally (cppcheck
      unavailable), relying on CI
- [x] New behavior is covered by a test (reproduce-first for bug fixes)
