### PR TITLE
fix(installer): stop PS 5.1 stderr wrapping from aborting version probes

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -281,8 +281,21 @@ if ($binaryItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
 }
 
 # Prove the downloaded binary runs before touching an existing installation.
+# PS 5.1 wraps redirected native stderr into ErrorRecords, so under the global
+# ErrorActionPreference=Stop a HEALTHY binary that prints one warning while
+# exiting 0 becomes a terminating error here. Relax to Continue for the probe
+# only; failure detection stays on $LASTEXITCODE, and the pre-seed guarantees
+# a binary that fails to START (stale $LASTEXITCODE from an earlier native
+# call) can never read as success.
 try {
-    $candidateVersion = & $DownloadedBinary --version 2>&1
+    $ProbeEap = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $global:LASTEXITCODE = 1
+        $candidateVersion = & $DownloadedBinary --version 2>&1
+    } finally {
+        $ErrorActionPreference = $ProbeEap
+    }
     if ($LASTEXITCODE -ne 0) { throw "candidate exited with $LASTEXITCODE" }
     Write-Host "Verified candidate: $candidateVersion"
 } catch {
@@ -349,8 +362,18 @@ if (Test-Path -LiteralPath $DownloadedInstaller -PathType Leaf) {
 }
 
 # Verify
+# Same PS 5.1 stderr-wrapping guard as the candidate probe above; the pre-seed
+# matters MOST here, because prior successful native calls leave a stale
+# $LASTEXITCODE=0 that a start-failure would otherwise inherit.
 try {
-    $ver = & $Dest --version 2>&1
+    $ProbeEap = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $global:LASTEXITCODE = 1
+        $ver = & $Dest --version 2>&1
+    } finally {
+        $ErrorActionPreference = $ProbeEap
+    }
     if ($LASTEXITCODE -ne 0) { throw "installed binary exited with $LASTEXITCODE" }
     Write-Host "Installed: $ver"
 } catch {

--- a/tests/test_windows_bundle_contract.sh
+++ b/tests/test_windows_bundle_contract.sh
@@ -229,6 +229,19 @@ require(
     "install.ps1 must verify and install through the downloaded binary",
 )
 
+# PS 5.1 wraps redirected native stderr into ErrorRecords; under the global
+# ErrorActionPreference=Stop a healthy binary that warns on stderr aborts the
+# version probes (#1255). Pin the guard's two load-bearing parts so neither
+# can be silently dropped: the probe-scoped relaxation with an exception-safe
+# restore, and the $LASTEXITCODE pre-seed that keeps a start-failure from
+# inheriting a stale 0 and reading as success.
+require(
+    installer.count('$ErrorActionPreference = "Continue"') == 2
+    and installer.count("$global:LASTEXITCODE = 1") == 2
+    and installer.count("$ErrorActionPreference = $ProbeEap") == 2,
+    "install.ps1 version probes must relax EAP with restore and pre-seed LASTEXITCODE (#1255)",
+)
+
 # ── 4. Package-manager shims resolve the single Windows binary ───────────────
 single_binary_contracts = {
     "pkg/npm/install.js": (


### PR DESCRIPTION
Distills #1255 by @MasterFede5 onto the current single-binary installer, completing the two conditions from the 31 July review.

## The bug (verified live on main)

PS 5.1 wraps redirected native stderr into ErrorRecords. Under `install.ps1`'s global `$ErrorActionPreference = "Stop"` (line 8, the file's only EAP statement), a **healthy** binary that prints one warning to stderr while exiting 0 turns both `--version 2>&1` probes into terminating errors — "downloaded binary failed to run" on a working install. Both the original author (PS 5.1.26100.8875, stub + negative test) and the 31 July review reproduced it independently. Only the two redirected probe sites are exposed; the unredirected install call and the try/catch-swallowed `daemon stop` are not.

## The fix, plus the review's two conditions

The author's conservative shape survives intact: relax EAP to `Continue` around the probe call only, restore in `finally`, keep failure detection on `$LASTEXITCODE`.

**Condition 1 — the `$global:LASTEXITCODE = 1` pre-seed.** Under `Continue`, a binary that fails to *start* may leave `$LASTEXITCODE` untouched. The candidate probe fails safe (`$null -ne 0`), but the installed-binary probe runs after earlier successful native calls — a stale `0` would print "Installed: …" over a corrupt install, which the old `Stop` behaviour caught. Seeding 1 makes start-failure read as failure on both probes, and moots the PS 5.1 start-failure semantics question entirely.

**Condition 2 — coverage.** The bundle contract now pins both load-bearing parts (the scoped relaxation-with-restore ×2 and the pre-seed ×2), and the pin is verified **binding**: stripping the pre-seed fails the contract, restoring passes it. The stderr-writing stub for `win.sh smoke-install` remains the ideal end-to-end test and is recorded as a VM-side follow-up — the contract pin is the floor the review named as acceptable.

## Hygiene

- **Zero non-ASCII bytes added; the file stays pure ASCII** (the PS 5.1 ANSI-decode rule) — byte-verified, and the write itself round-trips through the ascii codec so a stray character cannot slip in.
- Line-ending contract green (113 files).
- The distilled commit credits `Co-authored-by: MasterFede5` with DCO sign-off.

Closes #1255.
