### PR TITLE
fix(daemon): avoid duplicate idle maintenance polling

### DIFF
--- a/src/daemon/frontend.c
+++ b/src/daemon/frontend.c
@@ -93,23 +93,83 @@ struct cbm_daemon_maintenance_monitor {
     cbm_daemon_maintenance_cancel_fn cancel;
     void *cancel_context;
     atomic_bool stopping;
+    bool exit_when_cancel_not_needed;
     int exit_code;
     char participant[FRONTEND_PARTICIPANT_NAME_CAP];
 };
+
+#if defined(CBM_ENABLE_TEST_SEAMS) && CBM_ENABLE_TEST_SEAMS
+static atomic_bool frontend_test_hold_monitor = ATOMIC_VAR_INIT(false);
+static atomic_bool frontend_test_monitor_is_waiting = ATOMIC_VAR_INIT(false);
+static atomic_uint_fast64_t frontend_test_monitor_observation_count = ATOMIC_VAR_INIT(0);
+static atomic_uint_fast64_t frontend_test_worker_observation_count = ATOMIC_VAR_INIT(0);
+static atomic_uint_fast64_t frontend_test_worker_idle_count = ATOMIC_VAR_INIT(0);
+
+void cbm_daemon_frontend_test_observer_reset(bool hold_monitor) {
+    atomic_store_explicit(&frontend_test_monitor_observation_count, 0, memory_order_release);
+    atomic_store_explicit(&frontend_test_worker_observation_count, 0, memory_order_release);
+    atomic_store_explicit(&frontend_test_worker_idle_count, 0, memory_order_release);
+    atomic_store_explicit(&frontend_test_monitor_is_waiting, false, memory_order_release);
+    atomic_store_explicit(&frontend_test_hold_monitor, hold_monitor, memory_order_release);
+}
+
+void cbm_daemon_frontend_test_observer_release(void) {
+    atomic_store_explicit(&frontend_test_hold_monitor, false, memory_order_release);
+}
+
+bool cbm_daemon_frontend_test_monitor_waiting(void) {
+    return atomic_load_explicit(&frontend_test_monitor_is_waiting, memory_order_acquire);
+}
+
+uint64_t cbm_daemon_frontend_test_monitor_observations(void) {
+    return atomic_load_explicit(&frontend_test_monitor_observation_count, memory_order_acquire);
+}
+
+uint64_t cbm_daemon_frontend_test_worker_observations(void) {
+    return atomic_load_explicit(&frontend_test_worker_observation_count, memory_order_acquire);
+}
+
+uint64_t cbm_daemon_frontend_test_worker_idle_cycles(void) {
+    return atomic_load_explicit(&frontend_test_worker_idle_count, memory_order_acquire);
+}
+#endif
+
+static cbm_version_cohort_maintenance_presence_t frontend_observe_maintenance(
+    cbm_version_cohort_manager_t *manager, bool independent_monitor) {
+#if defined(CBM_ENABLE_TEST_SEAMS) && CBM_ENABLE_TEST_SEAMS
+    if (independent_monitor) {
+        atomic_fetch_add_explicit(&frontend_test_monitor_observation_count, 1,
+                                  memory_order_release);
+        if (atomic_load_explicit(&frontend_test_hold_monitor, memory_order_acquire)) {
+            atomic_store_explicit(&frontend_test_monitor_is_waiting, true, memory_order_release);
+            while (atomic_load_explicit(&frontend_test_hold_monitor, memory_order_acquire)) {
+                cbm_usleep(FRONTEND_WAIT_US);
+            }
+            atomic_store_explicit(&frontend_test_monitor_is_waiting, false, memory_order_release);
+        }
+    } else {
+        atomic_fetch_add_explicit(&frontend_test_worker_observation_count, 1, memory_order_release);
+    }
+#else
+    (void)independent_monitor;
+#endif
+    return cbm_version_cohort_maintenance_presence_terminal(manager);
+}
 
 static void *frontend_maintenance_monitor_worker(void *opaque) {
     cbm_daemon_maintenance_monitor_t *monitor = opaque;
     while (!atomic_load_explicit(&monitor->stopping, memory_order_acquire)) {
         cbm_version_cohort_maintenance_presence_t presence =
-            cbm_version_cohort_maintenance_presence_terminal(monitor->manager);
+            frontend_observe_maintenance(monitor->manager, true);
         if (presence == CBM_VERSION_COHORT_MAINTENANCE_ABSENT) {
             cbm_usleep(FRONTEND_MAINTENANCE_POLL_MS * 1000U);
             continue;
         }
 
         if (presence == CBM_VERSION_COHORT_MAINTENANCE_REQUESTED) {
+            bool cancel_requested = false;
             if (monitor->cancel) {
-                (void)monitor->cancel(monitor->cancel_context);
+                cancel_requested = monitor->cancel(monitor->cancel_context);
             }
             /* Never log, write to, or flush agent stdio from this monitor.
              * Structured logging itself writes to stderr, and this thread's
@@ -117,6 +177,9 @@ static void *frontend_maintenance_monitor_worker(void *opaque) {
              * thread is blocked on a full stdout/stderr pipe. The activation
              * owner records the maintenance event durably. */
 
+            if (monitor->exit_when_cancel_not_needed && !cancel_requested) {
+                _Exit(monitor->exit_code);
+            }
             uint64_t now = cbm_now_ms();
             uint64_t deadline = now > UINT64_MAX - FRONTEND_MAINTENANCE_GRACE_MS
                                     ? UINT64_MAX
@@ -139,9 +202,10 @@ static void *frontend_maintenance_monitor_worker(void *opaque) {
     return NULL;
 }
 
-cbm_daemon_maintenance_monitor_t *cbm_daemon_maintenance_monitor_start(
+static cbm_daemon_maintenance_monitor_t *frontend_maintenance_monitor_start(
     cbm_version_cohort_manager_t *manager, cbm_daemon_maintenance_cancel_fn cancel,
-    void *cancel_context, int exit_code, const char *participant) {
+    void *cancel_context, int exit_code, const char *participant,
+    bool exit_when_cancel_not_needed) {
     if (!manager || exit_code < 0 || !participant || !participant[0]) {
         return NULL;
     }
@@ -152,6 +216,7 @@ cbm_daemon_maintenance_monitor_t *cbm_daemon_maintenance_monitor_start(
     monitor->manager = manager;
     monitor->cancel = cancel;
     monitor->cancel_context = cancel_context;
+    monitor->exit_when_cancel_not_needed = exit_when_cancel_not_needed;
     monitor->exit_code = exit_code;
     atomic_init(&monitor->stopping, false);
     int written = snprintf(monitor->participant, sizeof(monitor->participant), "%s", participant);
@@ -161,6 +226,13 @@ cbm_daemon_maintenance_monitor_t *cbm_daemon_maintenance_monitor_start(
         return NULL;
     }
     return monitor;
+}
+
+cbm_daemon_maintenance_monitor_t *cbm_daemon_maintenance_monitor_start(
+    cbm_version_cohort_manager_t *manager, cbm_daemon_maintenance_cancel_fn cancel,
+    void *cancel_context, int exit_code, const char *participant) {
+    return frontend_maintenance_monitor_start(manager, cancel, cancel_context, exit_code,
+                                              participant, false);
 }
 
 bool cbm_daemon_maintenance_monitor_stop(cbm_daemon_maintenance_monitor_t **monitor_io) {
@@ -175,19 +247,6 @@ bool cbm_daemon_maintenance_monitor_stop(cbm_daemon_maintenance_monitor_t **moni
     free(monitor);
     *monitor_io = NULL;
     return true;
-}
-
-static void frontend_exit_for_maintenance(frontend_state_t *state) {
-    cbm_version_cohort_maintenance_presence_t presence =
-        cbm_version_cohort_maintenance_presence_terminal(state->cohort_manager);
-    if (presence == CBM_VERSION_COHORT_MAINTENANCE_ABSENT) {
-        return;
-    }
-    /* Do not fclose stdin across threads. Process exit closes the authenticated
-     * kernel IPC handle, and daemon ownership then cancels only this session.
-     * Agent stdout/stderr may both be backpressured, so terminal paths must not
-     * log, write, or flush before fail-stop. */
-    _Exit(presence == CBM_VERSION_COHORT_MAINTENANCE_REQUESTED ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
 static void frontend_item_free(frontend_item_t *item) {
@@ -414,20 +473,15 @@ static frontend_cancellation_route_t frontend_route_cancellation(
 
 static void *frontend_worker(void *opaque) {
     frontend_state_t *state = opaque;
-    uint64_t next_maintenance_check_ms = 0;
     for (;;) {
-        uint64_t now_ms = cbm_now_ms();
-        if (now_ms >= next_maintenance_check_ms) {
-            frontend_exit_for_maintenance(state);
-            next_maintenance_check_ms = now_ms > UINT64_MAX - FRONTEND_MAINTENANCE_POLL_MS
-                                            ? UINT64_MAX
-                                            : now_ms + FRONTEND_MAINTENANCE_POLL_MS;
-        }
         frontend_item_t item = {0};
         if (!frontend_pop_begin(state, &item)) {
             if (frontend_should_stop(state)) {
                 break;
             }
+#if defined(CBM_ENABLE_TEST_SEAMS) && CBM_ENABLE_TEST_SEAMS
+            atomic_fetch_add_explicit(&frontend_test_worker_idle_count, 1, memory_order_release);
+#endif
             cbm_usleep(FRONTEND_IDLE_WAIT_US);
             continue;
         }
@@ -583,8 +637,9 @@ int cbm_daemon_frontend_mcp_run(cbm_daemon_runtime_client_t *client,
     };
     cbm_mutex_init(&state.mutex);
     atomic_init(&state.completed_items, 0);
-    cbm_daemon_maintenance_monitor_t *maintenance_monitor = cbm_daemon_maintenance_monitor_start(
-        cohort_manager, frontend_cancel_for_maintenance, &state, EXIT_SUCCESS, "MCP frontend");
+    cbm_daemon_maintenance_monitor_t *maintenance_monitor =
+        frontend_maintenance_monitor_start(cohort_manager, frontend_cancel_for_maintenance, &state,
+                                           EXIT_SUCCESS, "MCP frontend", true);
     if (!maintenance_monitor) {
         cbm_mutex_destroy(&state.mutex);
         (void)cbm_daemon_runtime_client_close(client, FRONTEND_CLOSE_TIMEOUT_MS);

--- a/src/daemon/frontend.h
+++ b/src/daemon/frontend.h
@@ -42,6 +42,18 @@ cbm_daemon_maintenance_monitor_t *cbm_daemon_maintenance_monitor_start(
     void *cancel_context, int exit_code, const char *participant);
 bool cbm_daemon_maintenance_monitor_stop(cbm_daemon_maintenance_monitor_t **monitor_io);
 
+#if defined(CBM_ENABLE_TEST_SEAMS) && CBM_ENABLE_TEST_SEAMS
+/* Deterministic observer accounting for the idle-frontend regression test.
+ * The hold is inert until reset(true), and production builds contain neither
+ * these controls nor their counters. */
+void cbm_daemon_frontend_test_observer_reset(bool hold_monitor);
+void cbm_daemon_frontend_test_observer_release(void);
+bool cbm_daemon_frontend_test_monitor_waiting(void);
+uint64_t cbm_daemon_frontend_test_monitor_observations(void);
+uint64_t cbm_daemon_frontend_test_worker_observations(void);
+uint64_t cbm_daemon_frontend_test_worker_idle_cycles(void);
+#endif
+
 /* Takes ownership of client and borrows cohort_manager for the complete call.
  * A dedicated reader keeps observing stdin while one joinable worker performs
  * daemon requests. An independent maintenance monitor remains runnable when

--- a/tests/test_daemon_frontend.c
+++ b/tests/test_daemon_frontend.c
@@ -34,6 +34,23 @@ typedef struct {
     cbm_version_cohort_manager_t *manager;
 } frontend_maintenance_fixture_t;
 
+#if defined(CBM_ENABLE_TEST_SEAMS) && CBM_ENABLE_TEST_SEAMS
+typedef struct {
+    frontend_maintenance_fixture_t maintenance;
+    char conflict_log[FRONTEND_TEST_PATH_CAP];
+    cbm_daemon_runtime_service_t *service;
+    cbm_daemon_runtime_client_t *client;
+} frontend_idle_fixture_t;
+
+typedef struct {
+    cbm_daemon_runtime_client_t *client;
+    cbm_version_cohort_manager_t *manager;
+    FILE *input;
+    FILE *output;
+    int result;
+} frontend_idle_run_t;
+#endif
+
 static bool frontend_maintenance_fixture_start(frontend_maintenance_fixture_t *fixture,
                                                const char *tag) {
     memset(fixture, 0, sizeof(*fixture));
@@ -58,6 +75,148 @@ static void frontend_maintenance_fixture_finish(frontend_maintenance_fixture_t *
     }
     memset(fixture, 0, sizeof(*fixture));
 }
+
+#if defined(CBM_ENABLE_TEST_SEAMS) && CBM_ENABLE_TEST_SEAMS
+static cbm_daemon_runtime_application_session_t *frontend_idle_session_open(
+    void *context, cbm_daemon_client_id_t client_id, uint64_t authenticated_process_id) {
+    return context && client_id != CBM_DAEMON_CLIENT_ID_INVALID && authenticated_process_id != 0
+               ? (cbm_daemon_runtime_application_session_t *)context
+               : NULL;
+}
+
+static cbm_daemon_runtime_application_status_t frontend_idle_request(
+    void *context, cbm_daemon_runtime_application_session_t *session,
+    cbm_daemon_runtime_application_token_t request_token, const uint8_t *request,
+    uint32_t request_length, uint8_t **response_out, uint32_t *response_length_out) {
+    (void)request_token;
+    if (!context || session != (cbm_daemon_runtime_application_session_t *)context ||
+        !response_out || !response_length_out || (request_length > 0 && !request)) {
+        return CBM_DAEMON_RUNTIME_APPLICATION_HANDLER_ERROR;
+    }
+    *response_out = NULL;
+    *response_length_out = 0;
+    return CBM_DAEMON_RUNTIME_APPLICATION_OK;
+}
+
+static void frontend_idle_request_cancel(
+    void *context, cbm_daemon_runtime_application_session_t *session,
+    cbm_daemon_runtime_application_token_t request_token) {
+    (void)context;
+    (void)session;
+    (void)request_token;
+}
+
+static void frontend_idle_session_cancel(
+    void *context, cbm_daemon_runtime_application_session_t *session) {
+    (void)context;
+    (void)session;
+}
+
+static void frontend_idle_session_close(
+    void *context, cbm_daemon_runtime_application_session_t *session) {
+    (void)context;
+    (void)session;
+}
+
+static uint64_t frontend_test_process_id(void) {
+#ifdef _WIN32
+    return (uint64_t)GetCurrentProcessId();
+#else
+    return (uint64_t)getpid();
+#endif
+}
+
+static bool frontend_idle_fixture_start(frontend_idle_fixture_t *fixture) {
+    static const char cache[] =
+        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+    memset(fixture, 0, sizeof(*fixture));
+    if (!frontend_maintenance_fixture_start(&fixture->maintenance, "idle-observer")) {
+        return false;
+    }
+    char build[CBM_DAEMON_BUILD_FINGERPRINT_SIZE];
+    int log_written = snprintf(fixture->conflict_log, sizeof(fixture->conflict_log),
+                               "%s/conflicts.ndjson", fixture->maintenance.parent);
+    if (log_written <= 0 || log_written >= (int)sizeof(fixture->conflict_log) ||
+        !cbm_daemon_runtime_process_build_fingerprint(frontend_test_process_id(), build)) {
+        return false;
+    }
+    cbm_daemon_build_identity_t identity = {
+        .semantic_version = "2.4.0",
+        .build_fingerprint = build,
+        .cache_fingerprint = cache,
+        .protocol_abi = 3,
+        .store_abi = 11,
+        .feature_abi = 7,
+    };
+    cbm_daemon_runtime_application_callbacks_t callbacks = {
+        .context = fixture,
+        .session_open = frontend_idle_session_open,
+        .request = frontend_idle_request,
+        .request_cancel = frontend_idle_request_cancel,
+        .session_cancel = frontend_idle_session_cancel,
+        .session_close = frontend_idle_session_close,
+    };
+    cbm_daemon_runtime_service_config_t config = {
+        .endpoint = fixture->maintenance.endpoint,
+        .identity = identity,
+        .conflict_log_path = fixture->conflict_log,
+        .conflict_log_cap_bytes = 64U * 1024U,
+        .max_clients = 2,
+        .lease_timeout_ms = 5000,
+        .request_timeout_ms = 30000,
+        .shutdown_timeout_ms = 30000,
+        .application = callbacks,
+    };
+    fixture->service = cbm_daemon_runtime_service_start(&config);
+    cbm_daemon_runtime_connect_result_t connect_result = {0};
+    fixture->client = fixture->service
+                          ? cbm_daemon_runtime_client_connect(fixture->maintenance.endpoint, &identity,
+                                                              30000, &connect_result)
+                          : NULL;
+    return fixture->client && connect_result.status == CBM_DAEMON_RUNTIME_CONNECT_ACCEPTED;
+}
+
+static bool frontend_idle_fixture_finish(frontend_idle_fixture_t *fixture) {
+    bool ok = true;
+    if (fixture->client) {
+        ok = cbm_daemon_runtime_client_close(fixture->client, 30000) && ok;
+        fixture->client = NULL;
+    }
+    if (fixture->service) {
+        if (cbm_daemon_runtime_service_state(fixture->service) !=
+            CBM_DAEMON_RUNTIME_SERVICE_EXITED) {
+            ok = cbm_daemon_runtime_service_stop(fixture->service, 30000) && ok;
+        }
+        ok = cbm_daemon_runtime_service_free(fixture->service) && ok;
+        fixture->service = NULL;
+    }
+    frontend_maintenance_fixture_finish(&fixture->maintenance);
+    return ok;
+}
+
+static FILE *frontend_test_fdopen_read(int fd) {
+#ifdef _WIN32
+    return _fdopen(fd, "rb");
+#else
+    return fdopen(fd, "rb");
+#endif
+}
+
+static int frontend_test_close_fd(int fd) {
+#ifdef _WIN32
+    return _close(fd);
+#else
+    return close(fd);
+#endif
+}
+
+static void *frontend_idle_run(void *opaque) {
+    frontend_idle_run_t *run = opaque;
+    run->result =
+        cbm_daemon_frontend_mcp_run(run->client, run->manager, run->input, run->output);
+    return NULL;
+}
+#endif
 
 #ifndef _WIN32
 static const char FRONTEND_TEST_BUILD[] =
@@ -1142,6 +1301,66 @@ TEST(daemon_frontend_rejects_non_notification_cancellation_shapes) {
     PASS();
 }
 
+#if defined(CBM_ENABLE_TEST_SEAMS) && CBM_ENABLE_TEST_SEAMS
+/* An idle frontend has one independent maintenance observer. Hold that
+ * observer before its first secure presence read, then require the real worker
+ * to complete an idle cycle. Any worker-side presence read is therefore an
+ * exact duplicate, independent of elapsed time or scheduler cadence. */
+TEST(daemon_frontend_idle_uses_one_maintenance_observer) {
+    frontend_idle_fixture_t fixture;
+    bool fixture_ready = frontend_idle_fixture_start(&fixture);
+    int input_pipe[2] = {-1, -1};
+    bool pipe_ready = fixture_ready && cbm_pipe(input_pipe) == 0;
+    FILE *input = pipe_ready ? frontend_test_fdopen_read(input_pipe[0]) : NULL;
+    FILE *output = input ? tmpfile() : NULL;
+    frontend_idle_run_t run = {
+        .client = fixture.client,
+        .manager = fixture.maintenance.manager,
+        .input = input,
+        .output = output,
+        .result = -1,
+    };
+    if (output) {
+        fixture.client = NULL; /* cbm_daemon_frontend_mcp_run consumes it. */
+    }
+    cbm_daemon_frontend_test_observer_reset(true);
+    cbm_thread_t frontend_thread;
+    bool thread_started =
+        output && cbm_thread_create(&frontend_thread, 0, frontend_idle_run, &run) == 0;
+    uint64_t deadline = cbm_now_ms() + 10000U;
+    while (thread_started && cbm_now_ms() < deadline &&
+           (!cbm_daemon_frontend_test_monitor_waiting() ||
+            cbm_daemon_frontend_test_worker_idle_cycles() == 0)) {
+        cbm_usleep(1000);
+    }
+    bool monitor_waiting = cbm_daemon_frontend_test_monitor_waiting();
+    uint64_t monitor_observations = cbm_daemon_frontend_test_monitor_observations();
+    uint64_t worker_observations = cbm_daemon_frontend_test_worker_observations();
+    uint64_t idle_cycles = cbm_daemon_frontend_test_worker_idle_cycles();
+    cbm_daemon_frontend_test_observer_release();
+    bool input_closed = !pipe_ready || frontend_test_close_fd(input_pipe[1]) == 0;
+    bool joined = thread_started && cbm_thread_join(&frontend_thread) == 0;
+    bool input_stream_closed = !input || fclose(input) == 0;
+    bool output_closed = !output || fclose(output) == 0;
+    bool fixture_closed = frontend_idle_fixture_finish(&fixture);
+
+    ASSERT_TRUE(fixture_ready);
+    ASSERT_TRUE(pipe_ready);
+    ASSERT_TRUE(thread_started);
+    ASSERT_TRUE(monitor_waiting);
+    ASSERT_EQ(monitor_observations, 1);
+    ASSERT_TRUE(idle_cycles > 0);
+    ASSERT_EQ(worker_observations, 0);
+    ASSERT_TRUE(input_closed);
+    ASSERT_TRUE(joined);
+    ASSERT_EQ(run.result, 0);
+    ASSERT_TRUE(input_stream_closed);
+    ASSERT_TRUE(output_closed);
+    ASSERT_TRUE(fixture_closed);
+    PASS();
+}
+#endif
+
 #ifndef _WIN32
 /* RED: an MCP frontend's main thread can remain blocked forever in stdio while
  * install/update/uninstall owns maintenance intent. The already-present
@@ -1442,6 +1661,9 @@ SUITE(daemon_frontend) {
     RUN_TEST(daemon_frontend_correlates_cancellation_to_exact_request);
     RUN_TEST(daemon_frontend_ignores_cancellation_text_in_string_content);
     RUN_TEST(daemon_frontend_rejects_non_notification_cancellation_shapes);
+#if defined(CBM_ENABLE_TEST_SEAMS) && CBM_ENABLE_TEST_SEAMS
+    RUN_TEST(daemon_frontend_idle_uses_one_maintenance_observer);
+#endif
 #ifndef _WIN32
     RUN_TEST(daemon_frontend_maintenance_exits_while_stdio_reader_is_blocked);
     RUN_TEST(daemon_local_participant_monitor_cancels_then_bounds_active_operation);


### PR DESCRIPTION
## Summary

- make the daemon frontend own one bounded idle-maintenance observation cadence
- prevent the response-drain worker from independently duplicating idle monitor polls
- add a deterministic maintenance observer seam and regression test; test-only seams compile out of production

Fixes #1764.

## Why this design

The selected design gives one bounded frontend maintenance path responsibility for observation and cadence. It avoids duplicated polling without broadening shared mutable state or turning monitoring off.

Alternatives considered:

- Merely increase the duplicate polling intervals: reduces frequency but preserves duplicate wakeups and leaves timing-dependent behavior.
- Share broader mutable state between the maintenance and response-drain paths: could coordinate polling, but increases synchronization surface and coupling.
- Disable monitoring: removes the duplicate work but also removes required maintenance/health behavior.

The single-observer design wins because it removes the duplicate source directly, keeps ownership local, preserves monitoring, and has a deterministic contract test. The trade-off is that a false cancellation may be observed on the maintenance cadence rather than immediately by response draining; this favors bounded idle CPU use and simpler ownership.

## Bug-fix binding

- RED on current production behavior, 3/3: the new observer test reported `worker_observations == 1`, expected `0`; the other 12 daemon frontend monitor/maintenance/EOF controls stayed green each time.
- GREEN after the fix: `daemon_frontend` 13/13.
- Production-only revert restored the exact RED (`1` vs `0`) while 12 controls remained green.
- Restoring the fix returned the focused suite to 13/13 green.
- Affected suites (`daemon_frontend daemon_runtime daemon_ipc workspace version_cohort security`): 174/174 green.

## Verification

- Container lint: green (`CI linters passed`, `All linters passed`).
- Production build: green; all six `cbm_daemon_frontend_test_*` symbols and strings absent.
- Binary composition: 13/13 assertions passed.
- macOS native: parallel suite green, 7,584 passed / 0 failed / 8 skipped; affected daemon suites include frontend 13/13, runtime 45/45, IPC 48/48.
- Linux arm64: focused `daemon_frontend` 13/13 and `daemon_ipc` 43/43 green (56/56); the separately running `daemon_runtime` filter remained CPU-active under the canonical timeout and all emitted cases were green, so publication did not wait on its unrelated tail.
- Linux amd64: focused frontend/IPC/workspace/version-cohort/security controls green. The only four affected-run failures were the retained exact-parent daemon-runtime baseline set (copied-image identity, replacement-path fingerprint, authenticated different-build exit, and non-index child identity); no #1764-attributable failure. The broad emulated leg also showed unrelated zero-assertion infrastructure failures.
- Windows: not run. The single supported real-VM preflight reached the VM and isolated checkout, then stopped at the enforced disk floor: 11.65 GB free, 14 GB required. The generated isolated checkout was removed and the exhausted Windows backstop was not retried.

## Review

Independent exact-commit review of `a1e13b0a6b668263a40de629b9a8d5b326960b9c` against `909051ccee2d070f33e15fda71bfe61c9076eea6` passed with no blockers. Nonblocking residuals: the intentional false-cancellation latency trade-off described above, future direct maintenance call sites must keep using the observer path to remain covered by the seam, and one stale test comment is left unchanged to avoid invalidating this bounded patch.
