### PR TITLE
test(extract): bind the URL-builder language-gate test to a real URL shape

### DIFF
--- a/tests/test_extraction.c
+++ b/tests/test_extraction.c
@@ -3444,7 +3444,7 @@ static bool any_call_arg_resolves_to(CBMFileResult *r, const char *url) {
 
 TEST(extract_c_url_builder_gated_issue1009) {
     CBMFileResult *r = extract("static const char *cfg_path(void) {\n"
-                               "  return \"/etc/myapp/conf.d\";\n"
+                               "  return \"/srv/myapp/conf.d\";\n"
                                "}\n"
                                "void init(void) {\n"
                                "  parse_config(cfg_path());\n"
@@ -3452,7 +3452,7 @@ TEST(extract_c_url_builder_gated_issue1009) {
                                CBM_LANG_C, "t", "conf.c");
     ASSERT_NOT_NULL(r);
     ASSERT_FALSE(r->has_error);
-    ASSERT_FALSE(any_call_arg_resolves_to(r, "/etc/myapp/conf.d"));
+    ASSERT_FALSE(any_call_arg_resolves_to(r, "/srv/myapp/conf.d"));
     cbm_free_result(r);
     PASS();
 }


### PR DESCRIPTION
Follow-up to #1010, which merged as 909051cc.

That PR added a language gate restricting URL-builder resolution to JS/TS/TSX, and a test meant to prove C is excluded. The test does not prove it. Its fixture returns `/etc/myapp/conf.d`, and `is_filesystem_path()` rejects `/etc/` before `is_rest_path()` is ever consulted — so the value is never classified as a URL and never recorded as a builder, gate or no gate. Remove the gate entirely and the test still passes.

This changes the fixture to `/srv/myapp/conf.d`, which is not one of the ten filesystem prefixes and is therefore genuinely URL-shaped. Only the language gate now stops it being recorded for C.

**Verified by revert-check**, not by assertion:

- gate present → `extract_c_url_builder_gated_issue1009` PASS
- gate removed → FAIL at `tests/test_extraction.c:3455`
- gate restored → PASS

Two lines, fixture only. The gate implementation is unchanged and remains @CharlesQueiroz's work; he is credited as co-author.

My own fault for the original: `/etc/` was the example I used in July, and I only corrected it to "pick a path outside those prefixes" a few hours before the PR was pushed.
