### PR TITLE
chore(headers): sync stale decl names, name genuine buffer sizes (distilled from #1298)

### DIFF
--- a/src/daemon/runtime.h
+++ b/src/daemon/runtime.h
@@ -16,6 +16,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define CBM_DAEMON_SEMVER_SIZE 12U
+
 /* Detailed post-admission operation ABI. It is deliberately absent from the
  * stable endpoint HELLO: an exact executable fingerprint already selects this
  * layout, while conflicting generations must remain able to diagnose each
@@ -262,7 +264,7 @@ typedef struct {
     uint8_t client_count; /* entries in client_pids, capped at the wire limit */
     uint32_t client_pids[CBM_DAEMON_CONTROL_CLIENT_CAP];
     char build_fingerprint[CBM_DAEMON_BUILD_FINGERPRINT_SIZE];
-    char semantic_version[12];
+    char semantic_version[CBM_DAEMON_SEMVER_SIZE];
 } cbm_daemon_runtime_status_t;
 
 typedef struct {

--- a/src/pipeline/pass_lsp_cross.h
+++ b/src/pipeline/pass_lsp_cross.h
@@ -143,8 +143,9 @@ void cbm_pxc_filter_stats(uint64_t *defs_registered, uint64_t *build_files, uint
 
 static inline CBMTypeRegistry *cbm_pxc_registry_for_lang(const CBMCrossLspRegistries *r,
                                                          CBMLanguage lang) {
-    if (!r)
+    if (!r) {
         return NULL;
+    }
     switch (lang) {
     case CBM_LANG_GO:
         return r->go;
@@ -177,17 +178,17 @@ const struct CBMCargoManifest *cbm_pxc_get_rust_manifest(void);
 
 /* Run the cross-file LSP resolver for non-TS languages. Appends
  * resolved CALLS into r->resolved_calls (lives in r->arena). Caller
- * owns source, module_qn, all_defs, imp_keys, imp_vals.
- * NOTE: all_defs is read-only in practice but typed non-const to match
+ * owns source, module_qn, defs, imp_names, imp_qns.
+ * NOTE: defs is read-only in practice but typed non-const to match
  * the existing cbm_run_X_lsp_cross callee signatures. */
 void cbm_pxc_run_one(CBMLanguage lang, CBMFileResult *r, const char *source, int source_len,
-                     const char *module_qn, CBMLSPDef *all_defs, int def_count,
-                     const char **imp_keys, const char **imp_vals, int imp_count);
+                     const char *module_qn, CBMLSPDef *defs, int def_count, const char **imp_names,
+                     const char **imp_qns, int imp_count);
 
 /* TS / JS / JSX / TSX variant with explicit dialect flags. */
 void cbm_pxc_run_one_ts(CBMFileResult *r, const char *source, int source_len, const char *module_qn,
-                        CBMLSPDef *all_defs, int def_count, const char **imp_keys,
-                        const char **imp_vals, int imp_count, bool js_mode, bool jsx_mode,
+                        CBMLSPDef *defs, int def_count, const char **imp_names,
+                        const char **imp_qns, int imp_count, bool js_mode, bool jsx_mode,
                         bool dts_mode);
 
 /* Per-file cross-LSP dispatch shared by the parallel resolve worker AND the

--- a/src/ui/httpd.h
+++ b/src/ui/httpd.h
@@ -30,6 +30,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include "../foundation/constants.h"
 
 /* Maximum request head (request line + headers + terminating CRLFCRLF). */
 #define CBM_HTTP_MAX_HEAD (16 * 1024)
@@ -51,14 +52,14 @@ typedef enum {
  * Selected headers are copied for the routing/security layer ("" when
  * absent). `body` is heap-allocated and NUL-terminated. */
 typedef struct {
-    char method[16];
-    char path[2048];
-    char query[2048];
+    char method[CBM_SZ_16];
+    char path[CBM_SZ_2K];
+    char query[CBM_SZ_2K];
     unsigned char http_minor; /* 0 for HTTP/1.0, 1 for HTTP/1.1 */
-    char origin[256];
-    char host[256];
-    char content_type[128];
-    char accept_language[256];
+    char origin[CBM_SZ_256];
+    char host[CBM_SZ_256];
+    char content_type[CBM_SZ_128];
+    char accept_language[CBM_SZ_256];
     char *body;
     size_t body_len;
 } cbm_http_req_t;


### PR DESCRIPTION
Distills the surviving subset of #1298 by @aoright, per the 2026-08-17 split ruling.

## Carried

1. **`pass_lsp_cross.h` name sync** — the header still documented and declared `all_defs`/`imp_keys`/`imp_vals` while the implementation uses `defs`/`imp_names`/`imp_qns` (verified stale on main at `pass_lsp_cross.c:902/970`). Doc-only drift; plus the braced guard in `cbm_pxc_registry_for_lang`.
2. **`runtime.h`** — `semantic_version[12]` gains `CBM_DAEMON_SEMVER_SIZE`, the case the review called "defensible (a real size)".
3. **`httpd.h`** — request-field buffers take `CBM_SZ_*` names for their genuine sizes, with the include placed in the top include block rather than mid-file (the review's placement wart, fixed).

## Deliberately not carried, per the same ruling

- the `store.c` calloc hunk — the claimed uninitialized read does not exist (ruled twice; `scan_node` writes all fields, reads bounded by `visited_count`, and main has since added a clang-analyzer clamp in that very function while deliberately keeping `malloc`);
- the generic-constant renames (`CBM_SZ_2` as a growth factor, `CBM_ALLOC_ONE` as an fread size, `SKIP_ONE` as an argv slot) — semantic laundering, and clang-tidy is not CI-gating here;
- the `watcher.c` split — behaviourally equivalent as written, but its target function gained a semantic fix (`1af49dfe`) on 2026-08-20, so the refactor must be re-derived, and its "pure move" also dropped five rationale comments including the submodule-foreach shell-security note;
- the `lsp_resolve.h` extractions — their target loop was rebuilt on main and no longer exists.

Verified: build clean, `httpd` + `daemon_runtime` suites 107/0.

Closes #1298.
