### PR TITLE
fix: block sensitive program roots before background work

### DIFF
--- a/src/daemon/application.c
+++ b/src/daemon/application.c
@@ -14,6 +14,7 @@
 #include "foundation/secure_random.h"
 #include "foundation/sha256.h"
 #include "foundation/subprocess.h"
+#include "foundation/workspace.h"
 #include "mcp/index_supervisor.h"
 #include "mcp/mcp.h"
 #include "mcp/mcp_internal.h"
@@ -429,6 +430,22 @@ static void application_release_session_watch_locked(cbm_daemon_application_sess
     }
 }
 
+static bool application_session_workspace_allowed(const cbm_daemon_application_session_t *session,
+                                                  const char *operation) {
+    const char *root = session ? cbm_mcp_server_session_root(session->mcp) : NULL;
+    char boundary_error[CBM_SZ_1K];
+    bool allowed =
+        root && root[0] &&
+        cbm_workspace_root_allowed(root, cbm_workspace_home_dir(), cbm_workspace_cache_dir(),
+                                   cbm_mcp_server_allowed_root(session->mcp), boundary_error,
+                                   sizeof(boundary_error));
+    if (!allowed) {
+        cbm_log_warn("daemon.workspace.skipped", "operation", operation, "detail",
+                     root && root[0] ? boundary_error : "session root is unavailable");
+    }
+    return allowed;
+}
+
 /* Caller holds application->mutex. */
 static void application_refresh_watch_locked(cbm_daemon_application_session_t *session) {
     cbm_daemon_application_t *application = session->application;
@@ -440,6 +457,10 @@ static void application_refresh_watch_locked(cbm_daemon_application_session_t *s
     const char *project = cbm_mcp_server_session_project(session->mcp);
     const char *root = cbm_mcp_server_session_root(session->mcp);
     if (!project || !project[0] || !root || !root[0]) {
+        return;
+    }
+    if (!application_session_workspace_allowed(session, "watch")) {
+        application_release_session_watch_locked(session);
         return;
     }
     bool enabled = !application->config ||
@@ -1394,6 +1415,11 @@ static void application_auto_index_retry_pending_locked(cbm_daemon_application_t
             session->auto_index_retry_pending = false;
             continue;
         }
+        if (!application_session_workspace_allowed(session, "auto_index_retry")) {
+            session->auto_index_retry_pending = false;
+            application_refresh_watch_locked(session);
+            continue;
+        }
         if (application_regular_db_exists(project)) {
             session->auto_index_retry_pending = false;
             application_refresh_watch_locked(session);
@@ -1940,6 +1966,10 @@ static void application_background_initialize_impl(cbm_daemon_application_sessio
                             : CBM_MCP_DEFAULT_AUTO_INDEX_LIMIT;
     int tracked_files = -1;
     bool auto_index_candidate = auto_index && !db_exists;
+    if (auto_index_candidate &&
+        !application_session_workspace_allowed(session, "auto_index_discovery")) {
+        auto_index_candidate = false;
+    }
     bool within_auto_index_limit =
         !auto_index_candidate ||
         cbm_mcp_auto_index_within_file_limit(root_path, auto_index_limit, &tracked_files);

--- a/src/foundation/workspace.c
+++ b/src/foundation/workspace.c
@@ -211,6 +211,34 @@ static bool ws_any_component_matches(const char *path, const char *const *names,
     return false;
 }
 
+/* The default per-user Windows application prefix. Match from the drive root,
+ * by whole segments, so a project merely containing the same sequence (or a
+ * sibling such as Programs-src) is not captured. The second segment is the one
+ * and only user name; its spelling is deliberately unrestricted. */
+static bool ws_is_windows_user_programs_tree(const char *path) {
+    if (!ws_is_windows_style(path)) {
+        return false;
+    }
+    static const char *const expected[] = {"Users", NULL, "AppData", "Local", "Programs"};
+    const char *p = path + ws_volume_prefix_len(path);
+    for (size_t i = 0; i < sizeof(expected) / sizeof(expected[0]); i++) {
+        while (ws_is_sep(*p)) {
+            p++;
+        }
+        if (!*p) {
+            return false;
+        }
+        const char *start = p;
+        while (*p && !ws_is_sep(*p)) {
+            p++;
+        }
+        if (expected[i] && !ws_component_equals(start, (size_t)(p - start), expected[i], true)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 /* True when b is a or lives under a. Compares on a separator boundary so
  * "/a/bc" is not treated as living under "/a/b". */
 static bool ws_is_ancestor_or_equal(const char *a, const char *b) {
@@ -297,6 +325,10 @@ cbm_ws_verdict_t cbm_workspace_classify_root(const char *canonical_path, const c
         return CBM_WS_DENY_SENSITIVE;
     }
 
+    if (ws_is_windows_user_programs_tree(canonical_path)) {
+        return CBM_WS_DENY_SENSITIVE;
+    }
+
     /* "C:/Users" is the user tree itself — refuse it as a root, but leave the
      * projects below it alone; that is where Windows users actually work. */
     if (windows_style && depth == 1 &&
@@ -316,7 +348,7 @@ const char *cbm_workspace_verdict_reason(cbm_ws_verdict_t verdict) {
     case CBM_WS_DENY_ABSOLUTE:
         return "path is a volume root or holds the codebase-memory cache; it cannot be indexed";
     case CBM_WS_DENY_SENSITIVE:
-        return "path is a home or credential directory";
+        return "path is a home, credential, system, or application-install directory";
     default:
         break;
     }
@@ -455,10 +487,15 @@ bool cbm_workspace_grant_add(const char *cache_dir, const char *home_dir,
         }
     }
 
-    /* Already present is success, not a duplicate error. */
+    bool sensitive = verdict == CBM_WS_DENY_SENSITIVE;
+
+    /* Already present is success, not a duplicate error. A sensitive approval
+     * is narrower: an old ordinary grant (or an ordinary ancestor) establishes
+     * containment, but does not record the exact human-approved exception that
+     * cbm_workspace_root_allowed requires. Append that exact marked entry once. */
     ws_match_t existing = {canonical_path, false, false};
     (void)ws_grant_walk(cache_dir, ws_match_visit, &existing);
-    if (existing.contained) {
+    if (existing.contained && (!sensitive || existing.exact_sensitive)) {
         return true;
     }
 
@@ -476,7 +513,6 @@ bool cbm_workspace_grant_add(const char *cache_dir, const char *home_dir,
         }
         return false;
     }
-    bool sensitive = verdict == CBM_WS_DENY_SENSITIVE;
     (void)fprintf(f, "%s%s\n", sensitive ? "!" : "", canonical_path);
     bool ok = fclose(f) == 0;
     if (!ok && err) {

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -1600,6 +1600,10 @@ struct cbm_mcp_server {
     void *quarantine_test_context;
     cbm_mcp_command_test_hook_fn command_test_hook;
     void *command_test_context;
+#ifdef CBM_ENABLE_TEST_SEAMS
+    cbm_mcp_auto_index_count_test_hook_fn auto_index_count_test_hook;
+    void *auto_index_count_test_context;
+#endif
     size_t search_output_limit_override;
     cbm_thread_t autoindex_tid;
     bool autoindex_active; /* true if auto-index thread was started */
@@ -1668,6 +1672,17 @@ void cbm_mcp_server_set_config(cbm_mcp_server_t *srv, struct cbm_config *cfg) {
         srv->config = cfg;
     }
 }
+
+#ifdef CBM_ENABLE_TEST_SEAMS
+void cbm_mcp_server_set_auto_index_count_test_hook(cbm_mcp_server_t *srv,
+                                                   cbm_mcp_auto_index_count_test_hook_fn hook,
+                                                   void *context) {
+    if (srv) {
+        srv->auto_index_count_test_hook = hook;
+        srv->auto_index_count_test_context = context;
+    }
+}
+#endif
 
 bool cbm_mcp_server_set_session_context(cbm_mcp_server_t *srv, const char *session_root,
                                         const char *allowed_root) {
@@ -11624,6 +11639,21 @@ static void maybe_auto_index(cbm_mcp_server_t *srv) {
         return; /* no session root detected */
     }
 
+    /* Automatic work must honor the same shared workspace boundary as the
+     * explicit index_repository worker. Do this before the existing-DB watcher
+     * branch and before bounded discovery, so a refused session root begins no
+     * automatic observation or indexing. An exact sensitive-root grant remains
+     * the shared policy's authenticated override. */
+    const char *allowed_root =
+        srv->allowed_root_policy_set ? srv->allowed_root : getenv("CBM_ALLOWED_ROOT");
+    char boundary_err[CBM_SZ_1K];
+    if (!cbm_workspace_root_allowed(srv->session_root, cbm_workspace_home_dir(),
+                                    cbm_workspace_cache_dir(), allowed_root, boundary_err,
+                                    sizeof(boundary_err))) {
+        cbm_log_warn("autoindex.skip", "reason", "workspace_boundary", "detail", boundary_err);
+        return;
+    }
+
     /* Check if project already has a DB */
     const char *home = cbm_get_home_dir();
     if (home) {
@@ -11656,6 +11686,11 @@ static void maybe_auto_index(cbm_mcp_server_t *srv) {
 
     /* Quick tracked-file count check to avoid OOM on massive repos. */
     int file_count = -1;
+#ifdef CBM_ENABLE_TEST_SEAMS
+    if (srv->auto_index_count_test_hook) {
+        srv->auto_index_count_test_hook(srv->auto_index_count_test_context);
+    }
+#endif
     if (!cbm_mcp_auto_index_within_file_limit(srv->session_root, file_limit, &file_count)) {
         char files[32];
         (void)snprintf(files, sizeof(files), "%d", file_count);

--- a/src/mcp/mcp_internal.h
+++ b/src/mcp/mcp_internal.h
@@ -9,12 +9,20 @@
  * safety tests. This header is internal and is not part of the MCP API. */
 typedef bool (*cbm_mcp_quarantine_test_hook_fn)(void *context, const char *step);
 typedef bool (*cbm_mcp_command_test_hook_fn)(void *context, const char *command);
+#ifdef CBM_ENABLE_TEST_SEAMS
+typedef void (*cbm_mcp_auto_index_count_test_hook_fn)(void *context);
+#endif
 
 void cbm_mcp_server_set_quarantine_test_hook(cbm_mcp_server_t *srv,
                                              cbm_mcp_quarantine_test_hook_fn hook, void *context);
 void cbm_mcp_server_set_command_test_hook(cbm_mcp_server_t *srv, cbm_mcp_command_test_hook_fn hook,
                                           void *context);
 void cbm_mcp_server_set_search_output_limit_for_test(cbm_mcp_server_t *srv, size_t limit);
+#ifdef CBM_ENABLE_TEST_SEAMS
+void cbm_mcp_server_set_auto_index_count_test_hook(cbm_mcp_server_t *srv,
+                                                   cbm_mcp_auto_index_count_test_hook_fn hook,
+                                                   void *context);
+#endif
 
 /* Release only the constructor-created pristine in-memory store. Public
  * cbm_mcp_server_new(NULL) semantics remain unchanged; daemon sessions use

--- a/tests/repro/repro_issue403.c
+++ b/tests/repro/repro_issue403.c
@@ -1,159 +1,46 @@
 /*
- * repro_issue403.c -- Reproduce-first case for OPEN bug #403.
+ * repro_issue403.c -- Reproduce-first boundary case for issue #403.
  *
- * Issue: #403 -- "The IDE's installation directory is unnecessarily indexed"
- * https://github.com/DeusData/codebase-memory-mcp/issues/403
- *
- * Wrongly-indexed directory: AppData/Local/Programs/Antigravity
- *   (the Antigravity IDE install tree; reported name confirmed in issue comments)
- *
- * Root cause (src/discover/discover.c):
- *   cbm_should_skip_dir() (line 339) tests only the BARE directory name
- *   (entry->name, the last path component) against ALWAYS_SKIP_DIRS and
- *   FAST_SKIP_DIRS.  None of "AppData", "Local", "Programs", or "Antigravity"
- *   appears in either list.  Therefore cbm_discover() walks straight into the
- *   IDE install tree and indexes every source-like file it contains.
- *
- *   There is no install-directory guard at ANY layer:
- *     - ALWAYS_SKIP_DIRS covers VCS, build tools, and caches -- not IDE
- *       install prefixes (Programs, AppData/Local/Programs, etc.).
- *     - The .gitignore path is only loaded when a .git directory is present
- *       (is_git_repo gate, line 777 of discover.c).  An IDE install dir does
- *       not contain .git, so .gitignore exclusions never fire.
- *     - The cbmignore path (opts->ignore_file or .cbmignore at root) is
- *       similarly absent from an install dir by default.
- *   Result: any source-extension file found under Antigravity/ is returned
- *   as a discovered file, bloating the graph with IDE internals.
- *
- * Expected (correct) behaviour:
- *   When cbm_discover() is called on a directory that contains an
- *   "Antigravity" subdirectory (or more generally any IDE install subtree),
- *   files under that subdirectory must NOT appear in the discovered file list.
- *   The correct fix (per the issue owner's comment) is to add "Antigravity"
- *   (and the broader "Programs" / install-dir pattern) to the exclusion layer,
- *   OR to extend the exclusion to root-path patterns so auto-index never picks
- *   an install dir as a project root in the first place.
- *
- * Actual (buggy) behaviour:
- *   cbm_discover() returns files under Antigravity/ as normal discovered
- *   files because the bare dirname "Antigravity" is absent from ALWAYS_SKIP_DIRS.
- *
- * Why RED on current code:
- *   The fixture creates a temp dir with:
- *     normal.py           -- a legitimate source file (control: MUST appear)
- *     Antigravity/ide.py  -- sentinel inside the IDE install dir (MUST NOT appear)
- *   cbm_discover() is called on the temp dir.  The loop below asserts that
- *   ide.py is NOT in the result.  On current code "Antigravity" is not skipped,
- *   so ide.py IS discovered and the ASSERT_FALSE fires RED.
- *
- * Fix location (not implemented here):
- *   src/discover/discover.c, ALWAYS_SKIP_DIRS array:
- *   Add "Antigravity" (and any other IDE install dir names to be excluded)
- *   to the NULL-terminated list.  The broader fix is to extend the list with
- *   install-path components ("Programs", "AppData") or, per the issue owner,
- *   to implement a root-path exclusion in the auto-index root-selection logic
- *   so directories under AppData/Local/Programs are never chosen as repo roots.
- *
- * Exclusion is NOT config-driven in the current code.  The closest knob is a
- * .cbmignore file at the repo root (loaded unconditionally, unlike .gitignore
- * which requires .git/).  Passing opts->ignore_file also works.  However,
- * neither is set in this test -- we assert on the default behaviour, which is
- * what the bug reporter experiences.
+ * Automatic session discovery must not treat the default per-user Windows
+ * application install tree as a workspace. This is a root-selection policy,
+ * not a vendor-name exclusion: ordinary projects elsewhere remain eligible.
  */
 
-#include <foundation/compat.h>
 #include "test_framework.h"
-#include "test_helpers.h"
-#include "discover/discover.h"
+#include "foundation/workspace.h"
 
-#include <string.h>
-#include <stdlib.h>
-#include <stdio.h>
+TEST(repro_issue403_windows_user_programs_root_is_sensitive) {
+    static const char *const roots[] = {
+        "C:/Users/dev/AppData/Local/Programs",
+        "C:/Users/dev/AppData/Local/Programs/Antigravity",
+        "D:/Users/runneradmin/AppData/Local/Programs/Editor",
+        "c:\\uSeRs\\Dev\\aPpDaTa\\LoCaL\\pRoGrAmS\\IDE",
+    };
 
-/* ── Fixture ────────────────────────────────────────────────────────────────
- *
- * Directory layout (NOT a git repo -- no .git/ subdir):
- *
- *   <tmpdir>/
- *     normal.py           <- legitimate source file; MUST be discovered
- *     Antigravity/
- *       ide.py            <- sentinel inside IDE install dir; must NOT appear
- *
- * cbm_discover() is called on <tmpdir> with no opts (NULL) so all default
- * exclusions apply and no extra ignore file is consulted.
- *
- * Control assertion (expected GREEN even on buggy code):
- *   normal.py IS in the result -- proves discovery ran at all.
- *
- * Primary assertion (RED on buggy code):
- *   ide.py is NOT in the result -- the Antigravity subtree was skipped.
- */
-
-TEST(repro_issue403_install_dir_excluded) {
-    /* --- set up temp directory --- */
-    char tmpdir[256];
-    snprintf(tmpdir, sizeof(tmpdir), "%s/cbm_repro403_XXXXXX", cbm_tmpdir());
-    ASSERT_NOT_NULL(cbm_mkdtemp(tmpdir));
-
-    /* Control file: a normal Python source at the repo root. */
-    ASSERT_EQ(0, th_write_file(TH_PATH(tmpdir, "normal.py"),
-                               "def hello(): return 1\n"));
-
-    /* Sentinel file: a Python source inside the Antigravity install dir.
-     * This is the file that MUST be absent from discovery results.
-     * th_write_file creates intermediate directories automatically. */
-    ASSERT_EQ(0, th_write_file(TH_PATH(tmpdir, "Antigravity/ide.py"),
-                               "# Antigravity IDE internal module\ndef _internal(): pass\n"));
-
-    /* --- Run discovery (default opts: no .git, no .cbmignore, no opts) --- */
-    cbm_file_info_t *files = NULL;
-    int count = 0;
-    int rc = cbm_discover(tmpdir, NULL, &files, &count);
-    ASSERT_EQ(0, rc);
-
-    /* --- Scan results --- */
-    bool normal_found    = false;
-    bool ide_file_found  = false;
-    for (int i = 0; i < count; i++) {
-        if (strcmp(files[i].rel_path, "normal.py") == 0) {
-            normal_found = true;
-        }
-        /* Match any path that descends into the Antigravity directory. */
-        if (strncmp(files[i].rel_path, "Antigravity/", 12) == 0 ||
-            strcmp(files[i].rel_path, "Antigravity") == 0) {
-            ide_file_found = true;
-            printf("  BUG #403 reproduced: IDE install-dir file indexed: %s\n",
-                   files[i].rel_path);
-        }
+    for (size_t i = 0; i < sizeof(roots) / sizeof(roots[0]); i++) {
+        ASSERT_EQ(cbm_workspace_classify_root(roots[i], NULL, NULL), CBM_WS_DENY_SENSITIVE);
     }
-
-    cbm_discover_free(files, count);
-    th_rmtree(tmpdir);
-
-    /* Control: normal.py must be discovered -- discovery ran correctly. */
-    ASSERT_TRUE(normal_found);
-
-    /*
-     * PRIMARY assertion (RED on buggy code):
-     *
-     * No file under Antigravity/ may appear in the discovered set.
-     * On current code, "Antigravity" is absent from ALWAYS_SKIP_DIRS so
-     * cbm_should_skip_dir("Antigravity", ...) returns false and the walk
-     * descends into it.  ide.py is discovered, ide_file_found is true, and
-     * this ASSERT_FALSE fires RED.
-     *
-     * After the fix -- "Antigravity" added to ALWAYS_SKIP_DIRS (or an
-     * equivalent install-path exclusion applied) -- cbm_should_skip_dir
-     * returns true, the subtree is skipped, ide_file_found stays false,
-     * and this assertion passes GREEN.
-     */
-    ASSERT_FALSE(ide_file_found);
-
+    ASSERT_TRUE(cbm_workspace_verdict_is_overridable(CBM_WS_DENY_SENSITIVE));
     PASS();
 }
 
-/* ── Suite ──────────────────────────────────────────────────────────────── */
+TEST(repro_issue403_nearby_projects_are_not_false_positives) {
+    static const char *const roots[] = {
+        "C:/Users/dev/projects/app",
+        "C:/Users/dev/AppData/Local",
+        "C:/Users/dev/AppData/Local/Programs-src",
+        "C:/Users/dev/AppData/Local/ProgramsBackup",
+        "C:/workspace/Users/dev/AppData/Local/Programs",
+        "C:/Users/dev/team/AppData/Local/Programs",
+    };
+
+    for (size_t i = 0; i < sizeof(roots) / sizeof(roots[0]); i++) {
+        ASSERT_EQ(cbm_workspace_classify_root(roots[i], NULL, NULL), CBM_WS_ALLOW);
+    }
+    PASS();
+}
 
 SUITE(repro_issue403) {
-    RUN_TEST(repro_issue403_install_dir_excluded);
+    RUN_TEST(repro_issue403_windows_user_programs_root_is_sensitive);
+    RUN_TEST(repro_issue403_nearby_projects_are_not_false_positives);
 }

--- a/tests/test_daemon_application.c
+++ b/tests/test_daemon_application.c
@@ -15,6 +15,7 @@
 #include "foundation/platform.h"
 #include "foundation/sha256.h"
 #include "foundation/subprocess.h"
+#include "foundation/workspace.h"
 #include "mcp/mcp.h"
 #include "mcp/mcp_internal.h"
 #include "pipeline/pipeline.h"
@@ -2086,6 +2087,266 @@ TEST(daemon_application_initialize_coalesces_auto_index_for_full_sessions) {
     ASSERT_EQ(atomic_load(&update.destroys), 1);
     ASSERT_TRUE(stopped);
     ASSERT_TRUE(cache_restored);
+    PASS();
+}
+
+TEST(daemon_application_sensitive_root_blocks_auto_index_but_preserves_controls) {
+    app_env_backup_t cache_environment;
+    app_env_backup_t home_environment;
+    bool environments_saved = app_env_backup_capture(&cache_environment, "CBM_CACHE_DIR") &&
+                              app_env_backup_capture(&home_environment, "HOME");
+    char sensitive_raw[APP_TEST_PATH_CAP];
+    char ordinary_raw[APP_TEST_PATH_CAP];
+    char cache_raw[APP_TEST_PATH_CAP];
+    (void)snprintf(sensitive_raw, sizeof(sensitive_raw), "%s/cbm-app-sensitive-auto-home-XXXXXX",
+                   cbm_tmpdir());
+    (void)snprintf(ordinary_raw, sizeof(ordinary_raw), "%s/cbm-app-sensitive-auto-project-XXXXXX",
+                   cbm_tmpdir());
+    (void)snprintf(cache_raw, sizeof(cache_raw), "%s/cbm-app-sensitive-auto-cache-XXXXXX",
+                   cbm_tmpdir());
+    bool dirs_ok = cbm_mkdtemp(sensitive_raw) != NULL && cbm_mkdtemp(ordinary_raw) != NULL &&
+                   cbm_mkdtemp(cache_raw) != NULL;
+    char sensitive[APP_TEST_PATH_CAP] = {0};
+    char ordinary[APP_TEST_PATH_CAP] = {0};
+    char cache[APP_TEST_PATH_CAP] = {0};
+    bool canonical = dirs_ok && cbm_canonical_path(sensitive_raw, sensitive, sizeof(sensitive)) &&
+                     cbm_canonical_path(ordinary_raw, ordinary, sizeof(ordinary)) &&
+                     cbm_canonical_path(cache_raw, cache, sizeof(cache));
+    char sensitive_source[APP_TEST_PATH_CAP];
+    char ordinary_source[APP_TEST_PATH_CAP];
+    (void)snprintf(sensitive_source, sizeof(sensitive_source), "%s/tracked.c", sensitive);
+    (void)snprintf(ordinary_source, sizeof(ordinary_source), "%s/tracked.c", ordinary);
+    bool files_ok = canonical && app_test_create_empty_file(sensitive_source) &&
+                    app_test_create_empty_file(ordinary_source);
+    bool environments_set = environments_saved && files_ok &&
+                            cbm_setenv("CBM_CACHE_DIR", cache, 1) == 0 &&
+                            cbm_setenv("HOME", sensitive, 1) == 0;
+    cbm_config_t *stored_config = environments_set ? cbm_config_open(cache) : NULL;
+    bool config_ready = stored_config &&
+                        cbm_config_set(stored_config, CBM_CONFIG_AUTO_INDEX, "true") == 0 &&
+                        cbm_config_set(stored_config, CBM_CONFIG_AUTO_WATCH, "false") == 0;
+
+    app_fake_worker_context_t fake;
+    app_fake_worker_context_init(&fake);
+    cbm_daemon_application_worker_ops_t worker_ops = {
+        .context = &fake,
+        .start = app_fake_worker_start,
+        .poll = app_fake_worker_poll,
+        .cancel = app_fake_worker_cancel,
+        .log_path = app_fake_worker_log_path,
+        .destroy = app_fake_worker_destroy,
+    };
+    cbm_daemon_application_config_t config = {
+        .config = stored_config,
+        .worker_ops = &worker_ops,
+    };
+    cbm_daemon_application_t *application =
+        config_ready ? cbm_daemon_application_new(&config) : NULL;
+    cbm_daemon_runtime_application_callbacks_t callbacks =
+        cbm_daemon_application_runtime_callbacks(application);
+    cbm_daemon_runtime_application_session_t *sensitive_session =
+        application ? app_test_open(&callbacks, 4030) : NULL;
+    cbm_daemon_runtime_application_session_t *ordinary_session =
+        application ? app_test_open(&callbacks, 4031) : NULL;
+    cbm_daemon_runtime_application_session_t *approved_session =
+        application ? app_test_open(&callbacks, 4032) : NULL;
+
+    int background_baseline = cbm_daemon_application_background_initializes_for_test();
+    bool sensitive_initialized = app_test_initialize_profile(
+        &callbacks, sensitive_session, sensitive, CBM_MCP_TOOL_PROFILE_ALL, NULL, NULL);
+    bool sensitive_evaluated = app_wait_for_background_initializes(background_baseline + 1);
+    bool sensitive_blocked = sensitive_initialized && sensitive_evaluated &&
+                             atomic_load(&fake.starts) == 0 &&
+                             cbm_daemon_application_active_jobs(application) == 0;
+
+    bool ordinary_initialized = app_test_initialize_profile(&callbacks, ordinary_session, ordinary,
+                                                            CBM_MCP_TOOL_PROFILE_ALL, NULL, NULL);
+    bool ordinary_admitted = ordinary_initialized && app_wait_for_atomic_int(&fake.starts, 1) &&
+                             cbm_daemon_application_active_jobs(application) == 1;
+    if (ordinary_session) {
+        callbacks.session_cancel(callbacks.context, ordinary_session);
+        callbacks.session_close(callbacks.context, ordinary_session);
+        ordinary_session = NULL;
+    }
+    bool ordinary_reaped = ordinary_admitted && app_wait_for_atomic_int(&fake.cancels, 1) &&
+                           app_wait_for_atomic_int(&fake.destroys, 1) &&
+                           app_wait_for_active_jobs(application, 0);
+
+    char grant_error[APP_TEST_PATH_CAP];
+    bool approved = ordinary_reaped && cbm_workspace_grant_add(cache, sensitive, sensitive, true,
+                                                               grant_error, sizeof(grant_error));
+    bool approved_initialized =
+        approved && app_test_initialize_profile(&callbacks, approved_session, sensitive,
+                                                CBM_MCP_TOOL_PROFILE_ALL, NULL, NULL);
+    bool approved_admitted = approved_initialized && app_wait_for_atomic_int(&fake.starts, 2) &&
+                             cbm_daemon_application_active_jobs(application) == 1;
+
+    if (sensitive_session) {
+        callbacks.session_cancel(callbacks.context, sensitive_session);
+        callbacks.session_close(callbacks.context, sensitive_session);
+    }
+    if (approved_session) {
+        callbacks.session_cancel(callbacks.context, approved_session);
+        callbacks.session_close(callbacks.context, approved_session);
+    }
+    if (ordinary_session) {
+        callbacks.session_cancel(callbacks.context, ordinary_session);
+        callbacks.session_close(callbacks.context, ordinary_session);
+    }
+    bool approved_reaped = approved_admitted && app_wait_for_atomic_int(&fake.cancels, 2) &&
+                           app_wait_for_atomic_int(&fake.destroys, 2) &&
+                           app_wait_for_active_jobs(application, 0);
+    if (!approved_reaped) {
+        atomic_store(&fake.allow_completion, true);
+    }
+    bool stopped = application && cbm_daemon_application_shutdown(application, APP_TEST_TIMEOUT_MS);
+    cbm_daemon_application_free(application);
+    cbm_config_close(stored_config);
+    (void)th_rmtree(sensitive);
+    (void)th_rmtree(ordinary);
+    (void)th_rmtree(cache);
+    bool cache_restored = app_env_backup_restore(&cache_environment);
+    bool home_restored = app_env_backup_restore(&home_environment);
+
+    ASSERT_TRUE(environments_saved);
+    ASSERT_TRUE(dirs_ok);
+    ASSERT_TRUE(canonical);
+    ASSERT_TRUE(files_ok);
+    ASSERT_TRUE(environments_set);
+    ASSERT_TRUE(config_ready);
+    ASSERT_TRUE(sensitive_blocked);
+    ASSERT_TRUE(ordinary_admitted);
+    ASSERT_TRUE(ordinary_reaped);
+    ASSERT_TRUE(approved);
+    ASSERT_TRUE(approved_admitted);
+    ASSERT_TRUE(approved_reaped);
+    ASSERT_TRUE(stopped);
+    ASSERT_TRUE(cache_restored);
+    ASSERT_TRUE(home_restored);
+    PASS();
+}
+
+TEST(daemon_application_sensitive_root_blocks_watch_but_preserves_controls) {
+    app_env_backup_t cache_environment;
+    app_env_backup_t home_environment;
+    bool environments_saved = app_env_backup_capture(&cache_environment, "CBM_CACHE_DIR") &&
+                              app_env_backup_capture(&home_environment, "HOME");
+    char sensitive_raw[APP_TEST_PATH_CAP];
+    char ordinary_raw[APP_TEST_PATH_CAP];
+    char cache_raw[APP_TEST_PATH_CAP];
+    (void)snprintf(sensitive_raw, sizeof(sensitive_raw), "%s/cbm-app-sensitive-watch-home-XXXXXX",
+                   cbm_tmpdir());
+    (void)snprintf(ordinary_raw, sizeof(ordinary_raw), "%s/cbm-app-sensitive-watch-project-XXXXXX",
+                   cbm_tmpdir());
+    (void)snprintf(cache_raw, sizeof(cache_raw), "%s/cbm-app-sensitive-watch-cache-XXXXXX",
+                   cbm_tmpdir());
+    bool dirs_ok = cbm_mkdtemp(sensitive_raw) != NULL && cbm_mkdtemp(ordinary_raw) != NULL &&
+                   cbm_mkdtemp(cache_raw) != NULL;
+    char sensitive[APP_TEST_PATH_CAP] = {0};
+    char ordinary[APP_TEST_PATH_CAP] = {0};
+    char cache[APP_TEST_PATH_CAP] = {0};
+    bool canonical = dirs_ok && cbm_canonical_path(sensitive_raw, sensitive, sizeof(sensitive)) &&
+                     cbm_canonical_path(ordinary_raw, ordinary, sizeof(ordinary)) &&
+                     cbm_canonical_path(cache_raw, cache, sizeof(cache));
+    bool environments_set = environments_saved && canonical &&
+                            cbm_setenv("CBM_CACHE_DIR", cache, 1) == 0 &&
+                            cbm_setenv("HOME", sensitive, 1) == 0;
+    cbm_config_t *stored_config = environments_set ? cbm_config_open(cache) : NULL;
+    bool config_ready = stored_config &&
+                        cbm_config_set(stored_config, CBM_CONFIG_AUTO_INDEX, "false") == 0 &&
+                        cbm_config_set(stored_config, CBM_CONFIG_AUTO_WATCH, "true") == 0;
+    char *sensitive_project = canonical ? cbm_project_name_from_path(sensitive) : NULL;
+    char *ordinary_project = canonical ? cbm_project_name_from_path(ordinary) : NULL;
+    char sensitive_db[APP_TEST_PATH_CAP] = {0};
+    char ordinary_db[APP_TEST_PATH_CAP] = {0};
+    if (sensitive_project) {
+        (void)snprintf(sensitive_db, sizeof(sensitive_db), "%s/%s.db", cache, sensitive_project);
+    }
+    if (ordinary_project) {
+        (void)snprintf(ordinary_db, sizeof(ordinary_db), "%s/%s.db", cache, ordinary_project);
+    }
+    bool db_ready = config_ready && sensitive_project && ordinary_project &&
+                    app_test_create_empty_file(sensitive_db) &&
+                    app_test_create_empty_file(ordinary_db);
+
+    cbm_store_t *store = cbm_store_open_memory();
+    cbm_watcher_t *watcher = cbm_watcher_new(store, app_test_index_noop, NULL);
+    cbm_daemon_application_config_t config = {
+        .watcher = watcher,
+        .config = stored_config,
+    };
+    cbm_daemon_application_t *application =
+        db_ready && watcher ? cbm_daemon_application_new(&config) : NULL;
+    cbm_daemon_runtime_application_callbacks_t callbacks =
+        cbm_daemon_application_runtime_callbacks(application);
+    cbm_daemon_runtime_application_session_t *sensitive_session =
+        application ? app_test_open(&callbacks, 4033) : NULL;
+    cbm_daemon_runtime_application_session_t *ordinary_session =
+        application ? app_test_open(&callbacks, 4034) : NULL;
+    cbm_daemon_runtime_application_session_t *approved_session =
+        application ? app_test_open(&callbacks, 4035) : NULL;
+
+    bool sensitive_initialized = app_test_initialize_profile(
+        &callbacks, sensitive_session, sensitive, CBM_MCP_TOOL_PROFILE_ALL, NULL, NULL);
+    bool sensitive_blocked = sensitive_initialized && cbm_watcher_watch_count(watcher) == 0;
+    bool ordinary_initialized = app_test_initialize_profile(&callbacks, ordinary_session, ordinary,
+                                                            CBM_MCP_TOOL_PROFILE_ALL, NULL, NULL);
+    bool ordinary_watched = ordinary_initialized && cbm_watcher_watch_count(watcher) == 1;
+    if (ordinary_session) {
+        callbacks.session_close(callbacks.context, ordinary_session);
+        ordinary_session = NULL;
+    }
+    bool ordinary_released = ordinary_watched && cbm_watcher_watch_count(watcher) == 0;
+
+    char grant_error[APP_TEST_PATH_CAP];
+    bool approved = ordinary_released && cbm_workspace_grant_add(cache, sensitive, sensitive, true,
+                                                                 grant_error, sizeof(grant_error));
+    bool approved_initialized =
+        approved && app_test_initialize_profile(&callbacks, approved_session, sensitive,
+                                                CBM_MCP_TOOL_PROFILE_ALL, NULL, NULL);
+    bool approved_watched = approved_initialized && cbm_watcher_watch_count(watcher) == 1;
+
+    if (sensitive_session) {
+        callbacks.session_close(callbacks.context, sensitive_session);
+    }
+    if (approved_session) {
+        callbacks.session_close(callbacks.context, approved_session);
+    }
+    if (ordinary_session) {
+        callbacks.session_close(callbacks.context, ordinary_session);
+    }
+    bool watches_released = watcher && cbm_watcher_watch_count(watcher) == 0;
+    bool stopped = application && cbm_daemon_application_shutdown(application, APP_TEST_TIMEOUT_MS);
+    cbm_daemon_application_free(application);
+    if (watcher) {
+        cbm_watcher_stop(watcher);
+        cbm_watcher_free(watcher);
+    }
+    cbm_store_close(store);
+    cbm_config_close(stored_config);
+    free(sensitive_project);
+    free(ordinary_project);
+    (void)th_rmtree(sensitive);
+    (void)th_rmtree(ordinary);
+    (void)th_rmtree(cache);
+    bool cache_restored = app_env_backup_restore(&cache_environment);
+    bool home_restored = app_env_backup_restore(&home_environment);
+
+    ASSERT_TRUE(environments_saved);
+    ASSERT_TRUE(dirs_ok);
+    ASSERT_TRUE(canonical);
+    ASSERT_TRUE(environments_set);
+    ASSERT_TRUE(config_ready);
+    ASSERT_TRUE(db_ready);
+    ASSERT_TRUE(sensitive_blocked);
+    ASSERT_TRUE(ordinary_watched);
+    ASSERT_TRUE(ordinary_released);
+    ASSERT_TRUE(approved);
+    ASSERT_TRUE(approved_watched);
+    ASSERT_TRUE(watches_released);
+    ASSERT_TRUE(stopped);
+    ASSERT_TRUE(cache_restored);
+    ASSERT_TRUE(home_restored);
     PASS();
 }
 
@@ -5097,6 +5358,8 @@ SUITE(daemon_application) {
     RUN_TEST(daemon_application_free_releases_live_watch_once);
     RUN_TEST(daemon_application_prune_clears_logical_watch_for_reregistration);
     RUN_TEST(daemon_application_initialize_coalesces_auto_index_for_full_sessions);
+    RUN_TEST(daemon_application_sensitive_root_blocks_auto_index_but_preserves_controls);
+    RUN_TEST(daemon_application_sensitive_root_blocks_watch_but_preserves_controls);
     RUN_TEST(daemon_application_auto_index_honors_tracked_file_limit);
     RUN_TEST(daemon_application_auto_index_file_count_handles_literal_metacharacter_path);
     RUN_TEST(daemon_application_auto_index_file_count_supports_non_git_roots);

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -10,6 +10,7 @@
 #include "../src/foundation/log.h"
 #include "../src/foundation/platform.h" /* cbm_file_size */
 #include "../src/foundation/subprocess.h"
+#include "../src/foundation/workspace.h"
 #include "../src/mcp/compact_out.h"
 #include "test_framework.h"
 #include "test_helpers.h"
@@ -1292,6 +1293,83 @@ TEST(server_handle_initialized_notification) {
     cbm_mcp_server_free(srv);
     PASS();
 }
+
+#ifdef CBM_ENABLE_TEST_SEAMS
+static void issue403_count_started(void *context) {
+    int *calls = context;
+    (*calls)++;
+}
+
+static int issue403_initialize_count_calls(const char *session_root, bool approve_sensitive) {
+    char *cache = th_mktempdir("cbm_mcp_403");
+    if (!cache) {
+        return -1;
+    }
+    const char *saved_cache = getenv("CBM_CACHE_DIR");
+    char *saved_cache_copy = saved_cache ? strdup(saved_cache) : NULL;
+    cbm_setenv("CBM_CACHE_DIR", cache, 1);
+
+    char err[1024];
+    bool approved = !approve_sensitive ||
+                    cbm_workspace_grant_add(cache, cbm_workspace_home_dir(), session_root, true,
+                                            err, sizeof(err));
+    cbm_config_t *cfg = approved ? cbm_config_open(cache) : NULL;
+    cbm_mcp_server_t *srv = cfg ? cbm_mcp_server_new(NULL) : NULL;
+    int calls = -2;
+    if (srv) {
+        cbm_config_set(cfg, CBM_CONFIG_AUTO_INDEX, "true");
+        /* The hook proves entry to the count path; keep the actual discovery
+         * call fail-closed so this unit test can never launch an index thread. */
+        cbm_config_set(cfg, CBM_CONFIG_AUTO_INDEX_LIMIT, "-1");
+        if (cbm_mcp_server_set_session_context(srv, session_root, NULL)) {
+            calls = 0;
+            cbm_mcp_server_set_config(srv, cfg);
+            cbm_mcp_server_set_auto_index_count_test_hook(srv, issue403_count_started, &calls);
+            char *response = cbm_mcp_server_handle(
+                srv, "{\"jsonrpc\":\"2.0\",\"id\":403,\"method\":\"initialize\",\"params\":{}}");
+            free(response);
+        }
+        cbm_mcp_server_free(srv);
+    }
+    if (cfg) {
+        cbm_config_close(cfg);
+    }
+
+    restore_cache_dir(saved_cache_copy);
+    free(saved_cache_copy);
+    th_cleanup(cache);
+    return calls;
+}
+
+TEST(mcp_issue403_sensitive_root_stops_before_discovery_count) {
+    int sensitive = issue403_initialize_count_calls(
+        "C:/Users/dev/AppData/Local/Programs/Antigravity", false);
+    int ordinary = issue403_initialize_count_calls("C:/Users/dev/projects/app", false);
+    ASSERT_EQ(sensitive, 0);
+    ASSERT_EQ(ordinary, 1);
+    PASS();
+}
+
+TEST(mcp_issue403_explicit_approval_preserves_auto_index) {
+    char *sensitive_home = th_mktempdir("cbm_mcp_403_home");
+    ASSERT_NOT_NULL(sensitive_home);
+    const char *saved_home = getenv("HOME");
+    char *saved_home_copy = saved_home ? strdup(saved_home) : NULL;
+    cbm_setenv("HOME", sensitive_home, 1);
+
+    int approved = issue403_initialize_count_calls(sensitive_home, true);
+
+    if (saved_home_copy) {
+        cbm_setenv("HOME", saved_home_copy, 1);
+    } else {
+        cbm_unsetenv("HOME");
+    }
+    free(saved_home_copy);
+    th_cleanup(sensitive_home);
+    ASSERT_EQ(approved, 1);
+    PASS();
+}
+#endif
 
 TEST(server_handle_tools_list) {
     cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
@@ -11291,6 +11369,10 @@ SUITE(mcp) {
     /* Server protocol handling */
     RUN_TEST(server_handle_initialize);
     RUN_TEST(server_handle_initialized_notification);
+#ifdef CBM_ENABLE_TEST_SEAMS
+    RUN_TEST(mcp_issue403_sensitive_root_stops_before_discovery_count);
+    RUN_TEST(mcp_issue403_explicit_approval_preserves_auto_index);
+#endif
     RUN_TEST(server_handle_tools_list);
     RUN_TEST(server_handle_tools_list_defaults_to_all_tools_and_accepts_cursor);
     RUN_TEST(server_handle_analysis_profile_filters_and_rejects_mutators);

--- a/tests/test_workspace.c
+++ b/tests/test_workspace.c
@@ -132,6 +132,120 @@ TEST(ws_windows_system_trees_are_sensitive) {
     PASS();
 }
 
+TEST(ws_windows_user_programs_tree_has_exact_sensitive_boundaries) {
+    static const char *const sensitive[] = {
+        "C:/Users/dev/AppData/Local/Programs",
+        "C:/Users/dev/AppData/Local/Programs/Antigravity",
+        "D:/Users/runneradmin/AppData/Local/Programs/Editor",
+        "c:\\uSeRs\\Dev\\aPpDaTa\\LoCaL\\pRoGrAmS\\IDE",
+    };
+    for (size_t i = 0; i < sizeof(sensitive) / sizeof(sensitive[0]); i++) {
+        ASSERT_EQ(cbm_workspace_classify_root(sensitive[i], HOME, CACHE),
+                  CBM_WS_DENY_SENSITIVE);
+    }
+
+    static const char *const allowed[] = {
+        "C:/Users/dev/projects/app",
+        "C:/Users/dev/AppData/Local",
+        "C:/Users/dev/AppData/Local/Programs-src",
+        "C:/Users/dev/AppData/Local/ProgramsBackup",
+        "C:/workspace/Users/dev/AppData/Local/Programs",
+        "C:/Users/dev/team/AppData/Local/Programs",
+    };
+    for (size_t i = 0; i < sizeof(allowed) / sizeof(allowed[0]); i++) {
+        ASSERT_EQ(cbm_workspace_classify_root(allowed[i], HOME, CACHE), CBM_WS_ALLOW);
+    }
+    PASS();
+}
+
+TEST(ws_sensitive_root_explicit_approval_is_preserved) {
+    char root[256];
+    char *created = th_mktempdir("cbm_ws_403_home");
+    ASSERT_NOT_NULL(created);
+    snprintf(root, sizeof(root), "%s", created);
+
+    char cache[256];
+    created = th_mktempdir("cbm_ws_403");
+    ASSERT_NOT_NULL(created);
+    snprintf(cache, sizeof(cache), "%s", created);
+
+    char err[1024];
+    ASSERT_FALSE(cbm_workspace_root_allowed(root, root, cache, NULL, err, sizeof(err)));
+    ASSERT_NOT_NULL(strstr(err, "--approve-sensitive"));
+    ASSERT_TRUE(cbm_workspace_grant_add(cache, root, root, true, err, sizeof(err)));
+    ASSERT_TRUE(cbm_workspace_root_allowed(root, root, cache, NULL, err, sizeof(err)));
+
+    th_cleanup(root);
+    th_cleanup(cache);
+    PASS();
+}
+
+TEST(ws_sensitive_approval_upgrades_existing_ordinary_exact_grant) {
+    char root[256];
+    char *created = th_mktempdir("cbm_ws_403_exact");
+    ASSERT_NOT_NULL(created);
+    snprintf(root, sizeof(root), "%s", created);
+
+    char cache[256];
+    created = th_mktempdir("cbm_ws_403_exact_cache");
+    ASSERT_NOT_NULL(created);
+    snprintf(cache, sizeof(cache), "%s", created);
+
+    char err[1024];
+    ASSERT_TRUE(cbm_workspace_grant_add(cache, NULL, root, false, err, sizeof(err)));
+    ASSERT_FALSE(cbm_workspace_root_allowed(root, root, cache, NULL, err, sizeof(err)));
+
+    ASSERT_TRUE(cbm_workspace_grant_add(cache, root, root, true, err, sizeof(err)));
+    ASSERT_TRUE(cbm_workspace_root_allowed(root, root, cache, NULL, err, sizeof(err)));
+    /* A repeated explicit approval must recognize the marked exact grant rather
+     * than append another exception. */
+    ASSERT_TRUE(cbm_workspace_grant_add(cache, root, root, true, err, sizeof(err)));
+
+    char listed[4096];
+    char expected[4096];
+    ASSERT_TRUE(cbm_workspace_grant_list(cache, listed, sizeof(listed)));
+    snprintf(expected, sizeof(expected), "%s\n(approved) %s\n", root, root);
+    ASSERT_STR_EQ(listed, expected);
+
+    th_cleanup(root);
+    th_cleanup(cache);
+    PASS();
+}
+
+TEST(ws_sensitive_approval_adds_exact_exception_under_ordinary_ancestor) {
+    char ancestor[256];
+    char *created = th_mktempdir("cbm_ws_403_ancestor");
+    ASSERT_NOT_NULL(created);
+    snprintf(ancestor, sizeof(ancestor), "%s", created);
+
+    char cache[256];
+    created = th_mktempdir("cbm_ws_403_ancestor_cache");
+    ASSERT_NOT_NULL(created);
+    snprintf(cache, sizeof(cache), "%s", created);
+
+    char sensitive[1024];
+    snprintf(sensitive, sizeof(sensitive), "%s/private-project", ancestor);
+    ASSERT_EQ(cbm_mkdir(sensitive), 0);
+    char err[1024];
+    ASSERT_TRUE(cbm_workspace_grant_add(cache, NULL, ancestor, false, err, sizeof(err)));
+    ASSERT_FALSE(cbm_workspace_root_allowed(sensitive, sensitive, cache, NULL, err, sizeof(err)));
+
+    ASSERT_TRUE(cbm_workspace_grant_add(cache, sensitive, sensitive, true, err, sizeof(err)));
+    ASSERT_TRUE(
+        cbm_workspace_root_allowed(sensitive, sensitive, cache, NULL, err, sizeof(err)));
+    ASSERT_TRUE(cbm_workspace_grant_add(cache, sensitive, sensitive, true, err, sizeof(err)));
+
+    char listed[4096];
+    char expected[4096];
+    ASSERT_TRUE(cbm_workspace_grant_list(cache, listed, sizeof(listed)));
+    snprintf(expected, sizeof(expected), "%s\n(approved) %s\n", ancestor, sensitive);
+    ASSERT_STR_EQ(listed, expected);
+
+    th_cleanup(ancestor);
+    th_cleanup(cache);
+    PASS();
+}
+
 /* POSIX is case-sensitive, so a differently-cased directory is a different one
  * and must not be refused. */
 TEST(ws_posix_matching_is_case_sensitive) {
@@ -275,6 +389,10 @@ SUITE(workspace) {
     RUN_TEST(ws_home_itself_is_sensitive_but_subdirs_are_fine);
     RUN_TEST(ws_credential_directories_are_sensitive_at_any_depth);
     RUN_TEST(ws_windows_system_trees_are_sensitive);
+    RUN_TEST(ws_windows_user_programs_tree_has_exact_sensitive_boundaries);
+    RUN_TEST(ws_sensitive_root_explicit_approval_is_preserved);
+    RUN_TEST(ws_sensitive_approval_upgrades_existing_ordinary_exact_grant);
+    RUN_TEST(ws_sensitive_approval_adds_exact_exception_under_ordinary_ancestor);
     RUN_TEST(ws_posix_matching_is_case_sensitive);
     RUN_TEST(ws_null_context_disables_dependent_checks);
     RUN_TEST(ws_every_verdict_has_a_reason);


### PR DESCRIPTION
## Summary

Fixes #403 by applying one grant-aware sensitive-root boundary consistently across workspace classification, MCP auto-index admission, and daemon background work.

- classify Windows user program-install roots (`AppData/Local/Programs` and `AppData/Roaming/Programs`) as sensitive at exact segment boundaries, case-insensitively
- preserve explicit approval as an exact marked grant, including migration/upgrade from legacy ordinary grants
- reject sensitive MCP session roots before tracked-file discovery/counting or automatic indexing
- re-check the same policy in the production daemon before auto-index discovery/admission, retry admission, and physical watch registration
- preserve ordinary workspace behavior and exact explicit sensitive approval

## Why this approach

The recommended boundary is the shared `cbm_workspace_root_allowed` policy. Using it at every automatic observation boundary keeps classification and approval semantics in one place while preventing sensitive roots from reaching discovery, indexing, or watcher registration.

Alternatives considered:

- **Block only in MCP initialization:** smaller initial diff, but production daemon sessions disable that in-process background path and separately perform discovery and watch registration, leaving the real runtime exposed.
- **Add daemon-only path string checks:** locally simple, but duplicates classifier and grant semantics and would drift across platforms and migrations.
- **Disable all daemon background work for shallow/user roots:** strongest blanket restriction, but rejects ordinary projects and ignores the existing explicit-approval contract.

The selected approach adds boundary checks in the daemon as well as MCP. The trade-off is a small amount of repeated policy invocation at runtime boundaries; the benefit is fail-closed behavior with consistent exact-grant semantics and no duplicate classification logic.

## Binding evidence

- Valid-fixture baseline: 3/3 RED runs reproduced both migration/classification regressions while 18 controls remained green.
- Minimal workspace/MCP fix: GREEN 20/20; reverting production alone restored the exact RED failures; restoring production returned GREEN.
- Daemon follow-up baseline: 3/3 RED runs produced exactly two failures (sensitive auto-index admission and sensitive watch registration), with 49 daemon controls green.
- Daemon fix: 51/51 GREEN; reverting only `src/daemon/application.c` restored those exact two failures; restoring it returned 51/51 GREEN.
- Final affected gate: workspace + MCP + daemon application: 276 passed, 6 declared platform skips; issue #403 repro: 2/2 passed.
- `make -f Makefile.cbm lint-ci`: GREEN.
- Independent exact-commit review: PASS, no findings; exact eight-file scope and DCO verified.

## Local CI

- macOS arm64 canonical full leg: GREEN — 7,591 passed, 0 failed, 8 declared skips across 139 suites, followed by production watchdog and security-string gates.
- Linux arm64/amd64: not run. The canonical Docker preflight was denied because it would prune stopped containers, anonymous volumes, and dangling images from a shared long-lived Colima runtime; no bypass or alternate route was used.
- Windows ARM64: infrastructure-blocked before build. The VM was reachable with a healthy clock, but the isolated checkout's `git clone` segfaulted at 30%. The partial run checkout was removed; no product test executed and no shared checkout was modified.

## Platform notes

The new Windows classifier tests use Windows-style paths without requiring a Windows host. Native Windows execution remains valuable follow-through because the full VM leg was blocked before compilation. The production checks themselves use the existing cross-platform canonical-path and grant policy APIs.
