### PR TITLE
fix(contract): catch badge-form language counts, correct the README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/DeusData/codebase-memory-mcp/dry-run.yml?label=CI)](https://github.com/DeusData/codebase-memory-mcp/actions/workflows/dry-run.yml)
 [![Tests](https://img.shields.io/badge/tests-6768_passing-brightgreen)](https://github.com/DeusData/codebase-memory-mcp)
-[![Languages](https://img.shields.io/badge/languages-158-orange)](https://github.com/DeusData/codebase-memory-mcp)
+[![Languages](https://img.shields.io/badge/languages-161-orange)](https://github.com/DeusData/codebase-memory-mcp)
 [![Hybrid LSP](https://img.shields.io/badge/Hybrid_LSP-10_languages-blue)](#hybrid-lsp)
 [![Agents](https://img.shields.io/badge/agent_surfaces-43-purple)](https://github.com/DeusData/codebase-memory-mcp)
 [![Pure C](https://img.shields.io/badge/pure_C-no_language_runtime-blue)](https://github.com/DeusData/codebase-memory-mcp)

--- a/tests/repro/repro_call_argument_matrix_b.c
+++ b/tests/repro/repro_call_argument_matrix_b.c
@@ -1,5 +1,5 @@
 /*
- * Exhaustive call-argument reproduction matrix, CBMLanguage 80..163.
+ * Exhaustive call-argument reproduction matrix, CBMLanguage 80..164.
  *
  * Every language in this numeric range whose live spec has call-node metadata
  * owns one TEST row below. Semantic applications are exercised twice: once as

--- a/tests/test_language_count_contract.sh
+++ b/tests/test_language_count_contract.sh
@@ -81,7 +81,15 @@ for path in "${SURFACES[@]}"; do
         failures=$((failures + 1))
         continue
     fi
-    hits=$(grep -oE '[0-9]{2,3} languages' "$path" | grep -oE '^[0-9]+' | sort -u || true)
+    # Two claim forms. Prose says "<N> languages"; a shields.io badge says
+    # "languages-<N>-colour". The badge was MISSED by the first version of this
+    # contract: it gated only the prose form, so README's badge sat three behind
+    # the prose in the same file while this test reported success. The lesson is
+    # that the enumeration and the gate must not share a regex — if they do, the
+    # gate can only ever confirm what the enumeration already saw.
+    hits=$( { grep -oE '[0-9]{2,3} languages' "$path" | grep -oE '^[0-9]+'
+              grep -oiE 'languages-[0-9]{2,3}' "$path" | grep -oE '[0-9]+$'
+            } | sort -u || true)
     if [[ -z "$hits" ]]; then
         echo "FAIL: $path is registered as a language-count surface but states no" \
             "count — either it lost the claim (drop it from SURFACES) or the" \
@@ -113,7 +121,7 @@ while IFS= read -r path; do
         "SURFACES so it stays in step with the registry, or to EXEMPT with a" \
         "note saying what its number actually counts." >&2
     failures=$((failures + 1))
-done < <(git grep -IlE '[0-9]{2,3} languages' || true)
+done < <(git grep -IlE '[0-9]{2,3} languages|languages-[0-9]{2,3}' || true)
 
 if ((failures > 0)); then
     echo "FAIL: $failures language-count contract violation(s)" >&2


### PR DESCRIPTION
Follow-up to #1859, which shipped a language-count contract with a hole in it.

## The hole

The contract matched only the prose form `<N> languages`. README's shields badge is written `languages-158-orange` — the number comes *before* the word — so it never matched. The gate reported **success** while the badge in the README displayed **158** against prose saying **161**, in the same file.

**Why it was missed is the part worth recording.** The seven surfaces were enumerated with `git grep -IlE '[0-9]{2,3} languages'` — and then the gate was built on that same pattern. A verification that shares its regex with the thing it verifies can only ever confirm what the enumeration already saw. The badge was invisible to both steps for the same reason, so "7 surfaces, all agree" was true and useless.

Found because a review of #1179 (VB.NET) checked main independently rather than trusting the green gate.

## The fix

Both claim forms are matched now, in the per-surface check **and** in the unregistered-file sweep, so a new file stating a count in either form still fails. Verified in both directions: with the widened pattern the gate immediately fails on the un-corrected badge, and passes once corrected.

The README badge is corrected to **161**.

## Also: a stale comment from the PL/SQL merge

`tests/repro/repro_call_argument_matrix_b.c:2` described the matrix as `CBMLanguage 80..163`; PL/SQL had made it 164.

That is the **comment variant** of the additive-counter trap. When PL/SQL was rebased across ArkTS, every numeric *constant* was audited for silent additive merges — one had genuinely merged clean and wrong (`EXPECTED_CALL_CAPABLE_LANGUAGES`, 111 base, both sides 112, truth 113). The prose describing those constants was not audited, and it drifted the same way.

The two sibling range descriptors were checked and are correct: `GO..ARKTS ... exactly 68 language rows` and `RACKET..PLSQL ... exactly 47`.

## Scope

Three files, +12/−4. No behaviour change outside the contract script — the C edit is a comment.
