### PR TITLE
fix(install): forward clients selector

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,8 @@ main() {
 REPO="DeusData/codebase-memory-mcp"
 INSTALL_DIR="$HOME/.local/bin"
 SKIP_CONFIG=false
+CLIENTS_SET=false
+CLIENTS=""
 CBM_DOWNLOAD_URL="${CBM_DOWNLOAD_URL:-https://github.com/${REPO}/releases/latest/download}"
 
 # Security: every remote hop must remain HTTPS. Plain HTTP is accepted only
@@ -79,25 +81,45 @@ download_file() {
     fi
 }
 
-for arg in "$@"; do
-    case "$arg" in
-        --dir=*)        INSTALL_DIR="${arg#--dir=}" ;;
-        --skip-config)  SKIP_CONFIG=true ;;
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --dir=*)
+            INSTALL_DIR="${1#--dir=}"
+            shift
+            ;;
+        --dir)
+            if [ "$#" -lt 2 ] || [[ "$2" == -* ]]; then
+                echo "install.sh: '--dir' needs a value. Please consult --help." >&2
+                exit 2
+            fi
+            INSTALL_DIR="$2"
+            shift 2
+            ;;
+        --clients=*)
+            CLIENTS_SET=true
+            CLIENTS="${1#--clients=}"
+            shift
+            ;;
+        --skip-config)
+            SKIP_CONFIG=true
+            shift
+            ;;
         --help|-h)
-            echo "Usage: install.sh [--dir=<path>] [--skip-config]"
-            echo "  --dir PATH     Install directory (default: ~/.local/bin)"
-            echo "  --skip-config  Skip automatic agent configuration"
+            echo "Usage: install.sh [--dir=<path>] [--clients=<list>] [--skip-config]"
+            echo "  --dir PATH       Install directory (default: ~/.local/bin)"
+            echo "  --clients LIST   Configure only comma-separated clients"
+            echo "  --skip-config    Skip automatic agent configuration"
             exit 0
             ;;
+        -*)
+            echo "install.sh: unknown option '$1'. Please consult --help." >&2
+            exit 2
+            ;;
+        *)
+            echo "install.sh: unexpected argument '$1'. Please consult --help." >&2
+            exit 2
+            ;;
     esac
-done
-# Handle --dir <path> (space-separated)
-prev=""
-for arg in "$@"; do
-    if [ "$prev" = "--dir" ]; then
-        INSTALL_DIR="$arg"
-    fi
-    prev="$arg"
 done
 
 detect_os() {
@@ -314,6 +336,9 @@ echo "Verified candidate: $CANDIDATE_VERSION"
 
 DEST="$INSTALL_DIR/codebase-memory-mcp"
 INSTALL_ARGS=(-y --force "--dir=$INSTALL_DIR")
+if [ "$CLIENTS_SET" = true ]; then
+    INSTALL_ARGS+=("--clients=$CLIENTS")
+fi
 if [ "$SKIP_CONFIG" = true ]; then
     INSTALL_ARGS+=(--skip-config)
 fi

--- a/tests/test_smoke_fixture_contract.sh
+++ b/tests/test_smoke_fixture_contract.sh
@@ -8,10 +8,13 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 python3 - "$ROOT" <<'PY'
 from __future__ import annotations
 
+import hashlib
+import os
 import pathlib
 import re
 import subprocess
 import sys
+import tarfile
 import tempfile
 import time
 import urllib.request
@@ -412,6 +415,171 @@ require(
     "tests/test_smoke_fixture_contract.sh" in test_driver,
     "scripts/test.sh must run the smoke fixture contract",
 )
+
+# Functional wrapper contract: install.sh must pass its wrapper-only selectors
+# to the downloaded candidate, while retaining the existing dir/skip controls.
+# Native Windows ships and exercises install.ps1; the Unix wrapper is covered
+# on both macOS and Linux venue legs.
+if sys.platform != "win32":
+    with tempfile.TemporaryDirectory(prefix="cbm-install-wrapper-") as temp:
+        temp_path = pathlib.Path(temp)
+        fixture = temp_path / "fixture"
+        payload = temp_path / "payload"
+        fixture.mkdir()
+        payload.mkdir()
+
+        uname_s = subprocess.check_output(["uname", "-s"], text=True).strip()
+        uname_m = subprocess.check_output(["uname", "-m"], text=True).strip()
+        os_name = "darwin" if uname_s == "Darwin" else "linux"
+        if uname_m in ("arm64", "aarch64"):
+            arch_name = "arm64"
+        else:
+            arch_name = "amd64"
+        portable = "-portable" if os_name == "linux" else ""
+        archive_name = (
+            f"codebase-memory-mcp-{os_name}-{arch_name}{portable}.tar.gz"
+        )
+        archive = fixture / archive_name
+
+        candidate = payload / "codebase-memory-mcp"
+        candidate.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "if [ \"${1:-}\" = --version ]; then echo 'cbm fixture 0'; exit 0; fi\n"
+            "if [ \"${1:-}\" != install ]; then exit 64; fi\n"
+            "printf '%s\\n' \"$@\" > \"$CBM_INSTALL_ARG_LOG\"\n"
+            "target=''\n"
+            "for arg in \"$@\"; do case \"$arg\" in --dir=*) target=${arg#--dir=} ;; esac; done\n"
+            "[ -n \"$target\" ] || exit 65\n"
+            "mkdir -p \"$target\"\n"
+            "cp \"$0\" \"$target/codebase-memory-mcp\"\n",
+            encoding="utf-8",
+        )
+        candidate.chmod(0o755)
+        (payload / "LICENSE").write_text("fixture license\n", encoding="utf-8")
+        (payload / "install.sh").write_text(install_script, encoding="utf-8")
+        (payload / "THIRD_PARTY_NOTICES.md").write_text(
+            "fixture notices\n", encoding="utf-8"
+        )
+        with tarfile.open(archive, "w:gz") as bundle:
+            for name in (
+                "codebase-memory-mcp",
+                "LICENSE",
+                "install.sh",
+                "THIRD_PARTY_NOTICES.md",
+            ):
+                bundle.add(payload / name, arcname=name)
+        digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+        (fixture / "checksums.txt").write_text(
+            f"{digest}  {archive_name}\n", encoding="ascii"
+        )
+
+        # Replace curl only inside the subprocess environment. The wrapper still
+        # performs its real archive/checksum/extraction flow, but all bytes come
+        # from this generated fixture and no socket is opened.
+        fake_bin = temp_path / "fake-bin"
+        fake_bin.mkdir()
+        fake_curl = fake_bin / "curl"
+        fake_curl.write_text(
+            "#!/usr/bin/env python3\n"
+            "import os, pathlib, shutil, sys, urllib.parse\n"
+            "args = sys.argv[1:]\n"
+            "target = pathlib.Path(args[args.index('-o') + 1])\n"
+            "name = pathlib.PurePosixPath(urllib.parse.urlparse(args[-1]).path).name\n"
+            "shutil.copyfile(pathlib.Path(os.environ['CBM_INSTALL_FIXTURE']) / name, target)\n",
+            encoding="utf-8",
+        )
+        fake_curl.chmod(0o755)
+
+        wrapper = root / "install.sh"
+        help_result = subprocess.run(
+            [str(wrapper), "--help"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=10,
+            check=False,
+        )
+        require(
+            help_result.returncode == 0
+            and "--dir" in help_result.stdout
+            and "--skip-config" in help_result.stdout
+            and "--clients" in help_result.stdout,
+            "install.sh --help must document dir, skip-config, and clients",
+        )
+
+        base_env = dict(os.environ)
+        base_env.update(
+            CBM_DOWNLOAD_URL="http://127.0.0.1:9",
+            CBM_INSTALL_FIXTURE=str(fixture),
+            HOME=str(temp_path / "home"),
+            PATH=f"{fake_bin}{os.pathsep}{base_env['PATH']}",
+        )
+        pathlib.Path(base_env["HOME"]).mkdir()
+
+        def run_wrapper(
+            log_name: str, *arguments: str
+        ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+            argument_log = temp_path / log_name
+            env = dict(base_env)
+            env["CBM_INSTALL_ARG_LOG"] = str(argument_log)
+            result = subprocess.run(
+                [str(wrapper), *arguments],
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=20,
+                check=False,
+            )
+            logged = (
+                argument_log.read_text(encoding="utf-8").splitlines()
+                if argument_log.is_file()
+                else []
+            )
+            return result, logged
+
+        unknown, unknown_args = run_wrapper(
+            "unknown-args.log", "--definitely-not-a-wrapper-flag"
+        )
+        require(
+            unknown.returncode == 2
+            and "Please consult --help." in unknown.stdout
+            and not unknown_args,
+            "install.sh must reject unknown flags before executing the candidate",
+        )
+
+        selected_dir = temp_path / "selected-bin"
+        selected, selected_args = run_wrapper(
+            "selected-args.log",
+            f"--dir={selected_dir}",
+            "--clients=claude,codex",
+            "--skip-config",
+        )
+        require(
+            selected.returncode == 0
+            and selected_args
+            == [
+                "install",
+                "-y",
+                "--force",
+                f"--dir={selected_dir}",
+                "--clients=claude,codex",
+                "--skip-config",
+            ],
+            "install.sh must forward the explicit clients selector with dir and skip-config",
+        )
+
+        ordinary_dir = temp_path / "ordinary-bin"
+        ordinary, ordinary_args = run_wrapper(
+            "ordinary-args.log", f"--dir={ordinary_dir}"
+        )
+        require(
+            ordinary.returncode == 0
+            and ordinary_args
+            == ["install", "-y", "--force", f"--dir={ordinary_dir}"],
+            "install.sh without selectors must preserve the ordinary install arguments",
+        )
 
 # Functional check: the helper must publish a live kernel-assigned port and
 # serve the exact expected artifact. This is intentionally build-free.


### PR DESCRIPTION
## Summary

- parse Unix installer wrapper options in one strict pass
- forward an explicitly supplied `--clients=<list>` selector to the downloaded candidate
- preserve both supported `--dir` forms and the existing `--skip-config` behavior
- reject unknown, positional, or missing-value arguments before candidate execution

Closes #1753.

## Recommendation and trade-offs

The selected design is a strict single-pass wrapper parser. It distinguishes wrapper state from candidate arguments, then constructs the candidate argv explicitly. This keeps quoting intact, forwards `--clients` only when the caller supplied it, and makes unsupported input fail visibly instead of silently changing the requested configuration.

Material alternatives considered:

- Keep the permissive two-pass parser: smallest code change, but it cannot reliably add new valued options and silently accepts typos or stray arguments.
- Forward the original argv wholesale: less parsing code, but it blurs the wrapper/candidate boundary and risks passing wrapper-only controls with different semantics.
- Add another post-processing scan just for `--clients`: locally narrow, but order-sensitive and perpetuates the parser structure that caused the omission.

The strict single-pass approach won because it is deterministic, preserves exact argument boundaries, and gives future wrapper options one clear extension point. The main compatibility trade-off is intentional: previously ignored unknown or positional arguments now exit with status 2 and direct the caller to `--help`.

## Binding proof

The functional contract builds a hermetic release archive, substitutes a fixture-only `curl`, and exercises the real installer wrapper without opening a network socket. It asserts:

- exact candidate argv order for `--dir`, `--clients`, and `--skip-config`
- omission of `--clients` when no selector was supplied
- rejection of an unknown flag before candidate execution
- help coverage for all supported wrapper controls

The canonical reproduction was deterministic RED in 3/3 runs. The focused contract turned GREEN with the production change; reverting only the production change restored the exact RED; restoring it returned the contract to GREEN.

## Verification

Exact reviewed tree: `902f85b0f9566dea5a73a5dc2a724a282dc25fcb` on `909051ccee2d070f33e15fda71bfe61c9076eea6`.

- current-main `tests/test_smoke_fixture_contract.sh`: green
- current-main `scripts/lint.sh --ci`: green
- independent exact-commit review: PASS, no findings
- `bash -n`, ShellCheck, and `git diff --check`: green
- prior macOS full suite: 7,576 passed, 0 failed, 8 skipped
- prior real Windows ARM full result: 7,407 passed, 0 assertion failures, 63 skipped; an unrelated `grammar_probe_e` timeout was isolated with its focused 56/56 cases green
- prior Linux emitted/affected suites: green before coordinated infrastructure interruption

## Infrastructure caveats

Two identical Windows protected-temp-root disappearances exhausted that platform's rerun backstop, so no third full rerun was attempted. The Windows product assertions above remained green, and the unrelated timeout's focused cases passed. Linux emitted suites were green, but the broader leg was interrupted by shared infrastructure coordination rather than a product failure. These limits are recorded here for downstream review rather than hidden or retried probabilistically.
