### PR TITLE
feat(mcp): add bounded file outline tool

### DIFF
--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -130,6 +130,7 @@ enum {
 #define MCP_MAX_HEADER_SIZE ((size_t)8U * 1024U)
 #define MCP_SEARCH_OUTPUT_MAX ((size_t)64U * 1024U * 1024U)
 #define MCP_SEARCH_SCAN_TIMEOUT_MS ((uint64_t)30000U)
+#define MCP_FILE_OUTLINE_OUTPUT_MAX ((size_t)2U * 1024U * 1024U)
 
 /* ── Helpers ────────────────────────────────────────────────────── */
 
@@ -557,6 +558,21 @@ static const tool_def_t TOOLS[] = {
      "\"type\":\"string\"},\"include_neighbors\":{"
      "\"type\":\"boolean\",\"default\":false}},\"required\":[\"qualified_name\",\"project\"]}"},
 
+    {"get_file_outline", "Get file outline",
+     "Return a compact declaration outline for one exact repository-relative file. Results are "
+     "filtered by optional exact labels, ordered deterministically by source position, and "
+     "bounded with exact total/offset/limit pagination metadata. File/folder/container nodes "
+     "are excluded. The query observes request cancellation and fails without partial output.",
+     "{\"type\":\"object\",\"properties\":{\"project\":{\"type\":\"string\"},"
+     "\"file_path\":{\"type\":\"string\",\"description\":\"Exact repository-relative "
+     "file path\"},\"labels\":{\"type\":\"array\",\"items\":{\"type\":\"string\"},"
+     "\"maxItems\":16,\"description\":\"Optional exact node-label filter\"},"
+     "\"limit\":{\"type\":\"integer\",\"minimum\":1,\"maximum\":200,\"default\":100},"
+     "\"offset\":{\"type\":\"integer\",\"minimum\":0,\"default\":0},"
+     "\"format\":{\"type\":\"string\",\"enum\":[\"tree\",\"json\"],"
+     "\"default\":\"tree\"}},\"additionalProperties\":false,"
+     "\"required\":[\"project\",\"file_path\"]}"},
+
     {"get_graph_schema", "Get graph schema",
      "Get the schema of the knowledge graph (node labels, edge types)",
      "{\"type\":\"object\",\"properties\":{\"project\":{\"type\":\"string\"}},\"required\":["
@@ -745,6 +761,7 @@ static const tool_annotation_def_t TOOL_ANNOTATIONS[] = {
     {"query_graph", false, true, true, false},
     {"trace_path", false, true, true, false},
     {"get_code_snippet", false, true, true, false},
+    {"get_file_outline", false, true, true, false},
     {"get_graph_schema", false, true, true, false},
     {"compare_graphs", true, false, true, false},
     {"get_architecture", false, true, true, false},
@@ -808,13 +825,14 @@ static void mcp_add_tool_def(yyjson_mut_doc *doc, yyjson_mut_val *tools, int i) 
 
 static bool mcp_tool_allowed(cbm_mcp_tool_profile_t profile, const char *name) {
     static const char *const analysis_tools[] = {
-        "search_graph",     "query_graph",    "trace_path",           "get_code_snippet",
-        "get_graph_schema", "compare_graphs", "get_architecture",     "search_code",
-        "list_projects",    "index_status",   "check_index_coverage", "detect_changes",
+        "search_graph",     "query_graph",      "trace_path",           "get_code_snippet",
+        "get_file_outline", "get_graph_schema", "compare_graphs",       "get_architecture",
+        "search_code",      "list_projects",    "index_status",         "check_index_coverage",
+        "detect_changes",
     };
     static const char *const scout_tools[] = {
-        "search_graph",  "trace_path",   "get_code_snippet",     "get_architecture",
-        "list_projects", "index_status", "check_index_coverage",
+        "search_graph",     "trace_path",    "get_code_snippet", "get_file_outline",
+        "get_architecture", "list_projects", "index_status",     "check_index_coverage",
     };
     if (!name) {
         return false;
@@ -9303,6 +9321,230 @@ static char *build_snippet_response(cbm_mcp_server_t *srv, cbm_node_t *node,
     return result;
 }
 
+static bool file_outline_request_cancelled(void *context) {
+    return mcp_request_cancelled((const cbm_mcp_server_t *)context);
+}
+
+static char *handle_get_file_outline(cbm_mcp_server_t *srv, const char *args) {
+    const char *args_text = args ? args : "{}";
+    yyjson_doc *args_doc = yyjson_read(args_text, strlen(args_text), 0);
+    yyjson_val *root = args_doc ? yyjson_doc_get_root(args_doc) : NULL;
+    if (!root || !yyjson_is_obj(root)) {
+        yyjson_doc_free(args_doc);
+        return cbm_mcp_text_result("get_file_outline arguments must be a JSON object", true);
+    }
+
+    char *project = get_project_arg(args_text);
+    yyjson_val *file_value = yyjson_obj_get(root, "file_path");
+    const char *file_path =
+        file_value && yyjson_is_str(file_value) ? yyjson_get_str(file_value) : NULL;
+    if (!project) {
+        yyjson_doc_free(args_doc);
+        return cbm_mcp_text_result("project is required", true);
+    }
+    if (!file_path || !file_path[0]) {
+        free(project);
+        yyjson_doc_free(args_doc);
+        return cbm_mcp_text_result("file_path is required", true);
+    }
+
+    char normalized_path[CBM_SZ_4K];
+    if (coverage_normalize_rel(file_path, false, normalized_path, sizeof(normalized_path)) !=
+        COVERAGE_PATH_OK) {
+        free(project);
+        yyjson_doc_free(args_doc);
+        return cbm_mcp_text_result("file_path must be a repository-relative path without '..'",
+                                   true);
+    }
+
+    int limit = 100;
+    yyjson_val *limit_value = yyjson_obj_get(root, "limit");
+    if (limit_value) {
+        if (!yyjson_is_int(limit_value)) {
+            free(project);
+            yyjson_doc_free(args_doc);
+            return cbm_mcp_text_result("limit must be an integer", true);
+        }
+        int64_t parsed = yyjson_get_sint(limit_value);
+        if (parsed < 1 || parsed > CBM_STORE_FILE_OUTLINE_MAX_LIMIT) {
+            free(project);
+            yyjson_doc_free(args_doc);
+            return cbm_mcp_text_result("limit must be between 1 and 200", true);
+        }
+        limit = (int)parsed;
+    }
+
+    int offset = 0;
+    yyjson_val *offset_value = yyjson_obj_get(root, "offset");
+    if (offset_value) {
+        if (!yyjson_is_int(offset_value)) {
+            free(project);
+            yyjson_doc_free(args_doc);
+            return cbm_mcp_text_result("offset must be a non-negative integer", true);
+        }
+        int64_t parsed = yyjson_get_sint(offset_value);
+        if (parsed < 0 || parsed > INT_MAX) {
+            free(project);
+            yyjson_doc_free(args_doc);
+            return cbm_mcp_text_result("offset must be a non-negative integer", true);
+        }
+        offset = (int)parsed;
+    }
+
+    bool json_format = false;
+    yyjson_val *format_value = yyjson_obj_get(root, "format");
+    if (format_value) {
+        const char *format = yyjson_is_str(format_value) ? yyjson_get_str(format_value) : NULL;
+        if (!format || (strcmp(format, "tree") != 0 && strcmp(format, "json") != 0)) {
+            free(project);
+            yyjson_doc_free(args_doc);
+            return cbm_mcp_text_result("format must be either 'tree' or 'json'", true);
+        }
+        json_format = strcmp(format, "json") == 0;
+    }
+
+    const char *labels[CBM_STORE_FILE_OUTLINE_MAX_LABELS];
+    int label_count = 0;
+    yyjson_val *labels_value = yyjson_obj_get(root, "labels");
+    if (labels_value) {
+        if (!yyjson_is_arr(labels_value) ||
+            yyjson_arr_size(labels_value) > CBM_STORE_FILE_OUTLINE_MAX_LABELS) {
+            free(project);
+            yyjson_doc_free(args_doc);
+            return cbm_mcp_text_result("labels must be an array of at most 16 strings", true);
+        }
+        size_t index = 0;
+        size_t max = 0;
+        yyjson_val *item;
+        yyjson_arr_foreach(labels_value, index, max, item) {
+            const char *label = yyjson_is_str(item) ? yyjson_get_str(item) : NULL;
+            if (!label || !label[0] || strlen(label) >= CBM_SZ_128) {
+                free(project);
+                yyjson_doc_free(args_doc);
+                return cbm_mcp_text_result("labels must contain only non-empty bounded strings",
+                                           true);
+            }
+            labels[label_count++] = label;
+        }
+    }
+
+    cbm_store_t *store = resolve_store(srv, project);
+    if (!store) {
+        char *error = build_project_list_error("project not found or not indexed");
+        char *result = cbm_mcp_text_result(error, true);
+        free(error);
+        free(project);
+        yyjson_doc_free(args_doc);
+        return result;
+    }
+    char *not_indexed = verify_project_indexed(store, project);
+    if (not_indexed) {
+        free(project);
+        yyjson_doc_free(args_doc);
+        return not_indexed;
+    }
+
+    cbm_file_outline_row_t *rows = NULL;
+    int row_count = 0;
+    int total = 0;
+    int rc = cbm_store_get_file_outline(store, project, normalized_path, labels, label_count, limit,
+                                        offset, file_outline_request_cancelled, srv, &rows,
+                                        &row_count, &total);
+    if (rc != CBM_STORE_OK) {
+        free(project);
+        yyjson_doc_free(args_doc);
+        if (rc == CBM_STORE_CANCELLED) {
+            return cbm_mcp_text_result("get_file_outline cancelled for this request", true);
+        }
+        if (rc == CBM_STORE_SCAN_LIMIT) {
+            return cbm_mcp_text_result("get_file_outline exceeded its fixed output safety limit",
+                                       true);
+        }
+        return cbm_mcp_text_result("get_file_outline query failed", true);
+    }
+
+    char *payload = NULL;
+    if (!json_format) {
+        cbm_sb_t sb;
+        cbm_sb_init(&sb);
+        cbm_tree_scalar_str(&sb, "file_path", normalized_path);
+        static const char *const columns[] = {"name", "label", "lines", "qn"};
+        cbm_tree_table_header(&sb, "results", row_count, columns, 4);
+        for (int i = 0; i < row_count; i++) {
+            char lines[CBM_SZ_32];
+            if (rows[i].start_line > 0) {
+                snprintf(lines, sizeof(lines), "%d-%d", rows[i].start_line,
+                         rows[i].end_line > rows[i].start_line ? rows[i].end_line
+                                                               : rows[i].start_line);
+            } else {
+                lines[0] = '\0';
+            }
+            cbm_tree_row_begin(&sb);
+            cbm_tree_cell_str(&sb, rows[i].name, true);
+            cbm_tree_cell_str(&sb, rows[i].label, false);
+            cbm_tree_cell_str(&sb, lines, false);
+            cbm_tree_cell_str(&sb, rows[i].qualified_name, false);
+            cbm_tree_row_end(&sb);
+        }
+        cbm_tree_scalar_int(&sb, "total", total);
+        cbm_tree_scalar_int(&sb, "offset", offset);
+        cbm_tree_scalar_int(&sb, "limit", limit);
+        cbm_tree_scalar_int(&sb, "returned", row_count);
+        cbm_tree_scalar_bool(&sb, "has_more", (int64_t)offset + row_count < total);
+        payload = cbm_sb_finish(&sb);
+    } else {
+        yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+        yyjson_mut_val *object = yyjson_mut_obj(doc);
+        yyjson_mut_doc_set_root(doc, object);
+        yyjson_mut_obj_add_str(doc, object, "file_path", normalized_path);
+        yyjson_mut_val *columns = yyjson_mut_arr(doc);
+        static const char *const column_names[] = {"name", "label", "lines", "qn"};
+        for (size_t i = 0; i < sizeof(column_names) / sizeof(column_names[0]); i++) {
+            yyjson_mut_arr_add_str(doc, columns, column_names[i]);
+        }
+        yyjson_mut_obj_add_val(doc, object, "cols", columns);
+        yyjson_mut_val *json_rows = yyjson_mut_arr(doc);
+        for (int i = 0; i < row_count; i++) {
+            char lines[CBM_SZ_32];
+            if (rows[i].start_line > 0) {
+                snprintf(lines, sizeof(lines), "%d-%d", rows[i].start_line,
+                         rows[i].end_line > rows[i].start_line ? rows[i].end_line
+                                                               : rows[i].start_line);
+            } else {
+                lines[0] = '\0';
+            }
+            yyjson_mut_val *row = yyjson_mut_arr(doc);
+            yyjson_mut_arr_add_strcpy(doc, row, rows[i].name);
+            yyjson_mut_arr_add_strcpy(doc, row, rows[i].label);
+            yyjson_mut_arr_add_strcpy(doc, row, lines);
+            yyjson_mut_arr_add_strcpy(doc, row, rows[i].qualified_name);
+            yyjson_mut_arr_add_val(json_rows, row);
+        }
+        yyjson_mut_obj_add_val(doc, object, "rows", json_rows);
+        yyjson_mut_obj_add_int(doc, object, "total", total);
+        yyjson_mut_obj_add_int(doc, object, "offset", offset);
+        yyjson_mut_obj_add_int(doc, object, "limit", limit);
+        yyjson_mut_obj_add_int(doc, object, "returned", row_count);
+        yyjson_mut_obj_add_bool(doc, object, "has_more", (int64_t)offset + row_count < total);
+        payload = yy_doc_to_str(doc);
+        yyjson_mut_doc_free(doc);
+    }
+
+    cbm_store_free_file_outline(rows, row_count);
+    free(project);
+    yyjson_doc_free(args_doc);
+    if (!payload) {
+        return cbm_mcp_text_result("get_file_outline output allocation failed", true);
+    }
+    if (strlen(payload) > MCP_FILE_OUTLINE_OUTPUT_MAX) {
+        free(payload);
+        return cbm_mcp_text_result("get_file_outline exceeded its fixed output safety limit", true);
+    }
+    char *result = cbm_mcp_text_result(payload, false);
+    free(payload);
+    return result;
+}
+
 static char *handle_get_code_snippet(cbm_mcp_server_t *srv, const char *args) {
     char *qn = cbm_mcp_get_string_arg(args, "qualified_name");
     char *project = get_project_arg(args);
@@ -12360,6 +12602,9 @@ static char *dispatch_tool(cbm_mcp_server_t *srv, const char *tool_name, const c
     }
     if (strcmp(tool_name, "get_code_snippet") == 0) {
         return handle_get_code_snippet(srv, args_json);
+    }
+    if (strcmp(tool_name, "get_file_outline") == 0) {
+        return handle_get_file_outline(srv, args_json);
     }
     if (strcmp(tool_name, "search_code") == 0) {
         return handle_search_code(srv, args_json);

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -825,9 +825,9 @@ static void mcp_add_tool_def(yyjson_mut_doc *doc, yyjson_mut_val *tools, int i) 
 
 static bool mcp_tool_allowed(cbm_mcp_tool_profile_t profile, const char *name) {
     static const char *const analysis_tools[] = {
-        "search_graph",     "query_graph",      "trace_path",           "get_code_snippet",
-        "get_file_outline", "get_graph_schema", "compare_graphs",       "get_architecture",
-        "search_code",      "list_projects",    "index_status",         "check_index_coverage",
+        "search_graph",     "query_graph",      "trace_path",     "get_code_snippet",
+        "get_file_outline", "get_graph_schema", "compare_graphs", "get_architecture",
+        "search_code",      "list_projects",    "index_status",   "check_index_coverage",
         "detect_changes",
     };
     static const char *const scout_tools[] = {

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -2640,6 +2640,233 @@ int cbm_store_find_nodes_by_file(cbm_store_t *s, const char *project, const char
                               project, file_path, out, count);
 }
 
+typedef struct {
+    cbm_store_cancel_fn cancel;
+    void *context;
+} file_outline_cancel_guard_t;
+
+static bool file_outline_cancelled(const file_outline_cancel_guard_t *guard) {
+    return guard && guard->cancel && guard->cancel(guard->context);
+}
+
+static int file_outline_progress_cancel(void *context) {
+    return file_outline_cancelled((const file_outline_cancel_guard_t *)context) ? 1 : 0;
+}
+
+static bool file_outline_build_sql(char *sql, size_t sql_size, bool count_only, int label_count) {
+    int written =
+        snprintf(sql, sql_size,
+                 count_only ? "SELECT COUNT(*) FROM nodes WHERE project = ?1 AND file_path = ?2 "
+                              "AND label NOT IN ('Module','Package','File','Folder','Project')"
+                            : "SELECT name, label, qualified_name, start_line, end_line FROM nodes "
+                              "WHERE project = ?1 AND file_path = ?2 "
+                              "AND label NOT IN ('Module','Package','File','Folder','Project')");
+    if (written < 0 || (size_t)written >= sql_size) {
+        return false;
+    }
+    size_t used = (size_t)written;
+    if (label_count > 0) {
+        written = snprintf(sql + used, sql_size - used, " AND label IN (");
+        if (written < 0 || (size_t)written >= sql_size - used) {
+            return false;
+        }
+        used += (size_t)written;
+        for (int i = 0; i < label_count; i++) {
+            written = snprintf(sql + used, sql_size - used, "%s?%d", i > 0 ? "," : "", i + 3);
+            if (written < 0 || (size_t)written >= sql_size - used) {
+                return false;
+            }
+            used += (size_t)written;
+        }
+        written = snprintf(sql + used, sql_size - used, ")");
+        if (written < 0 || (size_t)written >= sql_size - used) {
+            return false;
+        }
+        used += (size_t)written;
+    }
+    if (!count_only) {
+        int limit_bind = label_count + 3;
+        int offset_bind = limit_bind + 1;
+        written = snprintf(sql + used, sql_size - used,
+                           " ORDER BY start_line, end_line, label COLLATE BINARY, "
+                           "name COLLATE BINARY, qualified_name COLLATE BINARY, id "
+                           "LIMIT ?%d OFFSET ?%d",
+                           limit_bind, offset_bind);
+        if (written < 0 || (size_t)written >= sql_size - used) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void file_outline_bind_common(sqlite3_stmt *stmt, const char *project, const char *file_path,
+                                     const char *const *labels, int label_count) {
+    bind_text(stmt, ST_COL_1, project);
+    bind_text(stmt, ST_COL_2, file_path);
+    for (int i = 0; i < label_count; i++) {
+        bind_text(stmt, i + 3, labels[i]);
+    }
+}
+
+void cbm_store_free_file_outline(cbm_file_outline_row_t *rows, int count) {
+    if (!rows) {
+        return;
+    }
+    for (int i = 0; i < count; i++) {
+        free((char *)rows[i].name);
+        free((char *)rows[i].label);
+        free((char *)rows[i].qualified_name);
+    }
+    free(rows);
+}
+
+int cbm_store_get_file_outline(cbm_store_t *s, const char *project, const char *file_path,
+                               const char *const *labels, int label_count, int limit, int offset,
+                               cbm_store_cancel_fn cancel, void *cancel_context,
+                               cbm_file_outline_row_t **out, int *count, int *total) {
+    if (out) {
+        *out = NULL;
+    }
+    if (count) {
+        *count = 0;
+    }
+    if (total) {
+        *total = 0;
+    }
+    if (!s || !s->db || !project || !project[0] || !file_path || !file_path[0] || !out || !count ||
+        !total || label_count < 0 || label_count > CBM_STORE_FILE_OUTLINE_MAX_LABELS ||
+        (label_count > 0 && !labels) || limit < 1 || limit > CBM_STORE_FILE_OUTLINE_MAX_LIMIT ||
+        offset < 0) {
+        return CBM_STORE_ERR;
+    }
+    for (int i = 0; i < label_count; i++) {
+        if (!labels[i] || !labels[i][0]) {
+            return CBM_STORE_ERR;
+        }
+    }
+
+    file_outline_cancel_guard_t guard = {.cancel = cancel, .context = cancel_context};
+    if (file_outline_cancelled(&guard)) {
+        return CBM_STORE_CANCELLED;
+    }
+    if (cancel) {
+        sqlite3_progress_handler(s->db, 1000, file_outline_progress_cancel, &guard);
+    }
+
+    char sql[ST_SQL_BUF];
+    if (!file_outline_build_sql(sql, sizeof(sql), true, label_count)) {
+        sqlite3_progress_handler(s->db, 0, NULL, NULL);
+        return CBM_STORE_ERR;
+    }
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(s->db, sql, CBM_NOT_FOUND, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        store_set_error_sqlite(s, "file outline count prepare");
+        sqlite3_progress_handler(s->db, 0, NULL, NULL);
+        return CBM_STORE_ERR;
+    }
+    file_outline_bind_common(stmt, project, file_path, labels, label_count);
+    rc = sqlite3_step(stmt);
+    if (rc == SQLITE_ROW) {
+        *total = sqlite3_column_int(stmt, 0);
+    }
+    sqlite3_finalize(stmt);
+    if (rc == SQLITE_INTERRUPT || file_outline_cancelled(&guard)) {
+        sqlite3_progress_handler(s->db, 0, NULL, NULL);
+        *total = 0;
+        return CBM_STORE_CANCELLED;
+    }
+    if (rc != SQLITE_ROW) {
+        store_set_error_sqlite(s, "file outline count");
+        sqlite3_progress_handler(s->db, 0, NULL, NULL);
+        *total = 0;
+        return CBM_STORE_ERR;
+    }
+
+    if (!file_outline_build_sql(sql, sizeof(sql), false, label_count)) {
+        sqlite3_progress_handler(s->db, 0, NULL, NULL);
+        *total = 0;
+        return CBM_STORE_ERR;
+    }
+    stmt = NULL;
+    rc = sqlite3_prepare_v2(s->db, sql, CBM_NOT_FOUND, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        store_set_error_sqlite(s, "file outline prepare");
+        sqlite3_progress_handler(s->db, 0, NULL, NULL);
+        *total = 0;
+        return CBM_STORE_ERR;
+    }
+    file_outline_bind_common(stmt, project, file_path, labels, label_count);
+    sqlite3_bind_int(stmt, label_count + 3, limit);
+    sqlite3_bind_int(stmt, label_count + 4, offset);
+
+    cbm_file_outline_row_t *rows = calloc((size_t)limit, sizeof(*rows));
+    if (!rows) {
+        sqlite3_finalize(stmt);
+        sqlite3_progress_handler(s->db, 0, NULL, NULL);
+        *total = 0;
+        return CBM_STORE_ERR;
+    }
+    size_t text_bytes = 0U;
+    int n = 0;
+    bool was_cancelled = false;
+    for (;;) {
+        if (file_outline_cancelled(&guard)) {
+            was_cancelled = true;
+            break;
+        }
+        rc = sqlite3_step(stmt);
+        if (rc != SQLITE_ROW) {
+            break;
+        }
+        const char *name = (const char *)sqlite3_column_text(stmt, 0);
+        const char *label = (const char *)sqlite3_column_text(stmt, 1);
+        const char *qn = (const char *)sqlite3_column_text(stmt, 2);
+        size_t row_bytes = (size_t)sqlite3_column_bytes(stmt, 0) +
+                           (size_t)sqlite3_column_bytes(stmt, 1) +
+                           (size_t)sqlite3_column_bytes(stmt, 2) + 3U;
+        if (row_bytes > CBM_STORE_FILE_OUTLINE_MAX_TEXT_BYTES - text_bytes) {
+            sqlite3_finalize(stmt);
+            sqlite3_progress_handler(s->db, 0, NULL, NULL);
+            cbm_store_free_file_outline(rows, n);
+            *total = 0;
+            return CBM_STORE_SCAN_LIMIT;
+        }
+        rows[n].name = heap_strdup(name ? name : "");
+        rows[n].label = heap_strdup(label ? label : "");
+        rows[n].qualified_name = heap_strdup(qn ? qn : "");
+        rows[n].start_line = sqlite3_column_int(stmt, 3);
+        rows[n].end_line = sqlite3_column_int(stmt, 4);
+        if (!rows[n].name || !rows[n].label || !rows[n].qualified_name) {
+            sqlite3_finalize(stmt);
+            sqlite3_progress_handler(s->db, 0, NULL, NULL);
+            cbm_store_free_file_outline(rows, n + 1);
+            *total = 0;
+            return CBM_STORE_ERR;
+        }
+        text_bytes += row_bytes;
+        n++;
+    }
+    was_cancelled = was_cancelled || rc == SQLITE_INTERRUPT || file_outline_cancelled(&guard);
+    sqlite3_finalize(stmt);
+    sqlite3_progress_handler(s->db, 0, NULL, NULL);
+    if (was_cancelled) {
+        cbm_store_free_file_outline(rows, n);
+        *total = 0;
+        return CBM_STORE_CANCELLED;
+    }
+    if (rc != SQLITE_DONE) {
+        store_set_error_sqlite(s, "file outline rows");
+        cbm_store_free_file_outline(rows, n);
+        *total = 0;
+        return CBM_STORE_ERR;
+    }
+
+    *out = rows;
+    *count = n;
+    return CBM_STORE_OK;
+}
+
 int cbm_store_count_nodes(cbm_store_t *s, const char *project) {
     if (!s || !s->db) {
         return 0;

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -28,6 +28,10 @@ typedef struct cbm_store cbm_store_t;
 #define CBM_STORE_SCAN_LIMIT (-4)
 #define CBM_STORE_CALLBACK_ERR (-5)
 
+#define CBM_STORE_FILE_OUTLINE_MAX_LIMIT 200
+#define CBM_STORE_FILE_OUTLINE_MAX_LABELS 16
+#define CBM_STORE_FILE_OUTLINE_MAX_TEXT_BYTES (256U * 1024U)
+
 /* ── Data structures ────────────────────────────────────────────── */
 
 typedef struct {
@@ -41,6 +45,18 @@ typedef struct {
     int end_line;
     const char *properties_json; /* JSON string, NULL → "{}" */
 } cbm_node_t;
+
+/* Compact declaration row returned by the bounded file-outline query. */
+typedef struct {
+    const char *name;
+    const char *label;
+    const char *qualified_name;
+    int start_line;
+    int end_line;
+} cbm_file_outline_row_t;
+
+/* Optional cancellation callback for bounded store queries. */
+typedef bool (*cbm_store_cancel_fn)(void *context);
 
 typedef struct {
     int64_t id;
@@ -496,6 +512,18 @@ int cbm_store_find_nodes_by_label(cbm_store_t *s, const char *project, const cha
 /* Find nodes by file path. */
 int cbm_store_find_nodes_by_file(cbm_store_t *s, const char *project, const char *file_path,
                                  cbm_node_t **out, int *count);
+
+/* Return a stable, paginated outline for one exact repository-relative file.
+ * File/folder/container nodes are excluded. labels may be NULL when
+ * label_count is zero; otherwise labels are exact-match filters. The query is
+ * capped by CBM_STORE_FILE_OUTLINE_MAX_LIMIT and a fixed aggregate text-byte
+ * budget, and fails without partial rows when cancelled or over budget.
+ * total is the exact filtered count before pagination. */
+int cbm_store_get_file_outline(cbm_store_t *s, const char *project, const char *file_path,
+                               const char *const *labels, int label_count, int limit, int offset,
+                               cbm_store_cancel_fn cancel, void *cancel_context,
+                               cbm_file_outline_row_t **out, int *count, int *total);
+void cbm_store_free_file_outline(cbm_file_outline_row_t *rows, int count);
 
 /* Batch lookup: map qualified names → node IDs.
  * qns[i] is resolved; out_ids[i] receives the ID or 0 if not found.

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -851,6 +851,7 @@ TEST(mcp_tools_list) {
     ASSERT_NOT_NULL(strstr(json, "query_graph"));
     ASSERT_NOT_NULL(strstr(json, "trace_path"));
     ASSERT_NOT_NULL(strstr(json, "get_code_snippet"));
+    ASSERT_NOT_NULL(strstr(json, "get_file_outline"));
     ASSERT_NOT_NULL(strstr(json, "get_graph_schema"));
     ASSERT_NOT_NULL(strstr(json, "get_architecture"));
     ASSERT_NOT_NULL(strstr(json, "search_code"));
@@ -905,6 +906,7 @@ TEST(mcp_tools_list_latest_metadata) {
     ASSERT_NOT_NULL(strstr(json, "\"title\":\"Search graph\""));
     ASSERT_NOT_NULL(strstr(json, "\"title\":\"Index repository\""));
     ASSERT_NOT_NULL(strstr(json, "\"title\":\"Check index coverage\""));
+    ASSERT_NOT_NULL(strstr(json, "\"title\":\"Get file outline\""));
     /* No tool may declare an outputSchema. The blanket permissive schema
      * ({"type":"object","additionalProperties":true}) carried zero information
      * for clients, but its presence made spec-compliant clients read
@@ -939,6 +941,7 @@ TEST(mcp_tools_have_behavior_annotations) {
         {"query_graph", false, true, true, false},
         {"trace_path", false, true, true, false},
         {"get_code_snippet", false, true, true, false},
+        {"get_file_outline", false, true, true, false},
         {"get_graph_schema", false, true, true, false},
         {"compare_graphs", true, false, true, false},
         {"get_architecture", false, true, true, false},
@@ -1463,9 +1466,10 @@ TEST(server_handle_analysis_profile_filters_and_rejects_mutators) {
     resp = cbm_mcp_server_handle(srv, "{\"jsonrpc\":\"2.0\",\"id\":220,\"method\":\"tools/list\"}");
     ASSERT_NOT_NULL(resp);
     static const char *const analysis_tools[] = {
-        "search_graph",     "query_graph",    "trace_path",           "get_code_snippet",
-        "get_graph_schema", "compare_graphs", "get_architecture",     "search_code",
-        "list_projects",    "index_status",   "check_index_coverage", "detect_changes",
+        "search_graph",     "query_graph",      "trace_path",           "get_code_snippet",
+        "get_file_outline", "get_graph_schema", "compare_graphs",       "get_architecture",
+        "search_code",      "list_projects",    "index_status",         "check_index_coverage",
+        "detect_changes",
     };
     ASSERT_EQ(mcp_response_tool_count(resp), sizeof(analysis_tools) / sizeof(analysis_tools[0]));
     for (size_t i = 0U; i < sizeof(analysis_tools) / sizeof(analysis_tools[0]); i++) {
@@ -1504,10 +1508,11 @@ TEST(server_handle_scout_profile_exposes_only_the_fast_tier) {
 
     resp = cbm_mcp_server_handle(srv, "{\"jsonrpc\":\"2.0\",\"id\":223,\"method\":\"tools/list\"}");
     ASSERT_NOT_NULL(resp);
-    ASSERT_EQ(mcp_response_tool_count(resp), 7U);
+    ASSERT_EQ(mcp_response_tool_count(resp), 8U);
     ASSERT_TRUE(mcp_response_has_exact_tool(resp, "search_graph"));
     ASSERT_TRUE(mcp_response_has_exact_tool(resp, "trace_path"));
     ASSERT_TRUE(mcp_response_has_exact_tool(resp, "get_code_snippet"));
+    ASSERT_TRUE(mcp_response_has_exact_tool(resp, "get_file_outline"));
     ASSERT_TRUE(mcp_response_has_exact_tool(resp, "get_architecture"));
     ASSERT_TRUE(mcp_response_has_exact_tool(resp, "list_projects"));
     ASSERT_TRUE(mcp_response_has_exact_tool(resp, "index_status"));
@@ -1730,6 +1735,8 @@ static cbm_mcp_server_t *setup_mcp_with_data(void) {
     return srv;
 }
 
+static char *extract_text_content(const char *mcp_result);
+
 TEST(tool_list_projects_empty) {
     cbm_mcp_server_t *srv = setup_mcp_with_data();
 
@@ -1788,6 +1795,142 @@ TEST(tool_compare_graphs_registered_issue525) {
     ASSERT_NOT_NULL(resp);
     ASSERT_NULL(strstr(resp, "unknown tool: compare_graphs"));
     free(resp);
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
+TEST(tool_get_file_outline_returns_bounded_filtered_columnar_rows_issue469) {
+    cbm_mcp_server_t *srv = setup_mcp_with_data();
+    cbm_store_t *store = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(store);
+    ASSERT_EQ(cbm_store_upsert_project(store, "outline-project", "/tmp/outline-project"),
+              CBM_STORE_OK);
+    cbm_mcp_server_set_project(srv, "outline-project");
+
+    cbm_node_t nodes[] = {
+        {.project = "outline-project",
+         .label = "Module",
+         .name = "main",
+         .qualified_name = "outline-project.main",
+         .file_path = "src/main.c",
+         .start_line = 1,
+         .end_line = 80},
+        {.project = "outline-project",
+         .label = "Function",
+         .name = "alpha",
+         .qualified_name = "outline-project.src.main.alpha",
+         .file_path = "src/main.c",
+         .start_line = 10,
+         .end_line = 14},
+        {.project = "outline-project",
+         .label = "Class",
+         .name = "IgnoredClass",
+         .qualified_name = "outline-project.src.main.IgnoredClass",
+         .file_path = "src/main.c",
+         .start_line = 15,
+         .end_line = 40},
+        {.project = "outline-project",
+         .label = "Method",
+         .name = "omega",
+         .qualified_name = "outline-project.src.main.omega",
+         .file_path = "src/main.c",
+         .start_line = 30,
+         .end_line = 33},
+        {.project = "outline-project",
+         .label = "Function",
+         .name = "other",
+         .qualified_name = "outline-project.src.other.other",
+         .file_path = "src/other.c",
+         .start_line = 1,
+         .end_line = 2},
+    };
+    for (size_t i = 0; i < sizeof(nodes) / sizeof(nodes[0]); i++) {
+        ASSERT_GT(cbm_store_upsert_node(store, &nodes[i]), 0);
+    }
+
+    char *response =
+        cbm_mcp_handle_tool(srv, "get_file_outline",
+                            "{\"project\":\"outline-project\",\"file_path\":\"src/main.c\","
+                            "\"labels\":[\"Function\",\"Method\"],\"limit\":1}");
+    ASSERT_NOT_NULL(response);
+    ASSERT_NOT_NULL(strstr(response, "cols"));
+    ASSERT_NOT_NULL(strstr(response, "(cols: name label lines qn)"));
+    ASSERT_NOT_NULL(strstr(response, "alpha"));
+    ASSERT_NULL(strstr(response, "omega"));
+    ASSERT_NULL(strstr(response, "IgnoredClass"));
+    ASSERT_NOT_NULL(strstr(response, "total: 2"));
+    ASSERT_NOT_NULL(strstr(response, "has_more: true"));
+    ASSERT_NULL(strstr(response, "unknown tool"));
+    free(response);
+
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
+TEST(tool_get_file_outline_validates_json_path_limit_and_cancel_issue469) {
+    cbm_mcp_server_t *srv = setup_mcp_with_data();
+    cbm_store_t *store = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(store);
+    ASSERT_EQ(cbm_store_upsert_project(store, "outline-controls", "/tmp/outline-controls"),
+              CBM_STORE_OK);
+    cbm_mcp_server_set_project(srv, "outline-controls");
+    cbm_node_t node = {.project = "outline-controls",
+                       .label = "Function",
+                       .name = "bounded",
+                       .qualified_name = "outline-controls.src.main.bounded",
+                       .file_path = "src/main.c",
+                       .start_line = 7,
+                       .end_line = 9};
+    ASSERT_GT(cbm_store_upsert_node(store, &node), 0);
+
+    char *response =
+        cbm_mcp_handle_tool(srv, "get_file_outline",
+                            "{\"project\":\"outline-controls\",\"file_path\":\"../outside.c\"}");
+    ASSERT_NOT_NULL(response);
+    ASSERT_NOT_NULL(strstr(response, "repository-relative"));
+    ASSERT_NOT_NULL(strstr(response, "isError"));
+    free(response);
+
+    response = cbm_mcp_handle_tool(
+        srv, "get_file_outline",
+        "{\"project\":\"outline-controls\",\"file_path\":\"src/main.c\",\"limit\":201}");
+    ASSERT_NOT_NULL(response);
+    ASSERT_NOT_NULL(strstr(response, "between 1 and 200"));
+    ASSERT_NOT_NULL(strstr(response, "isError"));
+    free(response);
+
+    response = cbm_mcp_handle_tool(srv, "get_file_outline",
+                                   "{\"project\":\"outline-controls\",\"file_path\":\"src/main.c\","
+                                   "\"format\":\"json\"}");
+    ASSERT_NOT_NULL(response);
+    char *inner = extract_text_content(response);
+    ASSERT_NOT_NULL(inner);
+    yyjson_doc *doc = yyjson_read(inner, strlen(inner), 0);
+    ASSERT_NOT_NULL(doc);
+    yyjson_val *root = yyjson_doc_get_root(doc);
+    ASSERT_TRUE(yyjson_is_arr(yyjson_obj_get(root, "cols")));
+    ASSERT_TRUE(yyjson_is_arr(yyjson_obj_get(root, "rows")));
+    ASSERT_EQ(yyjson_get_int(yyjson_obj_get(root, "total")), 1);
+    yyjson_doc_free(doc);
+    free(inner);
+    free(response);
+
+    ASSERT_TRUE(cbm_mcp_server_request_scope_begin(srv));
+    ASSERT_TRUE(cbm_mcp_server_cancel_active(srv));
+    response = cbm_mcp_handle_tool(
+        srv, "get_file_outline", "{\"project\":\"outline-controls\",\"file_path\":\"src/main.c\"}");
+    ASSERT_NOT_NULL(response);
+    ASSERT_NOT_NULL(strstr(response, "cancelled for this request"));
+    ASSERT_NOT_NULL(strstr(response, "isError"));
+    free(response);
+    cbm_mcp_server_request_scope_end(srv);
+
+    response = cbm_mcp_handle_tool(
+        srv, "get_file_outline", "{\"project\":\"outline-controls\",\"file_path\":\"src/main.c\"}");
+    ASSERT_NOT_NULL(response);
+    ASSERT_NOT_NULL(strstr(response, "bounded"));
+    ASSERT_NULL(strstr(response, "cancelled"));
+    free(response);
 
     cbm_mcp_server_free(srv);
     PASS();
@@ -1812,7 +1955,6 @@ TEST(tool_search_graph_basic) {
 /* Forward declarations for helpers defined later in this file */
 static cbm_mcp_server_t *setup_snippet_server(char *tmp_dir, size_t tmp_sz);
 static void cleanup_snippet_dir(const char *tmp_dir);
-static char *extract_text_content(const char *mcp_result);
 
 TEST(tool_search_graph_semantic_only_skips_structural_results_issue1295) {
     cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
@@ -13555,6 +13697,8 @@ SUITE(mcp) {
     RUN_TEST(tool_compare_graphs_enforces_encoded_budget_issue525);
     RUN_TEST(tool_compare_graphs_validation_and_scan_cap_are_atomic_issue525);
     RUN_TEST(tool_compare_graphs_cancel_and_readonly_handles_release_issue525);
+    RUN_TEST(tool_get_file_outline_returns_bounded_filtered_columnar_rows_issue469);
+    RUN_TEST(tool_get_file_outline_validates_json_path_limit_and_cancel_issue469);
     RUN_TEST(tool_search_graph_basic);
     RUN_TEST(tool_search_graph_semantic_only_skips_structural_results_issue1295);
     RUN_TEST(tool_trace_totals_respect_test_filter);

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -1437,13 +1437,37 @@ TEST(server_handle_tools_list_defaults_to_all_tools_and_accepts_cursor) {
     ASSERT_NOT_NULL(strstr(resp, "ingest_traces"));
     free(resp);
 
-    resp = cbm_mcp_server_handle(
-        srv,
-        "{\"jsonrpc\":\"2.0\",\"id\":201,\"method\":\"tools/list\",\"params\":{\"cursor\":\"8\"}}");
+    /* A cursored page advertises nextCursor exactly while tools remain after
+     * it. This used to pass the literal cursor "8", which silently encoded
+     * "there are at most MCP_TOOLS_PAGE_SIZE * 2 tools" -- so registering a
+     * 17th tool broke it for a reason that had nothing to do with pagination.
+     * Derive the offset from the live count instead: the final page, wherever
+     * it falls, is the one that must not advertise more. */
+    resp = cbm_mcp_server_handle(srv, "{\"jsonrpc\":\"2.0\",\"id\":203,\"method\":\"tools/list\"}");
+    ASSERT_NOT_NULL(resp);
+    size_t total_tools = mcp_response_tool_count(resp);
+    free(resp);
+    ASSERT_TRUE(total_tools > 1U);
+
+    char last_page_req[160];
+    snprintf(last_page_req, sizeof(last_page_req),
+             "{\"jsonrpc\":\"2.0\",\"id\":201,\"method\":\"tools/list\","
+             "\"params\":{\"cursor\":\"%zu\"}}",
+             total_tools - 1U);
+    resp = cbm_mcp_server_handle(srv, last_page_req);
     ASSERT_NOT_NULL(resp);
     ASSERT_NOT_NULL(strstr(resp, "\"id\":201"));
     ASSERT_NULL(strstr(resp, "\"nextCursor\""));
-    ASSERT_NOT_NULL(strstr(resp, "manage_adr"));
+    ASSERT_EQ(mcp_response_tool_count(resp), 1U);
+    free(resp);
+
+    /* ...and a page that does have tools after it MUST advertise the cursor,
+     * so the assertion above cannot pass merely because paging never emits. */
+    resp = cbm_mcp_server_handle(
+        srv,
+        "{\"jsonrpc\":\"2.0\",\"id\":204,\"method\":\"tools/list\",\"params\":{\"cursor\":\"0\"}}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "\"nextCursor\""));
     free(resp);
 
     cbm_mcp_server_free(srv);

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -1339,9 +1339,9 @@ static int issue403_initialize_count_calls(const char *session_root, bool approv
     cbm_setenv("CBM_CACHE_DIR", cache, 1);
 
     char err[1024];
-    bool approved = !approve_sensitive ||
-                    cbm_workspace_grant_add(cache, cbm_workspace_home_dir(), session_root, true,
-                                            err, sizeof(err));
+    bool approved =
+        !approve_sensitive || cbm_workspace_grant_add(cache, cbm_workspace_home_dir(), session_root,
+                                                      true, err, sizeof(err));
     cbm_config_t *cfg = approved ? cbm_config_open(cache) : NULL;
     cbm_mcp_server_t *srv = cfg ? cbm_mcp_server_new(NULL) : NULL;
     int calls = -2;
@@ -1371,8 +1371,8 @@ static int issue403_initialize_count_calls(const char *session_root, bool approv
 }
 
 TEST(mcp_issue403_sensitive_root_stops_before_discovery_count) {
-    int sensitive = issue403_initialize_count_calls(
-        "C:/Users/dev/AppData/Local/Programs/Antigravity", false);
+    int sensitive =
+        issue403_initialize_count_calls("C:/Users/dev/AppData/Local/Programs/Antigravity", false);
     int ordinary = issue403_initialize_count_calls("C:/Users/dev/projects/app", false);
     ASSERT_EQ(sensitive, 0);
     ASSERT_EQ(ordinary, 1);
@@ -1490,9 +1490,9 @@ TEST(server_handle_analysis_profile_filters_and_rejects_mutators) {
     resp = cbm_mcp_server_handle(srv, "{\"jsonrpc\":\"2.0\",\"id\":220,\"method\":\"tools/list\"}");
     ASSERT_NOT_NULL(resp);
     static const char *const analysis_tools[] = {
-        "search_graph",     "query_graph",      "trace_path",           "get_code_snippet",
-        "get_file_outline", "get_graph_schema", "compare_graphs",       "get_architecture",
-        "search_code",      "list_projects",    "index_status",         "check_index_coverage",
+        "search_graph",     "query_graph",      "trace_path",     "get_code_snippet",
+        "get_file_outline", "get_graph_schema", "compare_graphs", "get_architecture",
+        "search_code",      "list_projects",    "index_status",   "check_index_coverage",
         "detect_changes",
     };
     ASSERT_EQ(mcp_response_tool_count(resp), sizeof(analysis_tools) / sizeof(analysis_tools[0]));

--- a/tests/test_store_nodes.c
+++ b/tests/test_store_nodes.c
@@ -13,6 +13,17 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+typedef struct {
+    int calls;
+    int cancel_on_call;
+} file_outline_cancel_probe_t;
+
+static bool file_outline_cancel_probe(void *context) {
+    file_outline_cancel_probe_t *probe = context;
+    probe->calls++;
+    return probe->calls >= probe->cancel_on_call;
+}
+
 /* ── Label allowlist / SQL drift guard ──────────────────────────── */
 
 /* CONTRACT PIN. `cbm_label_is_type_like()` is documented in cbm.h as the single
@@ -325,6 +336,156 @@ TEST(store_node_find_by_file) {
     ASSERT_EQ(rc, CBM_STORE_OK);
     ASSERT_EQ(count, 2);
     cbm_store_free_nodes(nodes, count);
+
+    cbm_store_close(s);
+    PASS();
+}
+
+TEST(store_file_outline_is_filtered_stable_bounded_and_cancellable_issue469) {
+    cbm_store_t *s = cbm_store_open_memory();
+    ASSERT_NOT_NULL(s);
+    ASSERT_EQ(cbm_store_upsert_project(s, "outline", "/tmp/outline"), CBM_STORE_OK);
+
+    cbm_node_t nodes[] = {
+        {.project = "outline",
+         .label = "Method",
+         .name = "omega",
+         .qualified_name = "outline.main.omega",
+         .file_path = "main.c",
+         .start_line = 30,
+         .end_line = 33},
+        {.project = "outline",
+         .label = "Module",
+         .name = "main",
+         .qualified_name = "outline.main",
+         .file_path = "main.c",
+         .start_line = 1,
+         .end_line = 80},
+        {.project = "outline",
+         .label = "Function",
+         .name = "zeta",
+         .qualified_name = "outline.main.zeta",
+         .file_path = "main.c",
+         .start_line = 10,
+         .end_line = 20},
+        {.project = "outline",
+         .label = "Function",
+         .name = "alpha",
+         .qualified_name = "outline.main.alpha",
+         .file_path = "main.c",
+         .start_line = 10,
+         .end_line = 15},
+        {.project = "outline",
+         .label = "Class",
+         .name = "VisibleWithoutFilter",
+         .qualified_name = "outline.main.VisibleWithoutFilter",
+         .file_path = "main.c",
+         .start_line = 5,
+         .end_line = 40},
+        {.project = "outline",
+         .label = "Function",
+         .name = "other",
+         .qualified_name = "outline.other.other",
+         .file_path = "other.c",
+         .start_line = 1,
+         .end_line = 2},
+    };
+    for (size_t i = 0; i < sizeof(nodes) / sizeof(nodes[0]); i++) {
+        ASSERT_GT(cbm_store_upsert_node(s, &nodes[i]), 0);
+    }
+
+    static const char *const labels[] = {"Function", "Method"};
+    cbm_file_outline_row_t *rows = NULL;
+    int count = 0;
+    int total = 0;
+    ASSERT_EQ(cbm_store_get_file_outline(s, "outline", "main.c", labels, 2, 2, 0, NULL, NULL, &rows,
+                                         &count, &total),
+              CBM_STORE_OK);
+    ASSERT_EQ(total, 3);
+    ASSERT_EQ(count, 2);
+    ASSERT_STR_EQ(rows[0].name, "alpha");
+    ASSERT_STR_EQ(rows[1].name, "zeta");
+    cbm_store_free_file_outline(rows, count);
+
+    rows = NULL;
+    count = 0;
+    total = 0;
+    ASSERT_EQ(cbm_store_get_file_outline(s, "outline", "main.c", labels, 2, 2, 2, NULL, NULL, &rows,
+                                         &count, &total),
+              CBM_STORE_OK);
+    ASSERT_EQ(total, 3);
+    ASSERT_EQ(count, 1);
+    ASSERT_STR_EQ(rows[0].name, "omega");
+    cbm_store_free_file_outline(rows, count);
+
+    rows = NULL;
+    count = 0;
+    total = 0;
+    ASSERT_EQ(cbm_store_get_file_outline(s, "outline", "main.c", NULL, 0, 10, 0, NULL, NULL, &rows,
+                                         &count, &total),
+              CBM_STORE_OK);
+    ASSERT_EQ(total, 4);
+    ASSERT_EQ(count, 4);
+    ASSERT_STR_EQ(rows[0].name, "VisibleWithoutFilter");
+    ASSERT_STR_EQ(rows[1].name, "alpha");
+    ASSERT_STR_EQ(rows[2].name, "zeta");
+    ASSERT_STR_EQ(rows[3].name, "omega");
+    cbm_store_free_file_outline(rows, count);
+
+    file_outline_cancel_probe_t probe = {.cancel_on_call = 3};
+    rows = (cbm_file_outline_row_t *)(uintptr_t)1;
+    count = 99;
+    total = 99;
+    ASSERT_EQ(cbm_store_get_file_outline(s, "outline", "main.c", labels, 2, 2, 0,
+                                         file_outline_cancel_probe, &probe, &rows, &count, &total),
+              CBM_STORE_CANCELLED);
+    ASSERT_NULL(rows);
+    ASSERT_EQ(count, 0);
+    ASSERT_EQ(total, 0);
+    ASSERT_TRUE(probe.calls >= 3);
+
+    const char *empty_label[] = {""};
+    ASSERT_EQ(cbm_store_get_file_outline(s, "outline", "main.c", empty_label, 1, 1, 0, NULL, NULL,
+                                         &rows, &count, &total),
+              CBM_STORE_ERR);
+    ASSERT_EQ(cbm_store_get_file_outline(s, "outline", "main.c", NULL, 0,
+                                         CBM_STORE_FILE_OUTLINE_MAX_LIMIT + 1, 0, NULL, NULL, &rows,
+                                         &count, &total),
+              CBM_STORE_ERR);
+
+    cbm_store_close(s);
+    PASS();
+}
+
+TEST(store_file_outline_fails_closed_on_text_budget_issue469) {
+    cbm_store_t *s = cbm_store_open_memory();
+    ASSERT_NOT_NULL(s);
+    ASSERT_EQ(cbm_store_upsert_project(s, "outline-budget", "/tmp/outline-budget"), CBM_STORE_OK);
+
+    size_t qn_size = CBM_STORE_FILE_OUTLINE_MAX_TEXT_BYTES + 64U;
+    char *large_qn = malloc(qn_size + 1U);
+    ASSERT_NOT_NULL(large_qn);
+    memset(large_qn, 'q', qn_size);
+    large_qn[qn_size] = '\0';
+    cbm_node_t node = {.project = "outline-budget",
+                       .label = "Function",
+                       .name = "oversized",
+                       .qualified_name = large_qn,
+                       .file_path = "large.c",
+                       .start_line = 1,
+                       .end_line = 2};
+    ASSERT_GT(cbm_store_upsert_node(s, &node), 0);
+    free(large_qn);
+
+    cbm_file_outline_row_t *rows = (cbm_file_outline_row_t *)(uintptr_t)1;
+    int count = 99;
+    int total = 99;
+    ASSERT_EQ(cbm_store_get_file_outline(s, "outline-budget", "large.c", NULL, 0, 1, 0, NULL, NULL,
+                                         &rows, &count, &total),
+              CBM_STORE_SCAN_LIMIT);
+    ASSERT_NULL(rows);
+    ASSERT_EQ(count, 0);
+    ASSERT_EQ(total, 0);
 
     cbm_store_close(s);
     PASS();
@@ -2227,6 +2388,8 @@ SUITE(store_nodes) {
     RUN_TEST(store_node_dedup);
     RUN_TEST(store_node_find_by_label);
     RUN_TEST(store_node_find_by_file);
+    RUN_TEST(store_file_outline_is_filtered_stable_bounded_and_cancellable_issue469);
+    RUN_TEST(store_file_outline_fails_closed_on_text_budget_issue469);
     RUN_TEST(store_node_find_not_found);
     RUN_TEST(store_node_count_empty);
     RUN_TEST(store_node_delete_by_file);


### PR DESCRIPTION
## Summary

- add a dedicated `get_file_outline` MCP tool for one exact repository-relative file
- back it with a project-scoped, filtered, cancellable store query with deterministic ordering
- return compact columnar rows with exact pagination metadata and fixed row, label, text, and encoded-output caps

Related to #469.

## Design decision

Selected: a dedicated MCP tool backed by a bounded store query. It preserves the existing project resolution and indexed-project checks, validates repository-relative paths, excludes container nodes, supports exact label filters, and fails without partial output on cancellation or safety-limit exhaustion.

Material alternatives considered:

1. Reuse `get_code_snippet` per symbol. This would avoid a new tool, but requires many client round trips, returns substantially more source text, and cannot provide one deterministic bounded page with an exact total.
2. Require callers to use `query_graph`. This avoids a new registry entry, but exposes graph-schema knowledge to every client and makes consistent filtering, ordering, cancellation, and output caps caller-dependent.
3. Parse source files on demand. This could avoid a store query, but duplicates indexed language logic, weakens project/index scoping, and makes latency and cancellation less predictable.

The dedicated tool won because it provides the smallest stable client contract and the strongest centralized bounds. Benefits are compact output, deterministic source order, exact pagination, preserved authorization/project scoping, and explicit cancellation. Trade-offs are one additional MCP surface, a count query plus a page query, fixed container-label exclusions, and deliberately conservative limits of 16 labels, 200 rows, 256 KiB store text, and 2 MiB encoded output.

## Binding evidence

- Exact trusted base: `909051ccee2d070f33e15fda71bfe61c9076eea6`.
- Unknown-tool binding test was RED three consecutive times on that base with the same `cols`-missing assertion (`203 passed, 1 failed, 6 skipped`).
- Minimal implementation made the focused MCP/store tests GREEN.
- A production-only dispatch revert reproduced the original binding RED; the companion validation test also went RED because the handler was unreachable (`203 passed, 2 failed, 6 skipped`).
- Restoring production dispatch returned the affected gate to GREEN.

## Verification

- `clang-format --dry-run --Werror` on all five changed files: GREEN.
- `git diff --check`: GREEN.
- Canonical lint (`run.sh lint`, cppcheck, clang-format, policy checks): GREEN.
- Affected sanitized suites (`mcp store_nodes agent_clients cli`): `589 passed, 0 failed, 6 platform skips`.
- Native macOS canonical full gate: `7587 passed, 0 failed, 8 documented platform skips`, followed by GREEN parent/worker watchdog and security-string/destructive-ordering guards.
- Independent exact-commit review of `f18c0a3910a5fbe65e934abeb0b7f10ee51a6bf5`: PASS with no blocking findings; parent, one-commit/five-file scope, clean tree, DCO, snapshot screening, scoping, ordering, cancellation, limits, cleanup, registry/schema/dispatch, and test binding were verified.

Contained platform limitations:

- Linux arm64 and amd64 canonical containers passed Steps 0a-0t, then repeatedly failed at Step 0u because the container could not resolve this linked worktree's main-repository gitdir. The identical infrastructure failure exhausted the per-leg backstop; both legs were parked without workaround and their scoped artifacts were retained.
- Real-Windows admission was parked before sync when runtime policy denied transferring the private worktree over SSH to the configured but unverified destination. No Windows test was represented as executed.

## Graph and coverage evidence

- Tier-2 project: `codebase-memory-mcp-trusted-909051cc`.
- Generation: `2026-08-27T21:56:32Z`, matching the trusted base.
- Structural searches and snippets covered tool registration/profile filtering, dispatch, request cancellation, store resolution, existing file queries, compact output helpers, and affected tests.
- Coverage was clean for `src/store/store.h` and `tests/test_store_nodes.c`. Recorded base-generation partial ranges in `src/mcp/mcp.c` (3211, 3332, 4439, 4501, 5204, 5807, 7078, 10321/10323/10325), `src/store/store.c` (5652, 5690, 5756, 6412), and `tests/test_mcp.c` (56, 4299) were read directly; none affected the implementation claims.

## Base divergence

The reviewed commit is intentionally preserved exactly on trusted base `909051ccee2d070f33e15fda71bfe61c9076eea6`; remote `main` was `4149c5044cca16e86b4848d78e3ed86cdd2ca76f` at publication screening. The candidate was not rebased after review, so current-main reconciliation remains a later, separately screened step before merge.
