### PR TITLE
fix: register Claude hooks without a shell

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2550,7 +2550,19 @@ ok = ok and owned_total == 2
 sys.exit(0 if ok else 1)
 " 2>/dev/null ||
    ! grep -q 'SessionStart' "$FAKE_HOME/.claude/settings.json" 2>/dev/null ||
-   ! grep -q 'cbm-code-discovery-gate' "$FAKE_HOME/.claude/settings.json" 2>/dev/null; then
+   ! cat "$FAKE_HOME/.claude/settings.json" 2>/dev/null | SELF_PATH="$SELF_PATH" python3 -c "
+# Claude's gate is registered shell-free (#1733): the binary itself as the
+# command with 'hook-augment' as its argument, so no shim name can be grepped.
+import json, os, sys
+d = json.load(sys.stdin)
+self_path = os.environ['SELF_PATH']
+hooks = [h for entry in d.get('hooks', {}).get('PreToolUse', []) for h in entry.get('hooks', [])]
+ok = any(h.get('args') == ['hook-augment'] and
+         (h.get('command') == self_path or
+          os.path.basename(str(h.get('command', ''))) == os.path.basename(self_path))
+         for h in hooks)
+sys.exit(0 if ok else 1)
+" 2>/dev/null; then
   echo "FAIL 8aq: Devin hooks are not deduplicated against Claude SessionStart"
   exit 1
 else
@@ -2755,9 +2767,14 @@ if cat "$FAKE_HOME/.claude/settings.json" 2>/dev/null | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
 hooks = d.get('hooks', {})
+# Shim names cover legacy shell registrations; the exec form (#1733) carries
+# no shim name, so its 'hook-augment' argument is the owned marker there.
 found = any('cbm-code-discovery-gate' in str(h) or
             'cbm-session-reminder' in str(h) or
-            'cbm-subagent-reminder' in str(h)
+            'cbm-subagent-reminder' in str(h) or
+            any('hook-augment' in str(x.get('args', [])) or
+                'hook-augment' in str(x.get('command', ''))
+                for x in h.get('hooks', []))
             for entries in hooks.values() for h in entries)
 sys.exit(1 if found else 0)
 " 2>/dev/null; then

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -4171,6 +4171,7 @@ static int cbm_remove_grok_mcp_owned(const char *binary_path, const char *config
 /* Hard backstop in settings.json; the binary also self-bounds with an
  * in-process deadline well under this. */
 #define CMM_HOOK_TIMEOUT_SEC 5
+static const char *const cmm_claude_exec_args[] = {"hook-augment"};
 
 /* Old matcher values from previous versions — recognized during upgrade so
  * upsert/remove can clean them up before inserting the current matcher.
@@ -4192,6 +4193,26 @@ static const char *const cmm_gemini_session_old_matchers[] = {
     NULL,
 };
 
+static bool cmm_hook_args_equal(yyjson_mut_val *hook, const char *const *expected_args,
+                                size_t expected_arg_count) {
+    yyjson_mut_val *args = yyjson_mut_is_obj(hook) ? yyjson_mut_obj_get(hook, "args") : NULL;
+    if (expected_arg_count == 0U) {
+        return args == NULL;
+    }
+    if (!expected_args || !args || !yyjson_mut_is_arr(args) ||
+        yyjson_mut_arr_size(args) != expected_arg_count) {
+        return false;
+    }
+    for (size_t i = 0U; i < expected_arg_count; i++) {
+        yyjson_mut_val *arg = yyjson_mut_arr_get(args, i);
+        if (!expected_args[i] || !arg || !yyjson_mut_is_str(arg) ||
+            strcmp(yyjson_mut_get_str(arg), expected_args[i]) != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
 /* Check if a hook array entry is ours (current matcher or a known old one).
  * Matcher identity is never sufficient because users commonly choose the same
  * catch-all or lifecycle matchers. Ownership always requires the exact command
@@ -4199,6 +4220,7 @@ static const char *const cmm_gemini_session_old_matchers[] = {
 static bool find_cmm_hook_in_entry(yyjson_mut_val *entry, const char *matcher_str,
                                    const char *const *old_matchers,
                                    const char *require_command_exact,
+                                   const char *const *require_args, size_t require_arg_count,
                                    const char *const *old_commands, size_t *hook_index_out) {
     if (!entry || !require_command_exact) {
         return false;
@@ -4236,9 +4258,10 @@ static bool find_cmm_hook_in_entry(yyjson_mut_val *entry, const char *matcher_st
         if (cmd && yyjson_mut_is_str(cmd) && type && yyjson_mut_is_str(type) &&
             strcmp(yyjson_mut_get_str(type), "command") == 0) {
             const char *cs = yyjson_mut_get_str(cmd);
-            bool command_ok = cs && strcmp(cs, require_command_exact) == 0;
+            bool command_ok = cs && strcmp(cs, require_command_exact) == 0 &&
+                              cmm_hook_args_equal(h, require_args, require_arg_count);
             for (size_t i = 0U; !command_ok && cs && old_commands && old_commands[i]; i++) {
-                command_ok = strcmp(cs, old_commands[i]) == 0;
+                command_ok = strcmp(cs, old_commands[i]) == 0 && cmm_hook_args_equal(h, NULL, 0U);
             }
             if (command_ok) {
                 if (hook_index_out) {
@@ -4265,6 +4288,8 @@ static bool cmm_hook_outer_is_canonical(yyjson_mut_val *entry, bool has_matcher)
 static size_t remove_all_owned_hooks_from_event(yyjson_mut_val *event_arr, const char *matcher_str,
                                                 const char *const *old_matchers,
                                                 const char *match_command_exact,
+                                                const char *const *match_args,
+                                                size_t match_arg_count,
                                                 const char *const *old_commands) {
     if (!event_arr || !yyjson_mut_is_arr(event_arr) || !match_command_exact) {
         return 0U;
@@ -4276,7 +4301,7 @@ static size_t remove_all_owned_hooks_from_event(yyjson_mut_val *event_arr, const
         bool entry_removed = false;
         size_t hook_index = 0U;
         while (find_cmm_hook_in_entry(entry, matcher_str, old_matchers, match_command_exact,
-                                      old_commands, &hook_index)) {
+                                      match_args, match_arg_count, old_commands, &hook_index)) {
             yyjson_mut_val *entry_hooks = yyjson_mut_obj_get(entry, "hooks");
             yyjson_mut_arr_remove(entry_hooks, hook_index);
             removed++;
@@ -4303,6 +4328,8 @@ typedef struct {
     const char *command_str;
     const char *command_windows;
     const char *shell;
+    const char *const *command_args;
+    size_t command_arg_count;
     const char *const *old_matchers; /* NULL-terminated; may be NULL */
     const char *const *old_commands; /* finite exact identities; may be NULL */
     int timeout_value;               /* >0 adds runtime-native "timeout" */
@@ -4417,6 +4444,7 @@ static int upsert_hooks_json(hooks_upsert_args_t args) {
      * one canonical entry. Foreign commands remain untouched. */
     const char *effective_exact = args.match_command_exact ? args.match_command_exact : command_str;
     (void)remove_all_owned_hooks_from_event(event_arr, matcher_str, old_matchers, effective_exact,
+                                            args.command_args, args.command_arg_count,
                                             args.old_commands);
 
     /* Build our hook entry */
@@ -4429,6 +4457,21 @@ static int upsert_hooks_json(hooks_upsert_args_t args) {
     yyjson_mut_val *hook_obj = yyjson_mut_obj(mdoc);
     yyjson_mut_obj_add_str(mdoc, hook_obj, "type", "command");
     yyjson_mut_obj_add_str(mdoc, hook_obj, "command", command_str);
+    if (args.command_arg_count > 0U) {
+        yyjson_mut_val *command_args = yyjson_mut_arr(mdoc);
+        if (!args.command_args || !command_args) {
+            goto cleanup;
+        }
+        for (size_t i = 0U; i < args.command_arg_count; i++) {
+            if (!args.command_args[i] ||
+                !yyjson_mut_arr_add_str(mdoc, command_args, args.command_args[i])) {
+                goto cleanup;
+            }
+        }
+        if (!yyjson_mut_obj_add_val(mdoc, hook_obj, "args", command_args)) {
+            goto cleanup;
+        }
+    }
     if (args.command_windows) {
         yyjson_mut_obj_add_str(mdoc, hook_obj, "command_windows", args.command_windows);
     }
@@ -4462,6 +4505,8 @@ typedef struct {
     const char *const *old_matchers; /* NULL-terminated; may be NULL */
     const char *const *old_commands; /* finite exact identities; may be NULL */
     const char *match_command_exact;
+    const char *const *match_args;
+    size_t match_arg_count;
 } hooks_remove_args_t;
 static int remove_hooks_json(hooks_remove_args_t args) {
     const char *settings_path = args.settings_path;
@@ -4531,7 +4576,8 @@ static int remove_hooks_json(hooks_remove_args_t args) {
     }
 
     size_t removed = remove_all_owned_hooks_from_event(event_arr, matcher_str, old_matchers,
-                                                       args.match_command_exact, args.old_commands);
+                                                       args.match_command_exact, args.match_args,
+                                                       args.match_arg_count, args.old_commands);
 
     if (removed == 0U) {
         yyjson_mut_doc_free(mdoc);
@@ -4858,13 +4904,33 @@ static int cbm_remove_hermes_context_hook(const char *config_path, const char *b
     return CBM_YAML_IDENTITY_EDIT_OK;
 }
 
-int cbm_upsert_claude_hooks(const char *settings_path) {
-    char command[CLI_BUF_8K];
+static int cbm_remove_previous_claude_exec_hook(const char *settings_path, const char *hook_event,
+                                                const char *matcher_str,
+                                                const char *const *old_matchers,
+                                                const char *binary_path) {
+    if (!g_previous_managed_mcp_command || !g_previous_managed_mcp_command[0] ||
+        (binary_path && strcmp(g_previous_managed_mcp_command, binary_path) == 0)) {
+        return CLI_OK;
+    }
+    return remove_hooks_json((hooks_remove_args_t){
+        .settings_path = settings_path,
+        .hook_event = hook_event,
+        .matcher_str = matcher_str,
+        .old_matchers = old_matchers,
+        .match_command_exact = g_previous_managed_mcp_command,
+        .match_args = cmm_claude_exec_args,
+        .match_arg_count = sizeof(cmm_claude_exec_args) / sizeof(cmm_claude_exec_args[0]),
+    });
+}
+
+static int cbm_upsert_claude_hooks_with_binary(const char *settings_path, const char *binary_path) {
+    char shell_command[CLI_BUF_8K];
     char previous_command[CLI_BUF_8K];
     char released_command[CLI_BUF_8K];
     char previous_legacy_command[CLI_BUF_8K];
     char released_legacy_command[CLI_BUF_8K];
-    if (cbm_resolve_hook_command(CMM_HOOK_GATE_SCRIPT, command, sizeof(command)) != CLI_OK ||
+    if (cbm_resolve_hook_command(CMM_HOOK_GATE_SCRIPT, shell_command, sizeof(shell_command)) !=
+            CLI_OK ||
         cbm_resolve_previous_hook_command(CMM_HOOK_GATE_SCRIPT, previous_command,
                                           sizeof(previous_command)) != CLI_OK ||
         cbm_resolve_released_hook_command(CMM_HOOK_GATE_SCRIPT, released_command,
@@ -4875,13 +4941,27 @@ int cbm_upsert_claude_hooks(const char *settings_path) {
                                           sizeof(released_legacy_command)) != CLI_OK) {
         return CLI_ERR;
     }
-    const char *const old_commands[] = {released_command, previous_command, released_legacy_command,
+    const char *command = binary_path && binary_path[0] ? binary_path : shell_command;
+    const char *const *command_args = binary_path && binary_path[0] ? cmm_claude_exec_args : NULL;
+    size_t command_arg_count = binary_path && binary_path[0]
+                                   ? sizeof(cmm_claude_exec_args) / sizeof(cmm_claude_exec_args[0])
+                                   : 0U;
+    const char *const old_commands[] = {shell_command,           released_command,
+                                        previous_command,        released_legacy_command,
                                         previous_legacy_command, NULL};
+    if (cbm_remove_previous_claude_exec_hook(settings_path, "PreToolUse", CMM_HOOK_SEARCH_MATCHER,
+                                             cmm_claude_old_matchers, binary_path) != CLI_OK ||
+        cbm_remove_previous_claude_exec_hook(settings_path, "PostToolUse", CMM_HOOK_READ_MATCHER,
+                                             NULL, binary_path) != CLI_OK) {
+        return CLI_ERR;
+    }
     int search_result = upsert_hooks_json((hooks_upsert_args_t){
         .settings_path = settings_path,
         .hook_event = "PreToolUse",
         .matcher_str = CMM_HOOK_SEARCH_MATCHER,
         .command_str = command,
+        .command_args = command_args,
+        .command_arg_count = command_arg_count,
         .old_matchers = cmm_claude_old_matchers,
         .old_commands = old_commands,
         .timeout_value = CMM_HOOK_TIMEOUT_SEC,
@@ -4892,6 +4972,8 @@ int cbm_upsert_claude_hooks(const char *settings_path) {
         .hook_event = "PostToolUse",
         .matcher_str = CMM_HOOK_READ_MATCHER,
         .command_str = command,
+        .command_args = command_args,
+        .command_arg_count = command_arg_count,
         .old_commands = old_commands,
         .timeout_value = CMM_HOOK_TIMEOUT_SEC,
         .match_command_exact = command,
@@ -4899,13 +4981,18 @@ int cbm_upsert_claude_hooks(const char *settings_path) {
     return search_result == CLI_OK && read_result == CLI_OK ? CLI_OK : CLI_ERR;
 }
 
-int cbm_remove_claude_hooks(const char *settings_path) {
-    char command[CLI_BUF_8K];
+int cbm_upsert_claude_hooks(const char *settings_path) {
+    return cbm_upsert_claude_hooks_with_binary(settings_path, NULL);
+}
+
+static int cbm_remove_claude_hooks_with_binary(const char *settings_path, const char *binary_path) {
+    char shell_command[CLI_BUF_8K];
     char previous_command[CLI_BUF_8K];
     char released_command[CLI_BUF_8K];
     char previous_legacy_command[CLI_BUF_8K];
     char released_legacy_command[CLI_BUF_8K];
-    if (cbm_resolve_hook_command(CMM_HOOK_GATE_SCRIPT, command, sizeof(command)) != CLI_OK ||
+    if (cbm_resolve_hook_command(CMM_HOOK_GATE_SCRIPT, shell_command, sizeof(shell_command)) !=
+            CLI_OK ||
         cbm_resolve_previous_hook_command(CMM_HOOK_GATE_SCRIPT, previous_command,
                                           sizeof(previous_command)) != CLI_OK ||
         cbm_resolve_released_hook_command(CMM_HOOK_GATE_SCRIPT, released_command,
@@ -4916,7 +5003,13 @@ int cbm_remove_claude_hooks(const char *settings_path) {
                                           sizeof(released_legacy_command)) != CLI_OK) {
         return CLI_ERR;
     }
-    const char *const old_commands[] = {released_command, previous_command, released_legacy_command,
+    const char *command = binary_path && binary_path[0] ? binary_path : shell_command;
+    const char *const *command_args = binary_path && binary_path[0] ? cmm_claude_exec_args : NULL;
+    size_t command_arg_count = binary_path && binary_path[0]
+                                   ? sizeof(cmm_claude_exec_args) / sizeof(cmm_claude_exec_args[0])
+                                   : 0U;
+    const char *const old_commands[] = {shell_command,           released_command,
+                                        previous_command,        released_legacy_command,
                                         previous_legacy_command, NULL};
     int search_result = remove_hooks_json((hooks_remove_args_t){
         .settings_path = settings_path,
@@ -4925,6 +5018,8 @@ int cbm_remove_claude_hooks(const char *settings_path) {
         .old_matchers = cmm_claude_old_matchers,
         .old_commands = old_commands,
         .match_command_exact = command,
+        .match_args = command_args,
+        .match_arg_count = command_arg_count,
     });
     int read_result = remove_hooks_json((hooks_remove_args_t){
         .settings_path = settings_path,
@@ -4932,8 +5027,14 @@ int cbm_remove_claude_hooks(const char *settings_path) {
         .matcher_str = CMM_HOOK_READ_MATCHER,
         .old_commands = old_commands,
         .match_command_exact = command,
+        .match_args = command_args,
+        .match_arg_count = command_arg_count,
     });
     return search_result == CLI_OK && read_result == CLI_OK ? CLI_OK : CLI_ERR;
+}
+
+int cbm_remove_claude_hooks(const char *settings_path) {
+    return cbm_remove_claude_hooks_with_binary(settings_path, NULL);
 }
 
 /* Encode one shell word without permitting expansion or command substitution.
@@ -5415,14 +5516,15 @@ static bool cbm_install_session_reminder_script(const char *home, const char *bi
     return cbm_write_owned_hook_script_with_legacy(script_path, script, legacy, 1U);
 }
 
-static int cbm_upsert_session_hooks(const char *settings_path) {
+static int cbm_upsert_session_hooks(const char *settings_path, const char *binary_path) {
     static const char *matchers[] = {"startup", "resume", "clear", "compact"};
-    char command[CLI_BUF_8K];
+    char shell_command[CLI_BUF_8K];
     char previous_command[CLI_BUF_8K];
     char released_command[CLI_BUF_8K];
     char previous_legacy_command[CLI_BUF_8K];
     char released_legacy_command[CLI_BUF_8K];
-    if (cbm_resolve_hook_command(CMM_SESSION_REMINDER_SCRIPT, command, sizeof(command)) != CLI_OK ||
+    if (cbm_resolve_hook_command(CMM_SESSION_REMINDER_SCRIPT, shell_command,
+                                 sizeof(shell_command)) != CLI_OK ||
         cbm_resolve_previous_hook_command(CMM_SESSION_REMINDER_SCRIPT, previous_command,
                                           sizeof(previous_command)) != CLI_OK ||
         cbm_resolve_released_hook_command(CMM_SESSION_REMINDER_SCRIPT, released_command,
@@ -5435,14 +5537,27 @@ static int cbm_upsert_session_hooks(const char *settings_path) {
                                           sizeof(released_legacy_command)) != CLI_OK) {
         return CLI_ERR;
     }
-    const char *const old_commands[] = {released_command, previous_command, released_legacy_command,
+    const char *command = binary_path && binary_path[0] ? binary_path : shell_command;
+    const char *const *command_args = binary_path && binary_path[0] ? cmm_claude_exec_args : NULL;
+    size_t command_arg_count = binary_path && binary_path[0]
+                                   ? sizeof(cmm_claude_exec_args) / sizeof(cmm_claude_exec_args[0])
+                                   : 0U;
+    const char *const old_commands[] = {shell_command,           released_command,
+                                        previous_command,        released_legacy_command,
                                         previous_legacy_command, NULL};
     int rc = 0;
     for (int i = 0; i < NUM_DIRS; i++) {
+        if (cbm_remove_previous_claude_exec_hook(settings_path, "SessionStart", matchers[i], NULL,
+                                                 binary_path) != CLI_OK) {
+            rc = CLI_ERR;
+            continue;
+        }
         if (upsert_hooks_json((hooks_upsert_args_t){.settings_path = settings_path,
                                                     .hook_event = "SessionStart",
                                                     .matcher_str = matchers[i],
                                                     .command_str = command,
+                                                    .command_args = command_args,
+                                                    .command_arg_count = command_arg_count,
                                                     .old_commands = old_commands,
                                                     .timeout_value = CMM_HOOK_TIMEOUT_SEC,
                                                     .match_command_exact = command}) != 0) {
@@ -5452,14 +5567,15 @@ static int cbm_upsert_session_hooks(const char *settings_path) {
     return rc;
 }
 
-static int cbm_remove_session_hooks(const char *settings_path) {
+static int cbm_remove_session_hooks(const char *settings_path, const char *binary_path) {
     static const char *matchers[] = {"startup", "resume", "clear", "compact"};
-    char command[CLI_BUF_8K];
+    char shell_command[CLI_BUF_8K];
     char previous_command[CLI_BUF_8K];
     char released_command[CLI_BUF_8K];
     char previous_legacy_command[CLI_BUF_8K];
     char released_legacy_command[CLI_BUF_8K];
-    if (cbm_resolve_hook_command(CMM_SESSION_REMINDER_SCRIPT, command, sizeof(command)) != CLI_OK ||
+    if (cbm_resolve_hook_command(CMM_SESSION_REMINDER_SCRIPT, shell_command,
+                                 sizeof(shell_command)) != CLI_OK ||
         cbm_resolve_previous_hook_command(CMM_SESSION_REMINDER_SCRIPT, previous_command,
                                           sizeof(previous_command)) != CLI_OK ||
         cbm_resolve_released_hook_command(CMM_SESSION_REMINDER_SCRIPT, released_command,
@@ -5472,7 +5588,13 @@ static int cbm_remove_session_hooks(const char *settings_path) {
                                           sizeof(released_legacy_command)) != CLI_OK) {
         return CLI_ERR;
     }
-    const char *const old_commands[] = {released_command, previous_command, released_legacy_command,
+    const char *command = binary_path && binary_path[0] ? binary_path : shell_command;
+    const char *const *command_args = binary_path && binary_path[0] ? cmm_claude_exec_args : NULL;
+    size_t command_arg_count = binary_path && binary_path[0]
+                                   ? sizeof(cmm_claude_exec_args) / sizeof(cmm_claude_exec_args[0])
+                                   : 0U;
+    const char *const old_commands[] = {shell_command,           released_command,
+                                        previous_command,        released_legacy_command,
                                         previous_legacy_command, NULL};
     int rc = 0;
     for (int i = 0; i < NUM_DIRS; i++) {
@@ -5480,21 +5602,31 @@ static int cbm_remove_session_hooks(const char *settings_path) {
                                                     .hook_event = "SessionStart",
                                                     .matcher_str = matchers[i],
                                                     .old_commands = old_commands,
-                                                    .match_command_exact = command}) != 0) {
+                                                    .match_command_exact = command,
+                                                    .match_args = command_args,
+                                                    .match_arg_count = command_arg_count}) != 0) {
             rc = CLI_ERR;
         }
     }
     return rc;
 }
 
-static bool cbm_has_complete_claude_session_hooks(const char *home) {
+static bool cbm_has_complete_claude_session_hooks(const char *home, const char *binary_path) {
     static const char *const matchers[] = {"startup", "resume", "clear", "compact"};
     char config_dir[CLI_BUF_1K];
     char settings_path[CLI_BUF_1K];
     char expected_command[CLI_BUF_8K];
     cbm_claude_config_dir(home, config_dir, sizeof(config_dir));
-    if (!config_dir[0] || cbm_resolve_hook_command(CMM_SESSION_REMINDER_SCRIPT, expected_command,
-                                                   sizeof(expected_command)) != CLI_OK) {
+    if (!config_dir[0]) {
+        return false;
+    }
+    if (binary_path && binary_path[0]) {
+        if (snprintf(expected_command, sizeof(expected_command), "%s", binary_path) <= 0 ||
+            strlen(binary_path) >= sizeof(expected_command)) {
+            return false;
+        }
+    } else if (cbm_resolve_hook_command(CMM_SESSION_REMINDER_SCRIPT, expected_command,
+                                        sizeof(expected_command)) != CLI_OK) {
         return false;
     }
     int written = snprintf(settings_path, sizeof(settings_path), "%s/settings.json", config_dir);
@@ -5535,11 +5667,21 @@ static bool cbm_has_complete_claude_session_hooks(const char *home) {
             yyjson_arr_foreach(entry_hooks, hook_index, hook_count, hook) {
                 yyjson_val *type = yyjson_is_obj(hook) ? yyjson_obj_get(hook, "type") : NULL;
                 yyjson_val *command = yyjson_is_obj(hook) ? yyjson_obj_get(hook, "command") : NULL;
+                yyjson_val *args = yyjson_is_obj(hook) ? yyjson_obj_get(hook, "args") : NULL;
                 yyjson_val *timeout = yyjson_is_obj(hook) ? yyjson_obj_get(hook, "timeout") : NULL;
+                yyjson_val *first_arg =
+                    args && yyjson_is_arr(args) ? yyjson_arr_get(args, 0U) : NULL;
+                bool args_match =
+                    binary_path && binary_path[0]
+                        ? args && yyjson_is_arr(args) && yyjson_arr_size(args) == 1U && first_arg &&
+                              yyjson_is_str(first_arg) &&
+                              strcmp(yyjson_get_str(first_arg), cmm_claude_exec_args[0]) == 0
+                        : args == NULL;
                 if (type && yyjson_is_str(type) && strcmp(yyjson_get_str(type), "command") == 0 &&
                     command && yyjson_is_str(command) &&
-                    strcmp(yyjson_get_str(command), expected_command) == 0 && timeout &&
-                    yyjson_is_int(timeout) && yyjson_get_int(timeout) == CMM_HOOK_TIMEOUT_SEC) {
+                    strcmp(yyjson_get_str(command), expected_command) == 0 && args_match &&
+                    timeout && yyjson_is_int(timeout) &&
+                    yyjson_get_int(timeout) == CMM_HOOK_TIMEOUT_SEC) {
                     found = true;
                     break;
                 }
@@ -5656,14 +5798,15 @@ static bool cbm_hook_script_write_would_succeed(const char *home, const char *bi
     return cbm_text_owned_document_status(script_path, script, candidates, candidate_count) == 0;
 }
 
-int cbm_upsert_claude_subagent_hooks(const char *settings_path) {
-    char command[CLI_BUF_8K];
+static int cbm_upsert_claude_subagent_hooks_with_binary(const char *settings_path,
+                                                        const char *binary_path) {
+    char shell_command[CLI_BUF_8K];
     char previous_command[CLI_BUF_8K];
     char released_command[CLI_BUF_8K];
     char previous_legacy_command[CLI_BUF_8K];
     char released_legacy_command[CLI_BUF_8K];
-    if (cbm_resolve_hook_command(CMM_SUBAGENT_REMINDER_SCRIPT, command, sizeof(command)) !=
-            CLI_OK ||
+    if (cbm_resolve_hook_command(CMM_SUBAGENT_REMINDER_SCRIPT, shell_command,
+                                 sizeof(shell_command)) != CLI_OK ||
         cbm_resolve_previous_hook_command(CMM_SUBAGENT_REMINDER_SCRIPT, previous_command,
                                           sizeof(previous_command)) != CLI_OK ||
         cbm_resolve_released_hook_command(CMM_SUBAGENT_REMINDER_SCRIPT, released_command,
@@ -5676,8 +5819,18 @@ int cbm_upsert_claude_subagent_hooks(const char *settings_path) {
                                           sizeof(released_legacy_command)) != CLI_OK) {
         return CLI_ERR;
     }
-    const char *const old_commands[] = {released_command, previous_command, released_legacy_command,
+    const char *command = binary_path && binary_path[0] ? binary_path : shell_command;
+    const char *const *command_args = binary_path && binary_path[0] ? cmm_claude_exec_args : NULL;
+    size_t command_arg_count = binary_path && binary_path[0]
+                                   ? sizeof(cmm_claude_exec_args) / sizeof(cmm_claude_exec_args[0])
+                                   : 0U;
+    const char *const old_commands[] = {shell_command,           released_command,
+                                        previous_command,        released_legacy_command,
                                         previous_legacy_command, NULL};
+    if (cbm_remove_previous_claude_exec_hook(settings_path, "SubagentStart", "*", NULL,
+                                             binary_path) != CLI_OK) {
+        return CLI_ERR;
+    }
     /* matcher "*" is the natural choice a user would also pick for their own
      * catch-all SubagentStart hook, so claim ownership by command too — never
      * clobber or remove a foreign "*" entry. */
@@ -5685,19 +5838,26 @@ int cbm_upsert_claude_subagent_hooks(const char *settings_path) {
                                                    .hook_event = "SubagentStart",
                                                    .matcher_str = "*",
                                                    .command_str = command,
+                                                   .command_args = command_args,
+                                                   .command_arg_count = command_arg_count,
                                                    .old_commands = old_commands,
                                                    .timeout_value = CMM_HOOK_TIMEOUT_SEC,
                                                    .match_command_exact = command});
 }
 
-int cbm_remove_claude_subagent_hooks(const char *settings_path) {
-    char command[CLI_BUF_8K];
+int cbm_upsert_claude_subagent_hooks(const char *settings_path) {
+    return cbm_upsert_claude_subagent_hooks_with_binary(settings_path, NULL);
+}
+
+static int cbm_remove_claude_subagent_hooks_with_binary(const char *settings_path,
+                                                        const char *binary_path) {
+    char shell_command[CLI_BUF_8K];
     char previous_command[CLI_BUF_8K];
     char released_command[CLI_BUF_8K];
     char previous_legacy_command[CLI_BUF_8K];
     char released_legacy_command[CLI_BUF_8K];
-    if (cbm_resolve_hook_command(CMM_SUBAGENT_REMINDER_SCRIPT, command, sizeof(command)) !=
-            CLI_OK ||
+    if (cbm_resolve_hook_command(CMM_SUBAGENT_REMINDER_SCRIPT, shell_command,
+                                 sizeof(shell_command)) != CLI_OK ||
         cbm_resolve_previous_hook_command(CMM_SUBAGENT_REMINDER_SCRIPT, previous_command,
                                           sizeof(previous_command)) != CLI_OK ||
         cbm_resolve_released_hook_command(CMM_SUBAGENT_REMINDER_SCRIPT, released_command,
@@ -5710,13 +5870,25 @@ int cbm_remove_claude_subagent_hooks(const char *settings_path) {
                                           sizeof(released_legacy_command)) != CLI_OK) {
         return CLI_ERR;
     }
-    const char *const old_commands[] = {released_command, previous_command, released_legacy_command,
+    const char *command = binary_path && binary_path[0] ? binary_path : shell_command;
+    const char *const *command_args = binary_path && binary_path[0] ? cmm_claude_exec_args : NULL;
+    size_t command_arg_count = binary_path && binary_path[0]
+                                   ? sizeof(cmm_claude_exec_args) / sizeof(cmm_claude_exec_args[0])
+                                   : 0U;
+    const char *const old_commands[] = {shell_command,           released_command,
+                                        previous_command,        released_legacy_command,
                                         previous_legacy_command, NULL};
     return remove_hooks_json((hooks_remove_args_t){.settings_path = settings_path,
                                                    .hook_event = "SubagentStart",
                                                    .matcher_str = "*",
                                                    .old_commands = old_commands,
-                                                   .match_command_exact = command});
+                                                   .match_command_exact = command,
+                                                   .match_args = command_args,
+                                                   .match_arg_count = command_arg_count});
+}
+
+int cbm_remove_claude_subagent_hooks(const char *settings_path) {
+    return cbm_remove_claude_subagent_hooks_with_binary(settings_path, NULL);
 }
 
 /* Matcher excludes read_file for consistency with the Claude fix: the hook
@@ -7775,7 +7947,7 @@ static void install_claude_code_config(const char *home, const char *binary_path
          * update into config loss. Entry removal belongs to uninstall only. */
         if (!gate_ok) {
             record_agent_config_error(false, "Claude Code", "hook_script_install", hook_path);
-        } else if (cbm_upsert_claude_hooks(settings_path) != CLI_OK) {
+        } else if (cbm_upsert_claude_hooks_with_binary(settings_path, binary_path) != CLI_OK) {
             gate_ok = false;
             record_agent_config_error(false, "Claude Code", "hook_register", settings_path);
         }
@@ -7785,7 +7957,7 @@ static void install_claude_code_config(const char *home, const char *binary_path
                  CMM_SESSION_REMINDER_SCRIPT);
         if (!session_ok) {
             record_agent_config_error(false, "Claude Code", "hook_script_install", hook_path);
-        } else if (cbm_upsert_session_hooks(settings_path) != CLI_OK) {
+        } else if (cbm_upsert_session_hooks(settings_path, binary_path) != CLI_OK) {
             session_ok = false;
             record_agent_config_error(false, "Claude Code", "hook_register", settings_path);
         }
@@ -7795,7 +7967,8 @@ static void install_claude_code_config(const char *home, const char *binary_path
                  CMM_SUBAGENT_REMINDER_SCRIPT);
         if (!subagent_ok) {
             record_agent_config_error(false, "Claude Code", "hook_script_install", hook_path);
-        } else if (cbm_upsert_claude_subagent_hooks(settings_path) != CLI_OK) {
+        } else if (cbm_upsert_claude_subagent_hooks_with_binary(settings_path, binary_path) !=
+                   CLI_OK) {
             subagent_ok = false;
             record_agent_config_error(false, "Claude Code", "hook_register", settings_path);
         }
@@ -9585,7 +9758,7 @@ int cbm_install_agent_configs(const char *home, const char *binary_path, bool fo
     install_editor_agent_configs(&agents, home, binary_path, force, dry_run);
     install_additional_agent_configs(&agents, home, binary_path, force, dry_run);
     bool inherit_claude_session =
-        agents.claude_code && !dry_run && cbm_has_complete_claude_session_hooks(home);
+        agents.claude_code && !dry_run && cbm_has_complete_claude_session_hooks(home, binary_path);
     install_agent_client_registry(home, binary_path, inherit_claude_session, force, dry_run);
     return g_agent_install_errors == 0 ? CLI_OK : CLI_ERR;
 }
@@ -10611,9 +10784,7 @@ int cbm_cmd_install(int argc, char **argv) {
 /* ── Subcommand: uninstall ────────────────────────────────────── */
 
 /* Remove Claude Code agent configs. */
-static void uninstall_claude_code(const char *home, bool dry_run) {
-    char installed_binary[CLI_BUF_1K];
-    cbm_agent_installed_binary_path(home, installed_binary, sizeof(installed_binary));
+static void uninstall_claude_code(const char *home, const char *installed_binary, bool dry_run) {
     char config_dir[CLI_BUF_1K];
     cbm_claude_config_dir(home, config_dir, sizeof(config_dir));
     char user_root[CLI_BUF_1K];
@@ -10651,13 +10822,14 @@ static void uninstall_claude_code(const char *home, bool dry_run) {
     char settings_path[CLI_BUF_1K];
     snprintf(settings_path, sizeof(settings_path), "%s/settings.json", config_dir);
     if (!dry_run) {
-        if (cbm_remove_claude_hooks(settings_path) != CLI_OK) {
+        if (cbm_remove_claude_hooks_with_binary(settings_path, installed_binary) != CLI_OK) {
             record_agent_config_error(true, "Claude Code", "pretool_hook_uninstall", settings_path);
         }
-        if (cbm_remove_session_hooks(settings_path) != CLI_OK) {
+        if (cbm_remove_session_hooks(settings_path, installed_binary) != CLI_OK) {
             record_agent_config_error(true, "Claude Code", "session_hook_uninstall", settings_path);
         }
-        if (cbm_remove_claude_subagent_hooks(settings_path) != CLI_OK) {
+        if (cbm_remove_claude_subagent_hooks_with_binary(settings_path, installed_binary) !=
+            CLI_OK) {
             record_agent_config_error(true, "Claude Code", "subagent_hook_uninstall",
                                       settings_path);
         }
@@ -11861,7 +12033,7 @@ static int cli_uninstall_activate(void *opaque) {
     }
 
     if (activation->agents.claude_code) {
-        uninstall_claude_code(activation->home, activation->dry_run);
+        uninstall_claude_code(activation->home, activation->bin_path, activation->dry_run);
     }
     uninstall_cli_agents(&activation->agents, activation->home, activation->dry_run);
     uninstall_editor_agents(&activation->agents, activation->home, activation->dry_run);
@@ -12010,6 +12182,7 @@ int cbm_cmd_uninstall(int argc, char **argv) {
         (void)fprintf(stderr, "error: uninstall target path is too long\n");
         return CLI_TRUE;
     }
+    cbm_normalize_path_sep(bin_path_storage);
     cbm_path_info_t binary_status;
     bool binary_exists = cbm_path_info_utf8(bin_path, &binary_status) == 0;
     cbm_activation_transaction_t *binary_transaction = NULL;

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -10046,7 +10046,7 @@ TEST(cli_claude_hook_commands_use_exec_form_with_custom_config_dir) {
     yyjson_doc *document = settings ? yyjson_read(settings, strlen(settings), 0) : NULL;
     yyjson_val *root = document ? yyjson_doc_get_root(document) : NULL;
     static const char *const matchers[] = {"startup", "resume", "clear", "compact"};
-    size_t owned = test_count_exec_hook(root, "PreToolUse", "Grep|Glob", binary, "hook-augment") +
+    size_t owned = test_count_exec_hook(root, "PreToolUse", "Grep|Glob|Bash", binary, "hook-augment") +
                    test_count_exec_hook(root, "PostToolUse", "Read", binary, "hook-augment") +
                    test_count_exec_hook(root, "SubagentStart", "*", binary, "hook-augment");
     for (size_t i = 0U; i < sizeof(matchers) / sizeof(matchers[0]); i++) {
@@ -10914,7 +10914,7 @@ TEST(cli_upgrade_migrates_released_claude_hook_scripts) {
     yyjson_val *settings_root = settings_doc ? yyjson_doc_get_root(settings_doc) : NULL;
     static const char *const matchers[] = {"startup", "resume", "clear", "compact"};
     size_t registered =
-        test_count_exec_hook(settings_root, "PreToolUse", "Grep|Glob", binary, "hook-augment") +
+        test_count_exec_hook(settings_root, "PreToolUse", "Grep|Glob|Bash", binary, "hook-augment") +
         test_count_exec_hook(settings_root, "PostToolUse", "Read", binary, "hook-augment") +
         test_count_exec_hook(settings_root, "SubagentStart", "*", binary, "hook-augment");
     for (size_t i = 0U; i < sizeof(matchers) / sizeof(matchers[0]); i++) {
@@ -12124,8 +12124,13 @@ TEST(cli_windows_claude_lifecycle_migrates_only_exact_owned_legacy_state) {
     snprintf(settings_path, sizeof(settings_path), "%s/settings.json", config_dir);
     snprintf(appdata, sizeof(appdata), "%s/AppData/Roaming", tmpdir);
     snprintf(binary_path, sizeof(binary_path), "%s/.local/bin/codebase-memory-mcp.exe", tmpdir);
+    /* cbm_mkdtemp hands back a native '\\' temp root; the product normalizes
+     * the install directory before any registration (cbm_cmd_install), so the
+     * exact-owned exec command is the '/'-spelled path uninstall derives. */
+    cbm_normalize_path_sep(binary_path);
     test_mkdirp(hooks_dir);
 
+    static const char *const matchers[] = {"startup", "resume", "clear", "compact"};
     const char *const script_names[] = {
         "cbm-code-discovery-gate",
         "cbm-session-reminder",
@@ -12199,13 +12204,21 @@ TEST(cli_windows_claude_lifecycle_migrates_only_exact_owned_legacy_state) {
     yyjson_doc *installed_doc =
         installed_settings ? yyjson_read(installed_settings, strlen(installed_settings), 0) : NULL;
     yyjson_val *installed_root = installed_doc ? yyjson_doc_get_root(installed_doc) : NULL;
+    /* Every owned shell spelling (current .cmd, previous, released) converges
+     * on one exec-form registration per matcher; foreign hooks are untouched. */
+    size_t installed_exec =
+        test_count_exec_hook(installed_root, "SubagentStart", "*", binary_path, "hook-augment");
+    for (size_t i = 0U; i < sizeof(matchers) / sizeof(matchers[0]); i++) {
+        installed_exec += test_count_exec_hook(installed_root, "SessionStart", matchers[i],
+                                               binary_path, "hook-augment");
+    }
     bool commands_migrated =
-        install_rc == 0 &&
-        test_count_hook_command(installed_root, "SessionStart", session_current) == 4U &&
+        install_rc == 0 && installed_exec == 5U &&
+        test_count_hook_command(installed_root, "SessionStart", session_current) == 0U &&
         test_count_hook_command(installed_root, "SessionStart", session_previous) == 0U &&
         test_count_hook_command(installed_root, "SessionStart", session_released) == 0U &&
         test_count_hook_command(installed_root, "SessionStart", foreign_command) == 1U &&
-        test_count_hook_command(installed_root, "SubagentStart", subagent_current) == 1U &&
+        test_count_hook_command(installed_root, "SubagentStart", subagent_current) == 0U &&
         test_count_hook_command(installed_root, "SubagentStart", subagent_previous) == 0U &&
         test_count_hook_command(installed_root, "SubagentStart", subagent_released) == 0U &&
         test_count_hook_command(installed_root, "SubagentStart", foreign_command) == 1U;
@@ -12229,8 +12242,14 @@ TEST(cli_windows_claude_lifecycle_migrates_only_exact_owned_legacy_state) {
         uninstalled_settings ? yyjson_read(uninstalled_settings, strlen(uninstalled_settings), 0)
                              : NULL;
     yyjson_val *uninstalled_root = uninstalled_doc ? yyjson_doc_get_root(uninstalled_doc) : NULL;
+    size_t uninstalled_exec =
+        test_count_exec_hook(uninstalled_root, "SubagentStart", "*", binary_path, "hook-augment");
+    for (size_t i = 0U; i < sizeof(matchers) / sizeof(matchers[0]); i++) {
+        uninstalled_exec += test_count_exec_hook(uninstalled_root, "SessionStart", matchers[i],
+                                                 binary_path, "hook-augment");
+    }
     bool commands_clean =
-        uninstall_rc == 0 &&
+        uninstall_rc == 0 && uninstalled_exec == 0U &&
         test_count_hook_command(uninstalled_root, "SessionStart", session_current) == 0U &&
         test_count_hook_command(uninstalled_root, "SessionStart", session_previous) == 0U &&
         test_count_hook_command(uninstalled_root, "SessionStart", session_released) == 0U &&
@@ -12453,7 +12472,7 @@ TEST(cli_claude_hooks_use_exec_form_across_shells_issue1733) {
         yyjson_doc *doc = settings ? yyjson_read(settings, strlen(settings), 0) : NULL;
         yyjson_val *root = doc ? yyjson_doc_get_root(doc) : NULL;
         size_t owned =
-            test_count_exec_hook(root, "PreToolUse", "Grep|Glob", binary_path, "hook-augment") +
+            test_count_exec_hook(root, "PreToolUse", "Grep|Glob|Bash", binary_path, "hook-augment") +
             test_count_exec_hook(root, "PostToolUse", "Read", binary_path, "hook-augment") +
             test_count_exec_hook(root, "SubagentStart", "*", binary_path, "hook-augment");
         for (size_t i = 0U; i < sizeof(matchers) / sizeof(matchers[0]); i++) {
@@ -12516,7 +12535,7 @@ TEST(cli_claude_exec_hooks_custom_dir_uninstall_issue1733) {
     yyjson_val *installed_root = installed_doc ? yyjson_doc_get_root(installed_doc) : NULL;
     const char *const matchers[] = {"startup", "resume", "clear", "compact"};
     size_t before_owned =
-        test_count_exec_hook(installed_root, "PreToolUse", "Grep|Glob", binary_path,
+        test_count_exec_hook(installed_root, "PreToolUse", "Grep|Glob|Bash", binary_path,
                              "hook-augment") +
         test_count_exec_hook(installed_root, "PostToolUse", "Read", binary_path,
                              "hook-augment") +

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -308,6 +308,50 @@ static size_t test_count_substring(const char *text, const char *needle) {
     return count;
 }
 
+static size_t test_count_exec_hook(yyjson_val *root, const char *event_name,
+                                   const char *matcher_value, const char *expected_command,
+                                   const char *expected_arg) {
+    yyjson_val *hooks = root ? yyjson_obj_get(root, "hooks") : NULL;
+    yyjson_val *entries = hooks && yyjson_is_obj(hooks) ? yyjson_obj_get(hooks, event_name) : NULL;
+    if (!entries || !yyjson_is_arr(entries)) {
+        return 0U;
+    }
+    size_t matches = 0U;
+    size_t entry_index;
+    size_t entry_count;
+    yyjson_val *entry;
+    yyjson_arr_foreach(entries, entry_index, entry_count, entry) {
+        yyjson_val *matcher = yyjson_is_obj(entry) ? yyjson_obj_get(entry, "matcher") : NULL;
+        if ((matcher_value && (!matcher || !yyjson_is_str(matcher) ||
+                               strcmp(yyjson_get_str(matcher), matcher_value) != 0)) ||
+            (!matcher_value && matcher)) {
+            continue;
+        }
+        yyjson_val *entry_hooks = yyjson_obj_get(entry, "hooks");
+        if (!entry_hooks || !yyjson_is_arr(entry_hooks)) {
+            continue;
+        }
+        size_t hook_index;
+        size_t hook_count;
+        yyjson_val *hook;
+        yyjson_arr_foreach(entry_hooks, hook_index, hook_count, hook) {
+            yyjson_val *type = yyjson_is_obj(hook) ? yyjson_obj_get(hook, "type") : NULL;
+            yyjson_val *command = yyjson_is_obj(hook) ? yyjson_obj_get(hook, "command") : NULL;
+            yyjson_val *args = yyjson_is_obj(hook) ? yyjson_obj_get(hook, "args") : NULL;
+            yyjson_val *first_arg = args && yyjson_is_arr(args) ? yyjson_arr_get(args, 0U) : NULL;
+            if (type && yyjson_is_str(type) && strcmp(yyjson_get_str(type), "command") == 0 &&
+                command && yyjson_is_str(command) &&
+                strcmp(yyjson_get_str(command), expected_command) == 0 && args &&
+                yyjson_is_arr(args) && yyjson_arr_size(args) == 1U && first_arg &&
+                yyjson_is_str(first_arg) && strcmp(yyjson_get_str(first_arg), expected_arg) == 0 &&
+                !yyjson_obj_get(hook, "shell") && !yyjson_obj_get(hook, "command_windows")) {
+                matches++;
+            }
+        }
+    }
+    return matches;
+}
+
 #ifdef _WIN32
 static bool test_append_command_hook(yyjson_mut_doc *doc, yyjson_mut_val *event_entries,
                                      const char *matcher, const char *command) {
@@ -9287,8 +9331,13 @@ TEST(cli_claude_session_hook_preserves_user_entry) {
     cbm_install_agent_configs(tmpdir, "/usr/local/bin/codebase-memory-mcp", false, false);
 
     char *installed = read_test_file_alloc(settings_path);
-    bool preserved = installed && strstr(installed, "echo user-session-hook") &&
-                     strstr(installed, "cbm-session-reminder");
+    yyjson_doc *installed_doc = installed ? yyjson_read(installed, strlen(installed), 0) : NULL;
+    yyjson_val *installed_root = installed_doc ? yyjson_doc_get_root(installed_doc) : NULL;
+    bool preserved =
+        installed && strstr(installed, "echo user-session-hook") &&
+        test_count_exec_hook(installed_root, "SessionStart", "startup",
+                             "/usr/local/bin/codebase-memory-mcp", "hook-augment") == 1U;
+    yyjson_doc_free(installed_doc);
     free(installed);
     restore_test_env("PATH", saved_path);
     restore_test_env("CLAUDE_CONFIG_DIR", saved_config);
@@ -9971,7 +10020,7 @@ TEST(cli_claude_hook_scripts_shell_quote_binary_path) {
     PASS();
 }
 
-TEST(cli_claude_hook_commands_shell_quote_custom_config_dir) {
+TEST(cli_claude_hook_commands_use_exec_form_with_custom_config_dir) {
 #ifdef _WIN32
     SKIP_PLATFORM("POSIX shell quoting contract");
 #endif
@@ -9989,23 +10038,32 @@ TEST(cli_claude_hook_commands_shell_quote_custom_config_dir) {
     cbm_setenv("PATH", tmpdir, 1);
     cbm_setenv("CLAUDE_CONFIG_DIR", config_dir, 1);
 
-    cbm_install_agent_configs(tmpdir, "/opt/codebase-memory-mcp", false, false);
+    const char *binary = "/opt/codebase-memory-mcp";
+    cbm_install_agent_configs(tmpdir, binary, false, false);
     char settings_path[768];
     snprintf(settings_path, sizeof(settings_path), "%s/settings.json", config_dir);
     char *settings = read_test_file_alloc(settings_path);
-    char quoted_prefix[704];
-    snprintf(quoted_prefix, sizeof(quoted_prefix), "'%s/hooks/", config_dir);
-    bool quoted = settings && strstr(settings, quoted_prefix) &&
-                  strstr(settings, "cbm-code-discovery-gate'") &&
-                  strstr(settings, "cbm-session-reminder'") &&
-                  strstr(settings, "cbm-subagent-reminder'");
+    yyjson_doc *document = settings ? yyjson_read(settings, strlen(settings), 0) : NULL;
+    yyjson_val *root = document ? yyjson_doc_get_root(document) : NULL;
+    static const char *const matchers[] = {"startup", "resume", "clear", "compact"};
+    size_t owned = test_count_exec_hook(root, "PreToolUse", "Grep|Glob", binary, "hook-augment") +
+                   test_count_exec_hook(root, "PostToolUse", "Read", binary, "hook-augment") +
+                   test_count_exec_hook(root, "SubagentStart", "*", binary, "hook-augment");
+    for (size_t i = 0U; i < sizeof(matchers) / sizeof(matchers[0]); i++) {
+        owned += test_count_exec_hook(root, "SessionStart", matchers[i], binary, "hook-augment");
+    }
+    bool exec_form = settings && owned == 7U && !strstr(settings, config_dir) &&
+                     !strstr(settings, "cbm-code-discovery-gate") &&
+                     !strstr(settings, "cbm-session-reminder") &&
+                     !strstr(settings, "cbm-subagent-reminder");
+    yyjson_doc_free(document);
     free(settings);
 
     restore_test_env("PATH", saved_path);
     restore_test_env("CLAUDE_CONFIG_DIR", saved_claude);
     test_rmdir_r(tmpdir);
-    if (!quoted)
-        FAIL("Claude settings must shell-quote the complete custom hook script path");
+    if (!exec_form)
+        FAIL("Claude settings must keep custom config paths out of shell-free hook commands");
     PASS();
 }
 
@@ -10845,18 +10903,31 @@ TEST(cli_upgrade_migrates_released_claude_hook_scripts) {
     cbm_setenv("PATH", tmpdir, 1);
     cbm_unsetenv("CLAUDE_CONFIG_DIR");
     cbm_unsetenv("CODEX_HOME");
-    int rc = cbm_install_agent_configs(tmpdir, "/opt/codebase-memory-mcp", false, false);
+    const char *binary = "/opt/codebase-memory-mcp";
+    int rc = cbm_install_agent_configs(tmpdir, binary, false, false);
 
     char *gate = read_test_file_alloc(gate_path);
     char *session = read_test_file_alloc(session_path);
     char *subagent = read_test_file_alloc(subagent_path);
     char *settings = read_test_file_alloc(settings_path);
+    yyjson_doc *settings_doc = settings ? yyjson_read(settings, strlen(settings), 0) : NULL;
+    yyjson_val *settings_root = settings_doc ? yyjson_doc_get_root(settings_doc) : NULL;
+    static const char *const matchers[] = {"startup", "resume", "clear", "compact"};
+    size_t registered =
+        test_count_exec_hook(settings_root, "PreToolUse", "Grep|Glob", binary, "hook-augment") +
+        test_count_exec_hook(settings_root, "PostToolUse", "Read", binary, "hook-augment") +
+        test_count_exec_hook(settings_root, "SubagentStart", "*", binary, "hook-augment");
+    for (size_t i = 0U; i < sizeof(matchers) / sizeof(matchers[0]); i++) {
+        registered += test_count_exec_hook(settings_root, "SessionStart", matchers[i], binary,
+                                           "hook-augment");
+    }
     bool migrated = rc == 0 && gate && strcmp(gate, legacy_gate) != 0 && session &&
                     strcmp(session, legacy_session) != 0 && subagent &&
-                    strcmp(subagent, legacy_subagent) != 0 && settings &&
-                    strstr(settings, "cbm-code-discovery-gate") &&
-                    strstr(settings, "cbm-session-reminder") &&
-                    strstr(settings, "cbm-subagent-reminder");
+                    strcmp(subagent, legacy_subagent) != 0 && settings && registered == 7U &&
+                    !strstr(settings, "cbm-code-discovery-gate") &&
+                    !strstr(settings, "cbm-session-reminder") &&
+                    !strstr(settings, "cbm-subagent-reminder");
+    yyjson_doc_free(settings_doc);
     free(gate);
     free(session);
     free(subagent);
@@ -12333,6 +12404,152 @@ TEST(cli_windows_claude_hook_command_is_shell_portable) {
               -1);
 
     restore_test_env("CLAUDE_CONFIG_DIR", saved_config);
+    PASS();
+}
+
+/* #1733: shell-form Windows hooks cross two incompatible parsers. Git Bash
+ * rewrites cmd.exe's slash switches as paths, while PowerShell has different
+ * quoting and invocation rules. Claude's exec form avoids both shells: the
+ * executable path is one literal field, hook-augment is one literal argv
+ * element, and the hook payload is forwarded directly on stdin. */
+TEST(cli_claude_hooks_use_exec_form_across_shells_issue1733) {
+    char *saved_path = save_test_env("PATH");
+    char *saved_config = save_test_env("CLAUDE_CONFIG_DIR");
+    const char *const matchers[] = {"startup", "resume", "clear", "compact"};
+    const char *binary_path = "C:/Program Files/CBM & Tools/codebase-memory-mcp.exe";
+    bool all_valid = true;
+
+    for (int custom = 0; custom < 2; custom++) {
+        char tmpdir[256];
+        snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-hook-exec-XXXXXX");
+        if (!cbm_mkdtemp(tmpdir)) {
+            all_valid = false;
+            break;
+        }
+        char config_dir[640];
+        if (custom) {
+            snprintf(config_dir, sizeof(config_dir), "%s/custom Claude & $(inert)!100%%", tmpdir);
+            cbm_setenv("CLAUDE_CONFIG_DIR", config_dir, 1);
+        } else {
+            snprintf(config_dir, sizeof(config_dir), "%s/.claude", tmpdir);
+            cbm_unsetenv("CLAUDE_CONFIG_DIR");
+        }
+        test_mkdirp(config_dir);
+        cbm_setenv("PATH", tmpdir, 1);
+
+        char settings_path[768];
+        snprintf(settings_path, sizeof(settings_path), "%s/settings.json", config_dir);
+        const char *foreign =
+            "{\"hooks\":{\"SessionStart\":[{\"matcher\":\"resume\",\"hooks\":[{"
+            "\"type\":\"command\",\"command\":\"foreign-hook\",\"args\":[\"keep\"]}]}]}}";
+        if (write_test_file(settings_path, foreign) != 0 ||
+            cbm_install_agent_configs(tmpdir, binary_path, false, false) != 0) {
+            all_valid = false;
+            test_rmdir_r(tmpdir);
+            break;
+        }
+
+        char *settings = read_test_file_alloc(settings_path);
+        yyjson_doc *doc = settings ? yyjson_read(settings, strlen(settings), 0) : NULL;
+        yyjson_val *root = doc ? yyjson_doc_get_root(doc) : NULL;
+        size_t owned =
+            test_count_exec_hook(root, "PreToolUse", "Grep|Glob", binary_path, "hook-augment") +
+            test_count_exec_hook(root, "PostToolUse", "Read", binary_path, "hook-augment") +
+            test_count_exec_hook(root, "SubagentStart", "*", binary_path, "hook-augment");
+        for (size_t i = 0U; i < sizeof(matchers) / sizeof(matchers[0]); i++) {
+            owned += test_count_exec_hook(root, "SessionStart", matchers[i], binary_path,
+                                          "hook-augment");
+        }
+        size_t foreign_count =
+            test_count_exec_hook(root, "SessionStart", "resume", "foreign-hook", "keep");
+        all_valid = all_valid && owned == 7U && foreign_count == 1U && settings &&
+                    strstr(settings, "cmd.exe") == NULL &&
+                    strstr(settings, "cbm-session-reminder.cmd") == NULL &&
+                    strstr(settings, "cbm-subagent-reminder.cmd") == NULL &&
+                    strstr(settings, "cbm-code-discovery-gate.cmd") == NULL;
+        yyjson_doc_free(doc);
+        free(settings);
+        test_rmdir_r(tmpdir);
+    }
+
+    restore_test_env("PATH", saved_path);
+    restore_test_env("CLAUDE_CONFIG_DIR", saved_config);
+    if (!all_valid)
+        FAIL("Claude hooks must use shell-free exec form and preserve foreign hooks");
+    PASS();
+}
+
+TEST(cli_claude_exec_hooks_custom_dir_uninstall_issue1733) {
+    char *saved_home = save_test_env("HOME");
+    char *saved_path = save_test_env("PATH");
+    char *saved_config = save_test_env("CLAUDE_CONFIG_DIR");
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cli-hook-uninstall-XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    char config_dir[512];
+    char settings_path[640];
+    char install_dir[512];
+    char binary_path[640];
+    snprintf(config_dir, sizeof(config_dir), "%s/.claude", tmpdir);
+    snprintf(settings_path, sizeof(settings_path), "%s/settings.json", config_dir);
+    snprintf(install_dir, sizeof(install_dir), "%s/custom CBM & bin", tmpdir);
+#ifdef _WIN32
+    snprintf(binary_path, sizeof(binary_path), "%s/codebase-memory-mcp.exe", install_dir);
+#else
+    snprintf(binary_path, sizeof(binary_path), "%s/codebase-memory-mcp", install_dir);
+#endif
+    test_mkdirp(config_dir);
+    test_mkdirp(install_dir);
+    const char *foreign =
+        "{\"hooks\":{\"SessionStart\":[{\"matcher\":\"resume\",\"hooks\":[{"
+        "\"type\":\"command\",\"command\":\"foreign-hook\",\"args\":[\"keep\"]}]}]}}";
+    write_test_file(settings_path, foreign);
+    cbm_setenv("HOME", tmpdir, 1);
+    cbm_setenv("PATH", tmpdir, 1);
+    cbm_unsetenv("CLAUDE_CONFIG_DIR");
+
+    int install_rc = cbm_install_agent_configs(tmpdir, binary_path, false, false);
+    char *installed = read_test_file_alloc(settings_path);
+    yyjson_doc *installed_doc = installed ? yyjson_read(installed, strlen(installed), 0) : NULL;
+    yyjson_val *installed_root = installed_doc ? yyjson_doc_get_root(installed_doc) : NULL;
+    const char *const matchers[] = {"startup", "resume", "clear", "compact"};
+    size_t before_owned =
+        test_count_exec_hook(installed_root, "PreToolUse", "Grep|Glob", binary_path,
+                             "hook-augment") +
+        test_count_exec_hook(installed_root, "PostToolUse", "Read", binary_path,
+                             "hook-augment") +
+        test_count_exec_hook(installed_root, "SubagentStart", "*", binary_path, "hook-augment");
+    for (size_t i = 0U; i < sizeof(matchers) / sizeof(matchers[0]); i++) {
+        before_owned += test_count_exec_hook(installed_root, "SessionStart", matchers[i],
+                                             binary_path, "hook-augment");
+    }
+    yyjson_doc_free(installed_doc);
+    free(installed);
+
+    char dir_arg[640];
+    snprintf(dir_arg, sizeof(dir_arg), "--dir=%s", install_dir);
+    char *argv[] = {"uninstall", "--yes", dir_arg};
+    int uninstall_rc = cli_test_cmd_uninstall(3, argv);
+    char *uninstalled = read_test_file_alloc(settings_path);
+    yyjson_doc *uninstalled_doc =
+        uninstalled ? yyjson_read(uninstalled, strlen(uninstalled), 0) : NULL;
+    yyjson_val *uninstalled_root = uninstalled_doc ? yyjson_doc_get_root(uninstalled_doc) : NULL;
+    size_t after_owned =
+        test_count_substring(uninstalled ? uninstalled : "", "\"hook-augment\"");
+    size_t foreign_count = test_count_exec_hook(uninstalled_root, "SessionStart", "resume",
+                                                "foreign-hook", "keep");
+    yyjson_doc_free(uninstalled_doc);
+    free(uninstalled);
+
+    restore_test_env("HOME", saved_home);
+    restore_test_env("PATH", saved_path);
+    restore_test_env("CLAUDE_CONFIG_DIR", saved_config);
+    test_rmdir_r(tmpdir);
+    if (install_rc != 0 || before_owned != 7U || uninstall_rc != 0 || after_owned != 0U ||
+        foreign_count != 1U)
+        FAIL("custom --dir uninstall must remove seven exact-owned exec hooks and keep foreign hooks");
     PASS();
 }
 
@@ -14030,7 +14247,7 @@ SUITE(cli) {
     RUN_TEST(cli_mcp_installers_preserve_foreign_same_name_entries);
     RUN_TEST(cli_installer_rejects_symlinked_agent_roots);
     RUN_TEST(cli_claude_hook_scripts_shell_quote_binary_path);
-    RUN_TEST(cli_claude_hook_commands_shell_quote_custom_config_dir);
+    RUN_TEST(cli_claude_hook_commands_use_exec_form_with_custom_config_dir);
     RUN_TEST(cli_codex_migrates_to_single_hook_representation);
 #ifndef _WIN32
     RUN_TEST(cli_codex_preflight_reports_heading_and_reason);
@@ -14116,6 +14333,8 @@ SUITE(cli) {
     RUN_TEST(cli_windows_claude_hook_scripts_migrate_and_uninstall_all_owned_shapes);
 #endif
     RUN_TEST(cli_windows_claude_hook_command_is_shell_portable);
+    RUN_TEST(cli_claude_hooks_use_exec_form_across_shells_issue1733);
+    RUN_TEST(cli_claude_exec_hooks_custom_dir_uninstall_issue1733);
     RUN_TEST(cli_hook_augment_path_is_abs);
     RUN_TEST(cli_hook_augment_deadline_breadcrumb_issue858);
     RUN_TEST(cli_upsert_claude_hook_fresh);

--- a/tests/windows/test_hook_augment.py
+++ b/tests/windows/test_hook_augment.py
@@ -15,9 +15,11 @@ augmenter now fires for a drive-letter cwd.
 
 This test indexes a repo with a known symbol, confirms `search_graph` finds it
 (control — proves the index and project name are fine), then invokes
-`hook-augment` exactly as the installed PreToolUse hook does and asserts a
-`hookSpecificOutput` payload is produced. It fails (red) if that fix regresses.
-Also passes on Linux/macOS (`cwd` starts with `/`).
+`hook-augment` exactly as Claude's shell-free hook registration does: the
+executable is a literal argv element, including a forward-slash Windows path,
+and the hook payload is forwarded directly on stdin. It asserts a
+`hookSpecificOutput` payload is produced and fails (red) if either product
+contract regresses. Also passes on Linux/macOS (`cwd` starts with `/`).
 
 Exit code: 0 == augmenter fired (green), 1 == no-op (regression), 2 == setup error.
 
@@ -40,6 +42,7 @@ SRC = "export function %s(a: number): number { return a + 1; }\n" % SYMBOL
 def run_cli(binary, cache, args, stdin=None, timeout=120):
     env = dict(os.environ)
     env["CBM_CACHE_DIR"] = cache
+    env["CBM_RUNTIME_DIR"] = os.path.join(cache, "runtime")
     return subprocess.run([binary] + args, capture_output=True, timeout=timeout,
                           env=env, input=stdin)
 
@@ -48,12 +51,20 @@ def main():
     if len(sys.argv) < 2:
         print("usage: python test_hook_augment.py <binary>")
         return 2
-    binary = os.path.abspath(sys.argv[1])
+    # Claude's exec-form hook preserves this string exactly. On Windows, keep
+    # the forward-slash spelling that previously crossed Git Bash incorrectly.
+    binary = os.path.abspath(sys.argv[1]).replace("\\", "/")
     if not os.path.exists(binary):
         print("FAIL: binary not found: %s" % binary)
         return 2
 
-    work = tempfile.mkdtemp(prefix="cbm_win_hook_")
+    # macOS resolves /tmp through a symlink; the daemon's secure path walk
+    # accepts the canonical root-owned sticky parent at /private/tmp.
+    temp_parent = "/private/tmp" if sys.platform == "darwin" else None
+    work = tempfile.mkdtemp(prefix="cbm_win_hook_", dir=temp_parent)
+    cache = None
+    daemon_pid = 0
+    daemon_started = False
     try:
         repo = os.path.join(work, "repo")
         os.makedirs(os.path.join(repo, "src"), exist_ok=True)
@@ -61,6 +72,31 @@ def main():
             f.write(SRC.encode("utf-8"))
         cache = os.path.join(work, "cache")
         os.makedirs(cache, exist_ok=True)
+        os.makedirs(os.path.join(cache, "runtime"), mode=0o700, exist_ok=True)
+
+        # The CLI and hooks share the mandatory daemon. Start the supported
+        # permanent mode before indexing so every product-surface command uses
+        # the same isolated cache and daemon cohort.
+        # Retry once: a cold runner's daemon startup latency (#1952) is setup
+        # noise, not the surface under test.
+        start_out = ""
+        rc = 1
+        for attempt in (1, 2):
+            start = run_cli(binary, cache, ["daemon", "start"], timeout=60)
+            start_out = (start.stdout or b"").decode("utf-8", "replace")
+            start_err = (start.stderr or b"").decode("utf-8", "replace")
+            rc = start.returncode
+            print("daemon start attempt %d rc=%d stdout=%r stderr=%r" %
+                  (attempt, rc, start_out[:120], start_err[:500]))
+            if rc == 0:
+                break
+            time.sleep(2)
+        if rc != 0:
+            print("SETUP FAIL: permanent daemon did not start")
+            return 2
+        daemon_started = True
+        pid_match = re.search(r"pid (\d+)", start_out)
+        daemon_pid = int(pid_match.group(1)) if pid_match else 0
 
         # repo_path / cwd in the forward-slash drive form Claude Code passes.
         repo_fwd = repo.replace("\\", "/")
@@ -100,27 +136,6 @@ def main():
             return 2
         print("control: search_graph finds %s in project %s" % (SYMBOL, name))
 
-        # Hooks are connect-only under the mandatory daemon: they never spawn
-        # one and fail open when none is active. Bring up a permanent daemon
-        # first — the supported way to keep hooks armed outside MCP sessions —
-        # and retire it afterwards (with a kill-by-pid backstop so a stuck stop
-        # can never hang CI).
-        start_out = ""
-        rc = 1
-        for attempt in (1, 2):
-            start = run_cli(binary, cache, ["daemon", "start"], timeout=60)
-            start_out = (start.stdout or b"").decode("utf-8", "replace")
-            rc = start.returncode
-            print("daemon start attempt %d rc=%d %r" % (attempt, rc, start_out[:120]))
-            if rc == 0:
-                break
-            time.sleep(2)
-        if rc != 0:
-            print("SETUP FAIL: permanent daemon did not start")
-            return 2
-        pid_match = re.search(r"pid (\d+)", start_out)
-        daemon_pid = int(pid_match.group(1)) if pid_match else 0
-
         # Invoke hook-augment exactly as the installed PreToolUse hook does.
         payload = json.dumps({
             "hook_event_name": "PreToolUse",
@@ -128,21 +143,7 @@ def main():
             "cwd": repo_fwd,
             "tool_input": {"pattern": SYMBOL},
         }).encode("utf-8")
-        try:
-            ha = run_cli(binary, cache, ["hook-augment"], stdin=payload, timeout=60)
-        finally:
-            stopped = False
-            try:
-                stop = run_cli(binary, cache, ["daemon", "stop"], timeout=30)
-                stopped = stop.returncode == 0
-            except subprocess.TimeoutExpired:
-                pass
-            if not stopped and daemon_pid:
-                subprocess.run(["taskkill" if os.name == "nt" else "kill",
-                                "/F" if os.name == "nt" else "-9",
-                                "/PID" if os.name == "nt" else str(daemon_pid)] +
-                               ([str(daemon_pid)] if os.name == "nt" else []),
-                               capture_output=True, timeout=30)
+        ha = run_cli(binary, cache, ["hook-augment"], stdin=payload, timeout=60)
         out = (ha.stdout or b"").decode("utf-8", "replace").strip()
         print("hook-augment rc=%d stdout=%r" % (ha.returncode, out[:200]))
 
@@ -155,6 +156,19 @@ def main():
               "cbm_is_walkable_abs_path handling in hook_augment.c regressed?).")
         return 1
     finally:
+        if daemon_started and cache:
+            stopped = False
+            try:
+                stop = run_cli(binary, cache, ["daemon", "stop"], timeout=30)
+                stopped = stop.returncode == 0
+            except subprocess.TimeoutExpired:
+                pass
+            if not stopped and daemon_pid:
+                subprocess.run(["taskkill" if os.name == "nt" else "kill",
+                                "/F" if os.name == "nt" else "-9",
+                               "/PID" if os.name == "nt" else str(daemon_pid)] +
+                               ([str(daemon_pid)] if os.name == "nt" else []),
+                               capture_output=True, timeout=30)
         shutil.rmtree(work, ignore_errors=True)
 
 


### PR DESCRIPTION
Fixes #1733

## Summary

- register all seven managed Claude Code hooks with the executable-plus-arguments form, preserving the configured binary path literally and forwarding hook input directly on stdin
- migrate legacy shell registrations and a previously managed executable path while requiring exact command-and-arguments ownership, so foreign hooks that share a matcher remain untouched
- use the resolved install target during uninstall, including custom install directories and consistent Windows path spelling
- add deterministic unit and product regressions for the shared PreToolUse, PostToolUse, SessionStart, and SubagentStart behavior

## Design choice

The recommended native executable-plus-arguments form was selected because it has the smallest parser surface: Claude Code launches the binary directly, the path remains one literal value across native Windows and Git Bash, and stdin remains noninteractive.

Alternatives considered:

- retaining the command-shell wrapper would preserve the older settings shape, but still crosses incompatible shell parsers and can reinterpret Windows switches or paths
- adding a PowerShell wrapper would avoid part of the command-shell mismatch, but introduces another shell grammar and another runtime artifact
- generating shell-specific commands would multiply platform branches and still leave ownership and quoting behavior dependent on the launching shell

Trade-offs:

- this relies on the supported Claude Code hook arguments field
- managed helper scripts remain installed and migration-aware for upgrade and uninstall compatibility even though the new Claude Code settings execute the binary directly
- ownership is intentionally exact; hooks not matching both the managed command and arguments are preserved

## Verification

- deterministic current-main regression: the new cross-shell contract failed on the screened base
- lifecycle regression: custom-directory install followed by matching uninstall failed before the follow-up fix; final production-only revert returned exactly that test to red
- final sanitized CLI suite: 283 passed, 0 failed
- direct product test: isolated daemon/index/search control passed and direct executable argv plus stdin emitted hook-specific output
- Python syntax check passed
- make -j2 -f Makefile.cbm lint-ci passed
- Windows cross-build and Wine smoke passed
- full macOS local CI on the pre-lifecycle-review tree: 7,584 passed, 0 failed, 8 skipped
- Linux arm64 local CI on the pre-lifecycle-review tree: 7,422 passed, 0 failed, 8 skipped

The final lifecycle correction was revalidated by the full sanitized CLI suite, product test, lint, and Windows cross/Wine leg. The real-Windows VM leg could not run because the local CI infrastructure lacked the VM SSH host key; no infrastructure bypass was attempted.