### PR TITLE
fix(extract): extract structure from Vue inline scripts

### DIFF
--- a/internal/cbm/cbm.h
+++ b/internal/cbm/cbm.h
@@ -727,6 +727,9 @@ void cbm_channels_push(CBMChannelArray *arr, CBMArena *a, CBMChannel ch);
 // --- Sub-extractor entry points ---
 
 void cbm_extract_definitions(CBMExtractCtx *ctx);
+/* Internal companion for embedded-language trees that contribute definitions
+ * to an existing host-file Module rather than minting a second Module. */
+void cbm_extract_definitions_without_module(CBMExtractCtx *ctx);
 // dbt lineage for Jinja-templated SQL models: emits a Model def plus one usage
 // per ref()/source() call. No-op unless the file parses as SQL and actually
 // contains a dbt builtin call. Defined in extract_dbt.c.

--- a/internal/cbm/extract_defs.c
+++ b/internal/cbm/extract_defs.c
@@ -7524,6 +7524,19 @@ static void walk_defs(CBMExtractCtx *ctx, TSNode root, const CBMLangSpec *spec, 
     free(s.data);
 }
 
+void cbm_extract_definitions_without_module(CBMExtractCtx *ctx) {
+    const CBMLangSpec *spec = cbm_lang_spec(ctx->language);
+    if (!spec) {
+        return;
+    }
+
+    // Walk AST for function/class definitions
+    walk_defs(ctx, ctx->root, spec, 0);
+
+    // Extract module-level variables
+    extract_variables(ctx, ctx->root, spec);
+}
+
 void cbm_extract_definitions(CBMExtractCtx *ctx) {
     const CBMLangSpec *spec = cbm_lang_spec(ctx->language);
     if (!spec) {
@@ -7545,9 +7558,5 @@ void cbm_extract_definitions(CBMExtractCtx *ctx) {
     mod.is_test = ctx->result->is_test_file;
     cbm_defs_push(&ctx->result->defs, a, mod);
 
-    // Walk AST for function/class definitions
-    walk_defs(ctx, ctx->root, spec, 0);
-
-    // Extract module-level variables
-    extract_variables(ctx, ctx->root, spec);
+    cbm_extract_definitions_without_module(ctx);
 }

--- a/internal/cbm/extract_imports.c
+++ b/internal/cbm/extract_imports.c
@@ -1395,8 +1395,13 @@ static void parse_spec_imports(CBMExtractCtx *ctx) {
 // that the main parser uses.  Adding another host language is a one-line
 // declaration in lang_specs.c.
 
+typedef struct {
+    TSNode script;
+    TSNode content;
+} CBMEmbeddedBlock;
+
 static void embedded_collect_content_nodes(TSNode root, const CBMEmbeddedLangSpec *spec,
-                                           TSNode *out, int *out_count, int max_out) {
+                                           CBMEmbeddedBlock *out, int *out_count, int max_out) {
     /* Iterative DFS so deeply-nested script blocks are still found.  Cap the
      * stack to a sane bound (host grammars do not have million-deep markup
      * trees) — no need to introduce TSNodeStack here. */
@@ -1412,7 +1417,8 @@ static void embedded_collect_content_nodes(TSNode root, const CBMEmbeddedLangSpe
             for (uint32_t k = 0; k < cc; k++) {
                 TSNode c = ts_node_child(node, k);
                 if (strcmp(ts_node_type(c), spec->content_node_type) == 0) {
-                    out[(*out_count)++] = c;
+                    out[*out_count] = (CBMEmbeddedBlock){.script = node, .content = c};
+                    (*out_count)++;
                     if (*out_count >= max_out) {
                         return;
                     }
@@ -1429,50 +1435,166 @@ static void embedded_collect_content_nodes(TSNode root, const CBMEmbeddedLangSpe
     }
 }
 
+static bool ascii_trimmed_equals(const char *value, const char *expected) {
+    if (!value || !expected) {
+        return false;
+    }
+    while (*value && isspace((unsigned char)*value)) {
+        value++;
+    }
+    size_t len = strlen(value);
+    while (len > 0 && isspace((unsigned char)value[len - 1])) {
+        len--;
+    }
+    size_t expected_len = strlen(expected);
+    if (len != expected_len) {
+        return false;
+    }
+    for (size_t i = 0; i < len; i++) {
+        if (tolower((unsigned char)value[i]) != tolower((unsigned char)expected[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/* Vue is the only host that opts into structural embedded extraction. Restrict
+ * its inline programs to the language forms whose parsers we can select
+ * exactly. A src attribute always denotes an external program and therefore
+ * suppresses any inline extraction, even for malformed mixed markup. */
+static bool vue_embedded_language(CBMExtractCtx *ctx, TSNode script, CBMLanguage *language) {
+    enum { VUE_ATTR_STACK_CAP = 128 };
+    TSNode stack[VUE_ATTR_STACK_CAP];
+    int top = 0;
+    bool has_lang = false;
+    bool lang_supported = true;
+    CBMLanguage selected = CBM_LANG_JAVASCRIPT;
+    stack[top++] = script;
+    while (top > 0) {
+        TSNode node = stack[--top];
+        if (strcmp(ts_node_type(node), "attribute") == 0) {
+            uint32_t named_count = ts_node_named_child_count(node);
+            if (named_count == 0) {
+                return false;
+            }
+            TSNode name_node = ts_node_named_child(node, 0);
+            char *name = cbm_node_text(ctx->arena, name_node, ctx->source);
+            if (ascii_trimmed_equals(name, "src")) {
+                return false;
+            }
+            if (ascii_trimmed_equals(name, "lang")) {
+                TSNode value_node = node;
+                if (!find_first_descendant_of(node, "attribute_value", &value_node)) {
+                    return false;
+                }
+                char *value = cbm_node_text(ctx->arena, value_node, ctx->source);
+                has_lang = true;
+                if (ascii_trimmed_equals(value, "js") ||
+                    ascii_trimmed_equals(value, "javascript")) {
+                    selected = CBM_LANG_JAVASCRIPT;
+                } else if (ascii_trimmed_equals(value, "ts") ||
+                           ascii_trimmed_equals(value, "typescript")) {
+                    selected = CBM_LANG_TYPESCRIPT;
+                } else {
+                    lang_supported = false;
+                }
+            }
+            continue;
+        }
+        uint32_t count = ts_node_named_child_count(node);
+        if ((int)count > VUE_ATTR_STACK_CAP - top) {
+            return false;
+        }
+        for (int i = (int)count - 1; i >= 0; i--) {
+            stack[top++] = ts_node_named_child(node, (uint32_t)i);
+        }
+    }
+    if (has_lang && !lang_supported) {
+        return false;
+    }
+    *language = selected;
+    return true;
+}
+
+static void parse_one_embedded_block(CBMExtractCtx *ctx, const CBMEmbeddedBlock *block,
+                                     CBMLanguage embedded_language, bool extract_structure) {
+    const TSLanguage *language = cbm_ts_language(embedded_language);
+    if (!language || ctx->source_len < 0) {
+        return;
+    }
+    TSRange range = {
+        .start_point = ts_node_start_point(block->content),
+        .end_point = ts_node_end_point(block->content),
+        .start_byte = ts_node_start_byte(block->content),
+        .end_byte = ts_node_end_byte(block->content),
+    };
+    if (range.end_byte <= range.start_byte || range.end_byte > (uint32_t)ctx->source_len) {
+        return;
+    }
+
+    /* One fresh parser/tree per block prevents parser state or error recovery
+     * from one script from changing the next script's result. Parsing the full
+     * original buffer through the absolute included range preserves byte and
+     * point coordinates across CRLF and UTF-8 prefixes. */
+    TSParser *parser = ts_parser_new();
+    if (!parser) {
+        return;
+    }
+    if (!ts_parser_set_language(parser, language) ||
+        !ts_parser_set_included_ranges(parser, &range, 1)) {
+        ts_parser_delete(parser);
+        return;
+    }
+    TSTree *tree = ts_parser_parse_string(parser, NULL, ctx->source, (uint32_t)ctx->source_len);
+    if (!tree) {
+        ts_parser_delete(parser);
+        return;
+    }
+
+    CBMExtractCtx sub_ctx = {
+        .arena = ctx->arena,
+        .result = ctx->result,
+        .source = ctx->source,
+        .source_len = ctx->source_len,
+        .language = embedded_language,
+        .project = ctx->project,
+        .rel_path = ctx->rel_path,
+        .module_qn = ctx->module_qn,
+        .root = ts_tree_root_node(tree),
+        .macro_table = ctx->macro_table,
+        .return_type_table = ctx->return_type_table,
+    };
+    if (extract_structure) {
+        cbm_extract_definitions_without_module(&sub_ctx);
+    }
+    walk_es_imports(&sub_ctx, sub_ctx.root);
+    if (extract_structure) {
+        cbm_extract_unified(&sub_ctx);
+    }
+
+    ts_tree_delete(tree);
+    ts_parser_delete(parser);
+}
+
 static void parse_embedded_imports(CBMExtractCtx *ctx) {
     const CBMLangSpec *spec = cbm_lang_spec(ctx->language);
     if (!spec || !spec->embedded_imports) {
         return;
     }
     for (const CBMEmbeddedLangSpec *e = spec->embedded_imports; e->script_node_type != NULL; e++) {
-        const TSLanguage *embedded_lang = cbm_ts_language(e->embedded_language);
-        if (!embedded_lang) {
-            continue; /* embedded grammar not linked in — silently skip */
-        }
         enum { MAX_EMBEDDED_BLOCKS = 16 };
-        TSNode hits[MAX_EMBEDDED_BLOCKS];
+        CBMEmbeddedBlock hits[MAX_EMBEDDED_BLOCKS];
         int hit_count = 0;
         embedded_collect_content_nodes(ctx->root, e, hits, &hit_count, MAX_EMBEDDED_BLOCKS);
-        if (hit_count == 0) {
-            continue;
-        }
-        TSParser *parser = ts_parser_new();
-        if (!parser) {
-            continue;
-        }
-        if (!ts_parser_set_language(parser, embedded_lang)) {
-            ts_parser_delete(parser);
-            continue;
-        }
         for (int i = 0; i < hit_count; i++) {
-            uint32_t s = ts_node_start_byte(hits[i]);
-            uint32_t end = ts_node_end_byte(hits[i]);
-            if (end <= s) {
+            CBMLanguage embedded_language = e->embedded_language;
+            bool extract_structure = ctx->language == CBM_LANG_VUE;
+            if (extract_structure &&
+                !vue_embedded_language(ctx, hits[i].script, &embedded_language)) {
                 continue;
             }
-            const char *sub_src = ctx->source + s;
-            uint32_t sub_len = end - s;
-            TSTree *sub_tree = ts_parser_parse_string(parser, NULL, sub_src, sub_len);
-            if (!sub_tree) {
-                continue;
-            }
-            CBMExtractCtx sub_ctx = *ctx;
-            sub_ctx.source = sub_src;
-            sub_ctx.root = ts_tree_root_node(sub_tree);
-            walk_es_imports(&sub_ctx, sub_ctx.root);
-            ts_tree_delete(sub_tree);
+            parse_one_embedded_block(ctx, &hits[i], embedded_language, extract_structure);
         }
-        ts_parser_delete(parser);
     }
 }
 

--- a/tests/test_edge_structural.c
+++ b/tests/test_edge_structural.c
@@ -407,6 +407,19 @@ TEST(es_calls_crossfile_typescript) {
     PASS();
 }
 
+TEST(es_calls_vue_embedded_issue1410) {
+    static const ES_LangFile f[] = {
+        {"App.vue",
+         "<template><p>Vue</p></template>\n"
+         "<script setup lang=\"ts\">\n"
+         "function callee(): number { return 42; }\n"
+         "function caller(): number { return callee(); }\n"
+         "</script>\n"},
+    };
+    ASSERT_EQ(es_exact_edge_by_name(f, 1, "CALLS", "caller", "callee"), 1);
+    PASS();
+}
+
 /* Java: caller in Main.java calls static method from Util.java (same package). */
 TEST(es_calls_crossfile_java) {
     static const ES_LangFile f[] = {
@@ -913,6 +926,7 @@ SUITE(edge_structural) {
     RUN_TEST(es_calls_crossfile_java);
     RUN_TEST(es_calls_crossfile_kotlin);
     RUN_TEST(es_calls_crossfile_csharp);
+    RUN_TEST(es_calls_vue_embedded_issue1410);
 
     /* ── FAMILY 2: INHERITS cross-file ────────────────────────── */
     /* GREEN: Java, C#, C++ (extraction confirmed correct). */

--- a/tests/test_extraction.c
+++ b/tests/test_extraction.c
@@ -74,6 +74,27 @@ static int count_defs_with_label(CBMFileResult *r, const char *label) {
     return count;
 }
 
+static int count_defs_named(CBMFileResult *r, const char *label, const char *name) {
+    int count = 0;
+    for (int i = 0; i < r->defs.count; i++) {
+        if (strcmp(r->defs.items[i].label, label) == 0 &&
+            strcmp(r->defs.items[i].name, name) == 0) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static int count_calls_named(CBMFileResult *r, const char *callee) {
+    int count = 0;
+    for (int i = 0; i < r->calls.count; i++) {
+        if (r->calls.items[i].callee_name && strcmp(r->calls.items[i].callee_name, callee) == 0) {
+            count++;
+        }
+    }
+    return count;
+}
+
 /* Convenience: extract, assert no error, return result. Caller frees. */
 static CBMFileResult *extract(const char *src, CBMLanguage lang, const char *proj,
                               const char *path) {
@@ -2878,6 +2899,103 @@ TEST(vue_imports_basic) {
     ASSERT(has_import(r, "MyComp.vue"));
     ASSERT(has_import(r, "vue"));
     cbm_free_result(r);
+    PASS();
+}
+
+TEST(vue_embedded_structure_issue1410) {
+    const char *src = "<template><div>caf\xC3\xA9</div></template>\r\n"
+                      "<script>\r\n"
+                      "import { external } from './dep.js';\r\n"
+                      "function normalFn() { return callee(); }\r\n"
+                      "</script>\r\n"
+                      "<script setup lang=\"ts\">class Widget {}\r\n"
+                      "function setupFn(): void { callee(); }</script>\r\n";
+    CBMFileResult *r = extract(src, CBM_LANG_VUE, "t", "App.vue");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+    ASSERT_EQ(count_defs_with_label(r, "Module"), 1);
+    ASSERT_EQ(count_defs_with_label(r, "Function"), 2);
+    ASSERT_EQ(count_defs_with_label(r, "Class"), 1);
+    ASSERT_EQ(count_defs_named(r, "Function", "normalFn"), 1);
+    ASSERT_EQ(count_defs_named(r, "Function", "setupFn"), 1);
+    ASSERT_EQ(count_defs_named(r, "Class", "Widget"), 1);
+    ASSERT_EQ(count_calls_named(r, "callee"), 2);
+    ASSERT_EQ(r->imports.count, 1);
+    ASSERT(has_import(r, "dep.js"));
+
+    const CBMDefinition *normal = NULL;
+    const CBMDefinition *widget = NULL;
+    const CBMDefinition *setup = NULL;
+    for (int i = 0; i < r->defs.count; i++) {
+        if (strcmp(r->defs.items[i].name, "normalFn") == 0) {
+            normal = &r->defs.items[i];
+        } else if (strcmp(r->defs.items[i].name, "Widget") == 0) {
+            widget = &r->defs.items[i];
+        } else if (strcmp(r->defs.items[i].name, "setupFn") == 0) {
+            setup = &r->defs.items[i];
+        }
+    }
+    ASSERT_NOT_NULL(normal);
+    ASSERT_NOT_NULL(widget);
+    ASSERT_NOT_NULL(setup);
+    ASSERT_EQ(normal->start_line, 4);
+    ASSERT_EQ(widget->start_line, 6);
+    ASSERT_EQ(setup->start_line, 7);
+    cbm_free_result(r);
+    PASS();
+}
+
+TEST(vue_embedded_structure_negative_controls_issue1410) {
+    static const char *sources[] = {
+        "<script lang=\"coffee\">function hidden() { forbidden(); }</script>\n",
+        "<script src=\"./external.js\">function hidden() { forbidden(); }</script>\n",
+        "<template><p>scriptless</p></template>\n",
+    };
+    for (int i = 0; i < 3; i++) {
+        CBMFileResult *r = extract(sources[i], CBM_LANG_VUE, "t", "Negative.vue");
+        ASSERT_NOT_NULL(r);
+        ASSERT_FALSE(r->has_error);
+        ASSERT_EQ(count_defs_with_label(r, "Module"), 1);
+        ASSERT_EQ(count_defs_with_label(r, "Function"), 0);
+        ASSERT_EQ(count_defs_with_label(r, "Class"), 0);
+        ASSERT_EQ(r->calls.count, 0);
+        ASSERT_EQ(r->imports.count, 0);
+        cbm_free_result(r);
+    }
+    PASS();
+}
+
+TEST(vue_embedded_structure_host_controls_issue1410) {
+    CBMFileResult *plain = extract("function plainTs(): void { target(); }\n", CBM_LANG_TYPESCRIPT,
+                                   "t", "plain.ts");
+    ASSERT_NOT_NULL(plain);
+    ASSERT_FALSE(plain->has_error);
+    ASSERT_EQ(count_defs_named(plain, "Function", "plainTs"), 1);
+    ASSERT_EQ(count_calls_named(plain, "target"), 1);
+    cbm_free_result(plain);
+
+    static const struct {
+        CBMLanguage language;
+        const char *path;
+        const char *source;
+    } hosts[] = {
+        {CBM_LANG_SVELTE, "Control.svelte",
+         "<script>import value from './svelte.js'; function hidden() { target(); }</script>\n"},
+        {CBM_LANG_HTML, "control.html",
+         "<script>import value from './html.js'; function hidden() { target(); }</script>\n"},
+        {CBM_LANG_ASTRO, "Control.astro",
+         "---\nimport value from './astro.js'; function hidden() { target(); }\n---\n"},
+    };
+    for (int i = 0; i < 3; i++) {
+        CBMFileResult *r = extract(hosts[i].source, hosts[i].language, "t", hosts[i].path);
+        ASSERT_NOT_NULL(r);
+        ASSERT_FALSE(r->has_error);
+        ASSERT_EQ(count_defs_with_label(r, "Module"), 1);
+        ASSERT_EQ(count_defs_with_label(r, "Function"), 0);
+        ASSERT_EQ(r->calls.count, 0);
+        ASSERT_EQ(r->imports.count, 1);
+        cbm_free_result(r);
+    }
     PASS();
 }
 
@@ -5910,6 +6028,9 @@ SUITE(extraction) {
     RUN_TEST(svelte_imports_basic);
     RUN_TEST(svelte_imports_no_script);
     RUN_TEST(vue_imports_basic);
+    RUN_TEST(vue_embedded_structure_issue1410);
+    RUN_TEST(vue_embedded_structure_negative_controls_issue1410);
+    RUN_TEST(vue_embedded_structure_host_controls_issue1410);
     RUN_TEST(html_imports_basic);
 
     /* config_extraction_test.go ports */


### PR DESCRIPTION
Replaces #1843, which carried no `Signed-off-by` trailer and so failed DCO. The tree here is byte-identical to that commit (`befebbbb`); only the sign-off was added.

Fixes #1410.

## What it does

Vue single-file components produced a `Module` node and `IMPORTS` edges, but no `Function` definitions and no `CALLS` edges from the `<script>` block — so a component's call graph was empty.

## Scope, stated plainly

It includes a **control test** pinning current behaviour for **Svelte, HTML and Astro**: they still extract imports but zero functions and zero calls.

That is deliberate scoping rather than an oversight. It documents the remaining gap instead of hiding it, and it proves this change does not leak into sibling languages. Svelte is tracked by #1807 and will be a follow-up; whoever lands that will flip these assertions, which is exactly what a control test is for.

No new node or edge types — the fix produces `Function` and `CALLS` on the existing vocabulary.
