### PR TITLE
feat(mcp): add manage_adr mode='set_sections' and splice ADR sections instead of rebuilding

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,8 +666,10 @@ JSON arguments can also be piped on stdin, for tools that take arguments. A tool
 | `get_code_snippet` | Read source code for a function by qualified name. |
 | `get_architecture` | Codebase overview: languages, packages, routes, hotspots, clusters, ADR. |
 | `search_code` | Grep-like text search within indexed project files. |
-| `manage_adr` | CRUD for Architecture Decision Records (`get` reads, `update` replaces the whole document, `set_sections` rewrites only the named sections, `sections` lists headings). Query modes do not wait behind a same-project reindex; writes remain serialized. |
+| `manage_adr` | CRUD for Architecture Decision Records (`get` reads, `update` replaces the whole document, `set_sections` rewrites only the named sections and leaves every other byte untouched, `sections` lists headings). Query modes do not wait behind a same-project reindex; writes remain serialized. |
 | `ingest_traces` | Ingest runtime traces to validate HTTP_CALLS edges. |
+
+`manage_adr(mode='set_sections')` writes one or more sections by name and splices them into the stored document, so text outside the named sections — including a preamble, code fences and section ordering — is preserved byte-for-byte. Any `## Heading` works, not just the conventional PURPOSE / STACK / ARCHITECTURE / PATTERNS / TRADEOFFS / PHILOSOPHY set; names match exactly, including case. Writing the same section twice is a no-op, so a retry after a lost response cannot duplicate content.
 
 `manage_adr` query modes (`get` and `sections`) use the server's cached query store so they can proceed while a same-project reindex is running. If another process publishes a replacement store during reindexing, they can return the pre-publication ADR until idle eviction refreshes that cache. Updates remain serialized through the project mutation guard.
 

--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ JSON arguments can also be piped on stdin, for tools that take arguments. A tool
 | `get_code_snippet` | Read source code for a function by qualified name. |
 | `get_architecture` | Codebase overview: languages, packages, routes, hotspots, clusters, ADR. |
 | `search_code` | Grep-like text search within indexed project files. |
-| `manage_adr` | CRUD for Architecture Decision Records. Query modes do not wait behind a same-project reindex; writes remain serialized. |
+| `manage_adr` | CRUD for Architecture Decision Records (`get` reads, `update` replaces the whole document, `set_sections` rewrites only the named sections, `sections` lists headings). Query modes do not wait behind a same-project reindex; writes remain serialized. |
 | `ingest_traces` | Ingest runtime traces to validate HTTP_CALLS edges. |
 
 `manage_adr` query modes (`get` and `sections`) use the server's cached query store so they can proceed while a same-project reindex is running. If another process publishes a replacement store during reindexing, they can return the pre-publication ADR until idle eviction refreshes that cache. Updates remain serialized through the project mutation guard.

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -706,10 +706,19 @@ static const tool_def_t TOOLS[] = {
 
     {"manage_adr", "Manage ADR", "Create or update Architecture Decision Records",
      "{\"type\":\"object\",\"properties\":{\"project\":{\"type\":\"string\"},\"mode\":{\"type\":"
-     "\"string\",\"enum\":[\"get\",\"update\",\"sections\"],\"description\":\"update replaces "
-     "the entire ADR document; sections only lists existing "
-     "headings\"},\"content\":{\"type\":\"string\",\"description\":\"Complete replacement document "
-     "required by update\"}},\"additionalProperties\":false,"
+     "\"string\",\"enum\":[\"get\",\"update\",\"set_sections\",\"sections\"],\"description\":"
+     "\"update REPLACES the entire ADR document; set_sections rewrites only the named sections "
+     "and leaves every other byte of the stored document untouched, so adding one entry does not "
+     "mean re-sending the whole ADR (setting the same section to the same body twice leaves the "
+     "document byte-identical, so retrying after a lost response is safe); sections only lists "
+     "existing headings\"},\"content\":{\"type\":\"string\",\"description\":\"Complete replacement "
+     "document required by update\"},\"section_updates\":{\"type\":\"object\",\"description\":"
+     "\"Required by set_sections: section name -> new body for that section. Only the six "
+     "canonical sections exist; any other name is rejected.\",\"properties\":{"
+     "\"PURPOSE\":{\"type\":\"string\"},\"STACK\":{\"type\":\"string\"},"
+     "\"ARCHITECTURE\":{\"type\":\"string\"},\"PATTERNS\":{\"type\":\"string\"},"
+     "\"TRADEOFFS\":{\"type\":\"string\"},\"PHILOSOPHY\":{\"type\":\"string\"}},"
+     "\"additionalProperties\":false}},\"additionalProperties\":false,"
      "\"required\":[\"project\"]}"},
 
     {"ingest_traces", "Ingest traces", "Ingest runtime traces to enhance the knowledge graph",
@@ -11848,6 +11857,123 @@ static cbm_store_t *open_adr_store_for_write(cbm_mcp_server_t *srv, cbm_store_t 
     return *owned_rw;
 }
 
+/* Parsed `section_updates` for mode='set_sections'.
+ *
+ * mode='update' replaces the whole document, so adding one entry costs a full
+ * re-send and the stored ADR is only ever as good as that round-trip. Writing
+ * named sections instead leaves the rest of the document as the authority for
+ * itself — and, unlike a whole-document append, applying the same request
+ * twice yields the same document, so a client that retries after a lost
+ * response cannot silently duplicate content. */
+typedef struct {
+    char *keys[PROPS_MAX];
+    char *values[PROPS_MAX];
+    int count;
+    /* Rejection reason, or NULL when the request parsed cleanly. Set means no
+     * store was opened and nothing was written. */
+    const char *status;
+    const char *error;
+} adr_section_updates_t;
+
+static void adr_section_updates_free(adr_section_updates_t *u) {
+    for (int i = 0; i < u->count; i++) {
+        free(u->keys[i]);
+        free(u->values[i]);
+    }
+    u->count = 0;
+}
+
+static bool adr_collect_section_update(adr_section_updates_t *u, yyjson_val *key, yyjson_val *val) {
+    const char *name = yyjson_get_str(key);
+    if (!name || !name[0]) {
+        u->status = "invalid_section_updates";
+        u->error = "'section_updates' keys must be non-empty section names. "
+                   "No ADR write was performed.";
+        return false;
+    }
+    if (!yyjson_is_str(val)) {
+        u->status = "invalid_section_updates";
+        u->error = "'section_updates' values must be strings (the new body for that section). "
+                   "No ADR write was performed.";
+        return false;
+    }
+    const char *body = yyjson_get_str(val);
+    /* An empty body would render a heading with nothing under it — a silent
+     * content deletion wearing the response shape of an update. Clearing a
+     * section is whole-document surgery; that is what mode='update' is for. */
+    if (!body || !body[0]) {
+        u->status = "empty_section_content";
+        u->error = "'section_updates' values must be non-empty; use mode='update' to remove a "
+                   "section. No ADR write was performed.";
+        return false;
+    }
+    if (u->count >= PROPS_MAX) {
+        u->status = "too_many_sections";
+        u->error = "'section_updates' carries more entries than an ADR can hold. "
+                   "No ADR write was performed.";
+        return false;
+    }
+    u->keys[u->count] = heap_strdup(name);
+    u->values[u->count] = heap_strdup(body);
+    if (!u->keys[u->count] || !u->values[u->count]) {
+        free(u->keys[u->count]);
+        free(u->values[u->count]);
+        u->status = "write_error";
+        u->error = "out of memory parsing 'section_updates'. No ADR write was performed.";
+        return false;
+    }
+    u->count++;
+    return true;
+}
+
+static adr_section_updates_t adr_parse_section_updates(const char *args) {
+    adr_section_updates_t u;
+    memset(&u, 0, sizeof(u));
+
+    yyjson_doc *doc = yyjson_read(args, strlen(args), 0);
+    yyjson_val *root = doc ? yyjson_doc_get_root(doc) : NULL;
+    yyjson_val *updates =
+        (root && yyjson_is_obj(root)) ? yyjson_obj_get(root, "section_updates") : NULL;
+
+    if (!updates) {
+        /* Never fall through to 'get': a caller that meant to write must not
+         * receive a success-shaped read. */
+        u.status = "missing_section_updates";
+        u.error = "mode='set_sections' requires 'section_updates', an object mapping section "
+                  "name to its new body. No ADR write was performed.";
+    } else if (!yyjson_is_obj(updates) || yyjson_obj_size(updates) == 0) {
+        u.status = "invalid_section_updates";
+        u.error = "'section_updates' must be a non-empty object mapping section name to its new "
+                  "body. No ADR write was performed.";
+    } else {
+        size_t idx = 0;
+        size_t max = 0;
+        yyjson_val *key = NULL;
+        yyjson_val *val = NULL;
+        yyjson_obj_foreach(updates, idx, max, key, val) {
+            if (!adr_collect_section_update(&u, key, val)) {
+                adr_section_updates_free(&u);
+                break;
+            }
+        }
+    }
+    yyjson_doc_free(doc);
+    return u;
+}
+
+/* Build the rejection payload for a set_sections request that never reached a
+ * store. Caller frees. */
+static char *adr_section_updates_error(const adr_section_updates_t *u) {
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *root_obj = yyjson_mut_obj(doc);
+    yyjson_mut_doc_set_root(doc, root_obj);
+    yyjson_mut_obj_add_str(doc, root_obj, "status", u->status);
+    yyjson_mut_obj_add_strcpy(doc, root_obj, "error", u->error);
+    char *json = yy_doc_to_str(doc);
+    yyjson_mut_doc_free(doc);
+    return json;
+}
+
 static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
     char *project = get_project_arg(args);
     char *mode_str = cbm_mcp_get_string_arg(args, "mode");
@@ -11879,12 +12005,51 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
             true);
     }
 
+    bool set_sections_mode = (strcmp(mode_str, "set_sections") == 0);
+    adr_section_updates_t updates;
+    memset(&updates, 0, sizeof(updates));
+    char section_key_err[CBM_SZ_256] = "";
+    if (set_sections_mode) {
+        updates = adr_parse_section_updates(args);
+        /* Only the six canonical names are writable, and that is a correctness
+         * constraint rather than a house style: adr_try_section_header() parses
+         * ONLY canonical headers, so a '## FOO' written here would be read back
+         * as body text of the section above it and a second identical write
+         * would append a duplicate — destroying exactly the idempotence this
+         * mode exists to provide. */
+        if (!updates.status && cbm_adr_validate_section_keys(
+                                   (const char **)updates.keys, updates.count, section_key_err,
+                                   (int)sizeof(section_key_err)) != CBM_STORE_OK) {
+            adr_section_updates_free(&updates);
+            updates.status = "invalid_section_name";
+            updates.error = section_key_err;
+        }
+        if (updates.status) {
+            /* Reject before taking the project lease or opening a store: a
+             * malformed write must not block an index, and must not read. */
+            char *err = adr_section_updates_error(&updates);
+            adr_section_updates_free(&updates);
+            free(project);
+            free(mode_str);
+            free(content);
+            char *res = cbm_mcp_text_result(err, true);
+            free(err);
+            return res;
+        }
+    }
+
+    /* This classification is load-bearing. A mode missing from it takes no
+     * per-project mutation lease, resolves the store query-only, and never
+     * reaches open_adr_store_for_write — so its write would be attempted
+     * through a read-only handle, concurrently with an active index. */
     bool write_request =
-        content && (strcmp(mode_str, "update") == 0 || strcmp(mode_str, "store") == 0);
+        (content && (strcmp(mode_str, "update") == 0 || strcmp(mode_str, "store") == 0)) ||
+        set_sections_mode;
     bool mutation_held = false;
     if (write_request && project) {
         mutation_held = mcp_project_mutation_begin(srv, project);
         if (!mutation_held) {
+            adr_section_updates_free(&updates);
             free(project);
             free(mode_str);
             free(content);
@@ -11893,6 +12058,7 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
         }
         if (mcp_request_cancelled(srv)) {
             mcp_project_mutation_end(srv, project);
+            adr_section_updates_free(&updates);
             free(project);
             free(mode_str);
             free(content);
@@ -11921,6 +12087,7 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
         if (mutation_held) {
             mcp_project_mutation_end(srv, project);
         }
+        adr_section_updates_free(&updates);
         free(project);
         free(mode_str);
         free(content);
@@ -11935,6 +12102,7 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
             if (mutation_held) {
                 mcp_project_mutation_end(srv, project);
             }
+            adr_section_updates_free(&updates);
             free(project);
             free(mode_str);
             free(content);
@@ -11981,13 +12149,69 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
         }
     }
 
+    /* A set_sections write must see a legacy file-backed ADR too. The
+     * migration above deliberately runs on the read path only — it must never
+     * block on the lease — so the write path reads the file here, where the
+     * exclusive project lease and a writable store are already held. Merging
+     * onto an empty document instead would silently discard an ADR the user
+     * still has on disk. */
+    char *legacy_seed = NULL;
+    if (set_sections_mode && !have_adr) {
+        char *root_path = project_root_from_store(store, project);
+        legacy_seed = adr_read_legacy_file(root_path);
+        free(root_path);
+    }
+
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
     yyjson_mut_val *root_obj = yyjson_mut_obj(doc);
     yyjson_mut_doc_set_root(doc, root_obj);
 
     bool is_error = false;
     const char *adr_content = have_adr ? adr.content : legacy;
-    if (write_request) {
+    if (set_sections_mode) {
+        /* cbm_store_adr_update_sections requires an existing row — its
+         * contract, pinned by TEST(adr_update_no_existing). Seed one when the
+         * project has none, so the mode degrades to a plain create: the legacy
+         * document when there is one, an empty document otherwise. */
+        bool base_present = have_adr;
+        bool seeded_empty = false;
+        if (!base_present) {
+            const char *seed = legacy_seed ? legacy_seed : "";
+            if (cbm_store_adr_store(store, project, seed) == CBM_STORE_OK) {
+                base_present = true;
+                seeded_empty = (legacy_seed == NULL);
+            }
+        }
+        cbm_adr_t updated;
+        memset(&updated, 0, sizeof(updated));
+        int section_rc = base_present ? cbm_store_adr_update_sections(
+                                            store, project, (const char **)updates.keys,
+                                            (const char **)updates.values, updates.count, &updated)
+                                      : CBM_STORE_ERR;
+        if (section_rc == CBM_STORE_OK) {
+            yyjson_mut_obj_add_str(doc, root_obj, "status", "sections_updated");
+            yyjson_mut_obj_add_str(doc, root_obj, "semantics",
+                                   "named_sections_replaced_rest_preserved");
+            yyjson_mut_obj_add_uint(doc, root_obj, "sections_written", (uint64_t)updates.count);
+            /* Callers confirm the write landed without re-fetching the ADR. */
+            yyjson_mut_obj_add_uint(doc, root_obj, "content_length",
+                                    (uint64_t)strlen(updated.content));
+            cbm_store_adr_free(&updated);
+        } else {
+            /* Undo an empty seed. A rejected write must not leave the project
+             * holding a blank ADR where `get` used to answer no_adr. A legacy
+             * seed is a real migration and is kept. */
+            if (seeded_empty) {
+                (void)cbm_store_adr_delete(store, project);
+            }
+            yyjson_mut_obj_add_str(doc, root_obj, "status", "write_error");
+            const char *store_err = cbm_store_error(store);
+            if (store_err && store_err[0]) {
+                yyjson_mut_obj_add_strcpy(doc, root_obj, "error", store_err);
+            }
+            is_error = true;
+        }
+    } else if (write_request) {
         if (cbm_store_adr_store(store, project, content) == CBM_STORE_OK) {
             yyjson_mut_obj_add_str(doc, root_obj, "status", "updated");
             yyjson_mut_obj_add_str(doc, root_obj, "semantics", "whole_document_replaced");
@@ -12018,6 +12242,8 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
     if (mutation_held) {
         mcp_project_mutation_end(srv, project);
     }
+    adr_section_updates_free(&updates);
+    free(legacy_seed);
     free(legacy);
     free(project);
     free(mode_str);

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -713,12 +713,11 @@ static const tool_def_t TOOLS[] = {
      "document byte-identical, so retrying after a lost response is safe); sections only lists "
      "existing headings\"},\"content\":{\"type\":\"string\",\"description\":\"Complete replacement "
      "document required by update\"},\"section_updates\":{\"type\":\"object\",\"description\":"
-     "\"Required by set_sections: section name -> new body for that section. Only the six "
-     "canonical sections exist; any other name is rejected.\",\"properties\":{"
-     "\"PURPOSE\":{\"type\":\"string\"},\"STACK\":{\"type\":\"string\"},"
-     "\"ARCHITECTURE\":{\"type\":\"string\"},\"PATTERNS\":{\"type\":\"string\"},"
-     "\"TRADEOFFS\":{\"type\":\"string\"},\"PHILOSOPHY\":{\"type\":\"string\"}},"
-     "\"additionalProperties\":false}},\"additionalProperties\":false,"
+     "\"Required by set_sections: section name -> new body for that section. Any heading name "
+     "works, so a new entry can be added under its own heading; PURPOSE, STACK, ARCHITECTURE, "
+     "PATTERNS, TRADEOFFS and PHILOSOPHY are the conventional ones. Names match exactly, "
+     "including case, so 'Purpose' and 'PURPOSE' are different sections.\","
+     "\"additionalProperties\":{\"type\":\"string\"}}},\"additionalProperties\":false,"
      "\"required\":[\"project\"]}"},
 
     {"ingest_traces", "Ingest traces", "Ingest runtime traces to enhance the knowledge graph",
@@ -11763,31 +11762,33 @@ static char *handle_detect_changes(cbm_mcp_server_t *srv, const char *args) {
 
 /* ── manage_adr ───────────────────────────────────────────────── */
 
-/* ADR "sections" mode: list markdown headers ('#'-prefixed lines) from the
- * ADR content string. */
+typedef struct {
+    yyjson_mut_doc *doc;
+    yyjson_mut_val *arr;
+} adr_sections_ctx_t;
+
+static void adr_sections_cb(void *ctx, const cbm_adr_heading_t *h) {
+    adr_sections_ctx_t *c = (adr_sections_ctx_t *)ctx;
+    char hdr[CBM_SZ_1K];
+    snprintf(hdr, sizeof(hdr), "## %.*s", h->name_len, h->name);
+    yyjson_mut_arr_add_strcpy(c->doc, c->arr, hdr);
+}
+
+/* ADR "sections" mode: list the section headings of the ADR.
+ *
+ * This uses cbm_adr_scan_headings(), the SAME classifier the section-write
+ * path splices with. It used to list any '#'-prefixed line, so a '## Foo' in
+ * prose — or inside a fenced code block — was reported as a section that no
+ * write could target. Two components disagreeing about what a section is was
+ * how a section write came to be able to destroy one. */
 static void adr_list_sections_from_content(yyjson_mut_doc *doc, yyjson_mut_val *root_obj,
                                            const char *content) {
     yyjson_mut_val *sections = yyjson_mut_arr(doc);
-    const char *p = content;
-    while (p && *p) {
-        const char *eol = strchr(p, '\n');
-        size_t linelen = eol ? (size_t)(eol - p) : strlen(p);
-        while (linelen > 0 && p[linelen - SKIP_ONE] == '\r') {
-            linelen--;
-        }
-        if (linelen > 0 && p[0] == '#') {
-            char hdr[CBM_SZ_1K];
-            if (linelen >= sizeof(hdr)) {
-                linelen = sizeof(hdr) - SKIP_ONE;
-            }
-            memcpy(hdr, p, linelen);
-            hdr[linelen] = '\0';
-            yyjson_mut_arr_add_strcpy(doc, sections, hdr);
-        }
-        if (!eol) {
-            break;
-        }
-        p = eol + SKIP_ONE;
+    adr_sections_ctx_t ctx = {doc, sections};
+    if (content && cbm_adr_scan_headings(content, adr_sections_cb, &ctx) != CBM_STORE_OK) {
+        /* The ambiguity that refuses a section write is reported here too,
+         * rather than answering with a heading list that is quietly partial. */
+        yyjson_mut_obj_add_str(doc, root_obj, "sections_status", "unterminated_code_fence");
     }
     yyjson_mut_obj_add_val(doc, root_obj, "sections", sections);
 }
@@ -12011,12 +12012,12 @@ static char *handle_manage_adr(cbm_mcp_server_t *srv, const char *args) {
     char section_key_err[CBM_SZ_256] = "";
     if (set_sections_mode) {
         updates = adr_parse_section_updates(args);
-        /* Only the six canonical names are writable, and that is a correctness
-         * constraint rather than a house style: adr_try_section_header() parses
-         * ONLY canonical headers, so a '## FOO' written here would be read back
-         * as body text of the section above it and a second identical write
-         * would append a duplicate — destroying exactly the idempotence this
-         * mode exists to provide. */
+        /* Any heading name is writable — the canonical six are a convention,
+         * not a privilege. What is still refused is a name that could not
+         * round-trip through a "## NAME" line (empty, '#'-leading, newline- or
+         * edge-whitespace-bearing, over-long): such a name would scan back as
+         * a different heading or as none, so a second identical write would
+         * append a duplicate instead of being a no-op. */
         if (!updates.status && cbm_adr_validate_section_keys(
                                    (const char **)updates.keys, updates.count, section_key_err,
                                    (int)sizeof(section_key_err)) != CBM_STORE_OK) {

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -8900,6 +8900,44 @@ static void adr_find_cb(void *ctx, const cbm_adr_heading_t *h) {
     f->body_end = h->body_end;
 }
 
+/* The line ending this code should WRITE into `doc`: whichever of "\r\n" and
+ * "\n" the document already uses more often, LF on a tie or an empty document.
+ * Lines that already exist are never rewritten — this decides only the
+ * separator and the "## NAME" line an append adds, so a CRLF document does not
+ * acquire a stray bare newline nobody asked for. */
+static const char *adr_dominant_eol(const char *doc, size_t doc_len) {
+    size_t crlf = 0;
+    size_t lf = 0;
+    for (size_t i = 0; i < doc_len; i++) {
+        if (doc[i] != '\n') {
+            continue;
+        }
+        if (i > 0 && doc[i - SKIP_ONE] == '\r') {
+            crlf++;
+        } else {
+            lf++;
+        }
+    }
+    return crlf > lf ? "\r\n" : "\n";
+}
+
+/* Trailing line breaks, counting a "\r\n" PAIR as ONE break. Counting raw '\n'
+ * characters gets the count right but loses the shape, and the separator that
+ * is then appended has to match the ending it is continuing. */
+static size_t adr_trailing_breaks(const char *doc, size_t doc_len) {
+    size_t idx = doc_len;
+    size_t breaks = 0;
+    while (idx > 0 && (doc[idx - SKIP_ONE] == '\n' || doc[idx - SKIP_ONE] == '\r')) {
+        bool was_lf = doc[idx - SKIP_ONE] == '\n';
+        idx--;
+        if (was_lf && idx > 0 && doc[idx - SKIP_ONE] == '\r') {
+            idx--;
+        }
+        breaks++;
+    }
+    return breaks;
+}
+
 char *cbm_adr_splice_section(const char *content, const char *name, const char *body) {
     if (!name || !body) {
         return NULL;
@@ -8951,37 +8989,40 @@ char *cbm_adr_splice_section(const char *content, const char *name, const char *
         return out;
     }
 
-    /* Absent: append. Enough newlines are added to leave exactly one blank
+    /* Absent: append. Enough line breaks are added to leave exactly one blank
      * line before the new heading — never fewer, and never rewriting the
-     * newlines the document already ends with. */
-    size_t trailing = 0;
-    while (trailing < doc_len && doc[doc_len - SKIP_ONE - trailing] == '\n') {
-        trailing++;
-    }
+     * breaks the document already ends with. Both the separator and the
+     * heading line use the document's OWN ending: counting raw '\n' here would
+     * drop a bare newline into a CRLF document, leaving it mixed. */
+    const char *eol = adr_dominant_eol(doc, doc_len);
+    size_t eol_len = strlen(eol);
+    size_t breaks = adr_trailing_breaks(doc, doc_len);
     size_t sep = 0;
-    if (doc_len > 0 && trailing < PAIR_LEN) {
-        sep = PAIR_LEN - trailing;
+    if (doc_len > 0 && breaks < PAIR_LEN) {
+        sep = PAIR_LEN - breaks;
     }
     size_t name_len = strlen(name);
-    size_t total = doc_len + sep + ST_HEADER_PREFIX + name_len + SKIP_ONE + body_len;
+    size_t total = doc_len + (sep * eol_len) + ST_HEADER_PREFIX + name_len + eol_len + body_len;
     out = malloc(total + SKIP_ONE);
     if (!out) {
         return NULL;
     }
-    size_t at = 0;
+    size_t cursor = 0;
     memcpy(out, doc, doc_len);
-    at += doc_len;
+    cursor += doc_len;
     for (size_t i = 0; i < sep; i++) {
-        out[at++] = '\n';
+        memcpy(out + cursor, eol, eol_len);
+        cursor += eol_len;
     }
-    memcpy(out + at, "## ", ST_HEADER_PREFIX);
-    at += ST_HEADER_PREFIX;
-    memcpy(out + at, name, name_len);
-    at += name_len;
-    out[at++] = '\n';
-    memcpy(out + at, body, body_len);
-    at += body_len;
-    out[at] = '\0';
+    memcpy(out + cursor, "## ", ST_HEADER_PREFIX);
+    cursor += ST_HEADER_PREFIX;
+    memcpy(out + cursor, name, name_len);
+    cursor += name_len;
+    memcpy(out + cursor, eol, eol_len);
+    cursor += eol_len;
+    memcpy(out + cursor, body, body_len);
+    cursor += body_len;
+    out[cursor] = '\0';
     return out;
 }
 

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -8883,10 +8883,25 @@ int cbm_store_adr_delete(cbm_store_t *s, const char *project) {
 
 int cbm_store_adr_update_sections(cbm_store_t *s, const char *project, const char **keys,
                                   const char **values, int count, cbm_adr_t *out) {
+    if (!s || !s->db || !project || !keys || !values || !out) {
+        return CBM_STORE_ERR;
+    }
+
+    /* The read-modify-write below must be ONE transaction. Three writers
+     * replace this row wholesale — the indexing pipeline, the UI POST
+     * /api/adr handler, and manage_adr mode='update' — so an unguarded
+     * get/merge/store silently loses whichever of them commits between the
+     * read and the UPSERT. BEGIN IMMEDIATE takes the write lock up front, so a
+     * competing writer waits rather than being overwritten. */
+    if (cbm_store_begin(s) != CBM_STORE_OK) {
+        return CBM_STORE_ERR;
+    }
+
     /* Get existing ADR */
     cbm_adr_t existing;
     int rc = cbm_store_adr_get(s, project, &existing);
     if (rc != CBM_STORE_OK) {
+        (void)cbm_store_rollback(s);
         store_set_error(s, "no existing ADR to update");
         return rc;
     }
@@ -8917,13 +8932,20 @@ int cbm_store_adr_update_sections(cbm_store_t *s, const char *project, const cha
     char *merged = cbm_adr_render(&sections);
     cbm_adr_sections_free(&sections);
 
+    if (!merged) {
+        (void)cbm_store_rollback(s);
+        store_set_error(s, "failed to render merged ADR");
+        return CBM_STORE_ERR;
+    }
+
     /* Check length */
     if ((int)strlen(merged) > CBM_ADR_MAX_LENGTH) {
         char msg[CBM_SZ_128];
         snprintf(msg, sizeof(msg), "merged ADR exceeds %d chars (%d chars)", CBM_ADR_MAX_LENGTH,
                  (int)strlen(merged));
-        store_set_error(s, msg);
         free(merged);
+        (void)cbm_store_rollback(s);
+        store_set_error(s, msg);
         return CBM_STORE_ERR;
     }
 
@@ -8931,10 +8953,22 @@ int cbm_store_adr_update_sections(cbm_store_t *s, const char *project, const cha
     rc = cbm_store_adr_store(s, project, merged);
     free(merged);
     if (rc != CBM_STORE_OK) {
+        (void)cbm_store_rollback(s);
         return rc;
     }
 
-    return cbm_store_adr_get(s, project, out);
+    /* Read back INSIDE the transaction so `out` is exactly what commits. */
+    rc = cbm_store_adr_get(s, project, out);
+    if (rc != CBM_STORE_OK) {
+        (void)cbm_store_rollback(s);
+        return rc;
+    }
+    if (cbm_store_commit(s) != CBM_STORE_OK) {
+        cbm_store_adr_free(out);
+        (void)cbm_store_rollback(s);
+        return CBM_STORE_ERR;
+    }
+    return CBM_STORE_OK;
 }
 
 void cbm_store_adr_free(cbm_adr_t *adr) {

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -8708,46 +8708,323 @@ int cbm_adr_validate_content(const char *content, char *errbuf, int errbuf_size)
     return CBM_STORE_OK;
 }
 
-int cbm_adr_validate_section_keys(const char **keys, int count, char *errbuf, int errbuf_size) {
-    char invalid[CBM_SZ_256] = "";
-    int ilen = 0;
-    int ninvalid = 0;
+/* ── ADR heading scanning and splicing ──────────────────────────── */
 
-    /* Collect and sort invalid keys */
-    const char *inv_keys[ST_MAX_SECTIONS];
-    int inv_n = 0;
-    for (int i = 0; i < count; i++) {
-        if (!is_canonical_section(keys[i])) {
-            if (inv_n < ST_BUF_16) {
-                inv_keys[inv_n++] = keys[i];
+/* Length of a code-fence run (``` or ~~~, after at most three spaces of
+ * indent), or 0 when the line does not open or close a fence. */
+static int adr_fence_run(const char *line, int line_len, char *ch_out) {
+    int i = 0;
+    while (i < line_len && i < ST_HEADER_PREFIX && line[i] == ' ') {
+        i++;
+    }
+    if (i >= line_len || (line[i] != '`' && line[i] != '~')) {
+        return 0;
+    }
+    char c = line[i];
+    int n = 0;
+    while (i + n < line_len && line[i + n] == c) {
+        n++;
+    }
+    if (n < ST_HEADER_PREFIX) {
+        return 0;
+    }
+    *ch_out = c;
+    return n;
+}
+
+/* True when the line is a closing fence for an open run of `open_n` `open_ch`:
+ * same character, at least as long, and nothing but whitespace after it. */
+static bool adr_fence_closes(const char *line, int line_len, char open_ch, int open_n) {
+    char ch = 0;
+    int n = adr_fence_run(line, line_len, &ch);
+    if (n == 0 || ch != open_ch || n < open_n) {
+        return false;
+    }
+    int i = 0;
+    while (i < line_len && line[i] != open_ch) {
+        i++;
+    }
+    i += n;
+    while (i < line_len) {
+        if (line[i] != ' ' && line[i] != '\t' && line[i] != '\r') {
+            return false;
+        }
+        i++;
+    }
+    return true;
+}
+
+/* Name length of a "## NAME" heading line, or 0 when it is not a heading.
+ * "###" fails on the third '#', so deeper markdown headings are body text. */
+static int adr_heading_name_len(const char *line, int line_len) {
+    if (line_len <= ST_HEADER_PREFIX || line[0] != '#' || line[SKIP_ONE] != '#' ||
+        line[PAIR_LEN] != ' ') {
+        return 0;
+    }
+    int len = line_len - ST_HEADER_PREFIX;
+    const char *name = line + ST_HEADER_PREFIX;
+    while (len > 0 && (name[len - SKIP_ONE] == ' ' || name[len - SKIP_ONE] == '\t' ||
+                       name[len - SKIP_ONE] == '\r')) {
+        len--;
+    }
+    /* A leading space would not survive a render/scan round-trip. */
+    if (len == 0 || name[0] == ' ' || name[0] == '\t') {
+        return 0;
+    }
+    return len;
+}
+
+/* True when the document leaves a code fence open. Such a document cannot be
+ * spliced: every heading after the opener is hidden, so an update would append
+ * a duplicate heading instead of replacing the existing one. */
+static bool adr_has_unterminated_fence(const char *content) {
+    const char *p = content;
+    bool in_fence = false;
+    char fence_ch = 0;
+    int fence_n = 0;
+    while (p && *p) {
+        const char *eol = strchr(p, '\n');
+        int line_len = eol ? (int)(eol - p) : (int)strlen(p);
+        if (in_fence) {
+            if (adr_fence_closes(p, line_len, fence_ch, fence_n)) {
+                in_fence = false;
+            }
+        } else {
+            char ch = 0;
+            int n = adr_fence_run(p, line_len, &ch);
+            if (n > 0) {
+                in_fence = true;
+                fence_ch = ch;
+                fence_n = n;
             }
         }
-    }
-    /* Sort alphabetically */
-    for (int i = SKIP_ONE; i < inv_n; i++) {
-        int j = i;
-        while (j > 0 && strcmp(inv_keys[j], inv_keys[j - SKIP_ONE]) < 0) {
-            const char *tmp = inv_keys[j];
-            inv_keys[j] = inv_keys[j - SKIP_ONE];
-            inv_keys[j - SKIP_ONE] = tmp;
-            j--;
+        if (!eol) {
+            break;
         }
+        p = eol + SKIP_ONE;
     }
+    return in_fence;
+}
 
-    for (int i = 0; i < inv_n; i++) {
-        if (ilen > 0) {
-            ilen += snprintf(invalid + ilen, sizeof(invalid) - ilen, ", ");
-        }
-        ilen += snprintf(invalid + ilen, sizeof(invalid) - ilen, "%s", inv_keys[i]);
-        ninvalid++;
+int cbm_adr_scan_headings(const char *content, void (*cb)(void *ctx, const cbm_adr_heading_t *h),
+                          void *ctx) {
+    if (!content || !cb) {
+        return content ? CBM_STORE_ERR : CBM_STORE_OK;
     }
-
-    if (ninvalid > 0) {
-        snprintf(errbuf, errbuf_size,
-                 "invalid section names: %s. Valid sections: PURPOSE, STACK, ARCHITECTURE, "
-                 "PATTERNS, TRADEOFFS, PHILOSOPHY",
-                 invalid);
+    if (adr_has_unterminated_fence(content)) {
         return CBM_STORE_ERR;
+    }
+
+    cbm_adr_heading_t pending;
+    memset(&pending, 0, sizeof(pending));
+    bool have_pending = false;
+    bool in_fence = false;
+    char fence_ch = 0;
+    int fence_n = 0;
+
+    const char *p = content;
+    while (*p) {
+        const char *eol = strchr(p, '\n');
+        int line_len = eol ? (int)(eol - p) : (int)strlen(p);
+        size_t line_off = (size_t)(p - content);
+
+        if (in_fence) {
+            if (adr_fence_closes(p, line_len, fence_ch, fence_n)) {
+                in_fence = false;
+            }
+        } else {
+            char ch = 0;
+            int fn = adr_fence_run(p, line_len, &ch);
+            if (fn > 0) {
+                in_fence = true;
+                fence_ch = ch;
+                fence_n = fn;
+            } else {
+                int name_len = adr_heading_name_len(p, line_len);
+                if (name_len > 0) {
+                    /* The previous heading's body ends where this one starts. */
+                    if (have_pending) {
+                        pending.body_end = line_off;
+                        cb(ctx, &pending);
+                    }
+                    pending.name = p + ST_HEADER_PREFIX;
+                    pending.name_len = name_len;
+                    pending.heading_start = line_off;
+                    pending.body_start =
+                        eol ? line_off + (size_t)line_len + SKIP_ONE : line_off + (size_t)line_len;
+                    have_pending = true;
+                }
+            }
+        }
+        if (!eol) {
+            break;
+        }
+        p = eol + SKIP_ONE;
+    }
+    if (have_pending) {
+        pending.body_end = strlen(content);
+        cb(ctx, &pending);
+    }
+    return CBM_STORE_OK;
+}
+
+int cbm_adr_check_structure(const char *content, char *errbuf, int errbuf_size) {
+    if (content && adr_has_unterminated_fence(content)) {
+        snprintf(errbuf, (size_t)errbuf_size,
+                 "the stored ADR leaves a code fence open, so its section boundaries are "
+                 "ambiguous and a section write could splice into a code sample; repair it "
+                 "with mode='update'");
+        return CBM_STORE_ERR;
+    }
+    return CBM_STORE_OK;
+}
+
+typedef struct {
+    const char *name;
+    int name_len;
+    bool found;
+    size_t body_start;
+    size_t body_end;
+} adr_find_ctx_t;
+
+static void adr_find_cb(void *ctx, const cbm_adr_heading_t *h) {
+    adr_find_ctx_t *f = (adr_find_ctx_t *)ctx;
+    /* First occurrence wins, so a document that repeats a heading updates
+     * deterministically rather than depending on scan order. */
+    if (f->found || h->name_len != f->name_len ||
+        memcmp(h->name, f->name, (size_t)f->name_len) != 0) {
+        return;
+    }
+    f->found = true;
+    f->body_start = h->body_start;
+    f->body_end = h->body_end;
+}
+
+char *cbm_adr_splice_section(const char *content, const char *name, const char *body) {
+    if (!name || !body) {
+        return NULL;
+    }
+    const char *doc = content ? content : "";
+    size_t doc_len = strlen(doc);
+
+    /* Trailing newlines are stripped from the incoming body so that splicing
+     * the same body twice is byte-identical: without this the separator run
+     * would grow by one blank line on every repeat. */
+    size_t body_len = strlen(body);
+    while (body_len > 0 &&
+           (body[body_len - SKIP_ONE] == '\n' || body[body_len - SKIP_ONE] == '\r')) {
+        body_len--;
+    }
+
+    adr_find_ctx_t find;
+    memset(&find, 0, sizeof(find));
+    find.name = name;
+    find.name_len = (int)strlen(name);
+    if (cbm_adr_scan_headings(doc, adr_find_cb, &find) != CBM_STORE_OK) {
+        return NULL;
+    }
+
+    char *out = NULL;
+    if (find.found) {
+        /* Keep the replaced region's own trailing newline run, so the blank
+         * line that separates this section from the next survives untouched. */
+        size_t ws = find.body_end;
+        while (ws > find.body_start && (doc[ws - SKIP_ONE] == '\n' || doc[ws - SKIP_ONE] == '\r')) {
+            ws--;
+        }
+        size_t ws_len = find.body_end - ws;
+        size_t total = find.body_start + body_len + ws_len + (doc_len - find.body_end);
+        out = malloc(total + SKIP_ONE);
+        if (!out) {
+            return NULL;
+        }
+        size_t at = 0;
+        memcpy(out, doc, find.body_start);
+        at += find.body_start;
+        memcpy(out + at, body, body_len);
+        at += body_len;
+        memcpy(out + at, doc + ws, ws_len);
+        at += ws_len;
+        memcpy(out + at, doc + find.body_end, doc_len - find.body_end);
+        at += doc_len - find.body_end;
+        out[at] = '\0';
+        return out;
+    }
+
+    /* Absent: append. Enough newlines are added to leave exactly one blank
+     * line before the new heading — never fewer, and never rewriting the
+     * newlines the document already ends with. */
+    size_t trailing = 0;
+    while (trailing < doc_len && doc[doc_len - SKIP_ONE - trailing] == '\n') {
+        trailing++;
+    }
+    size_t sep = 0;
+    if (doc_len > 0 && trailing < PAIR_LEN) {
+        sep = PAIR_LEN - trailing;
+    }
+    size_t name_len = strlen(name);
+    size_t total = doc_len + sep + ST_HEADER_PREFIX + name_len + SKIP_ONE + body_len;
+    out = malloc(total + SKIP_ONE);
+    if (!out) {
+        return NULL;
+    }
+    size_t at = 0;
+    memcpy(out, doc, doc_len);
+    at += doc_len;
+    for (size_t i = 0; i < sep; i++) {
+        out[at++] = '\n';
+    }
+    memcpy(out + at, "## ", ST_HEADER_PREFIX);
+    at += ST_HEADER_PREFIX;
+    memcpy(out + at, name, name_len);
+    at += name_len;
+    out[at++] = '\n';
+    memcpy(out + at, body, body_len);
+    at += body_len;
+    out[at] = '\0';
+    return out;
+}
+
+int cbm_adr_validate_section_name(const char *name, char *errbuf, int errbuf_size) {
+    if (!name || !name[0]) {
+        snprintf(errbuf, (size_t)errbuf_size, "section name must not be empty");
+        return CBM_STORE_ERR;
+    }
+    size_t len = strlen(name);
+    if (len >= CBM_SZ_64) {
+        snprintf(errbuf, (size_t)errbuf_size, "section name must be shorter than %d characters",
+                 CBM_SZ_64);
+        return CBM_STORE_ERR;
+    }
+    /* Everything below would make the written "## NAME" line scan back as a
+     * different heading, or as no heading at all. */
+    if (name[0] == '#') {
+        snprintf(errbuf, (size_t)errbuf_size, "section name must not start with '#': %s", name);
+        return CBM_STORE_ERR;
+    }
+    for (size_t i = 0; i < len; i++) {
+        if (name[i] == '\n' || name[i] == '\r') {
+            snprintf(errbuf, (size_t)errbuf_size, "section name must not contain a line break");
+            return CBM_STORE_ERR;
+        }
+    }
+    if (name[0] == ' ' || name[0] == '\t' || name[len - SKIP_ONE] == ' ' ||
+        name[len - SKIP_ONE] == '\t') {
+        snprintf(errbuf, (size_t)errbuf_size,
+                 "section name must not start or end with whitespace: '%s'", name);
+        return CBM_STORE_ERR;
+    }
+    return CBM_STORE_OK;
+}
+
+int cbm_adr_validate_section_keys(const char **keys, int count, char *errbuf, int errbuf_size) {
+    /* Section names used to be restricted to the six canonical headings. They
+     * are now a convention rather than a privilege, so the only names refused
+     * are the ones that could not round-trip through a "## NAME" line. */
+    for (int i = 0; i < count; i++) {
+        if (cbm_adr_validate_section_name(keys[i], errbuf, errbuf_size) != CBM_STORE_OK) {
+            return CBM_STORE_ERR;
+        }
     }
     return CBM_STORE_OK;
 }
@@ -8906,35 +9183,32 @@ int cbm_store_adr_update_sections(cbm_store_t *s, const char *project, const cha
         return rc;
     }
 
-    /* Parse existing sections */
-    cbm_adr_sections_t sections = cbm_adr_parse_sections(existing.content);
-    cbm_store_adr_free(&existing);
-
-    /* Merge new sections */
-    for (int i = 0; i < count; i++) {
-        bool found = false;
-        for (int j = 0; j < sections.count; j++) {
-            if (strcmp(sections.keys[j], keys[i]) == 0) {
-                free(sections.values[j]);
-                sections.values[j] = heap_strdup(values[i]);
-                found = true;
-                break;
-            }
-        }
-        if (!found && sections.count < ST_BUF_16) {
-            sections.keys[sections.count] = heap_strdup(keys[i]);
-            sections.values[sections.count] = heap_strdup(values[i]);
-            sections.count++;
-        }
+    /* Splice each section in place. The document is NOT rebuilt from parsed
+     * sections: that model drops the preamble, drops headings it does not
+     * recognise (including a mis-cased '## Purpose', whose whole block then
+     * disappears) and reorders the rest, so rendering from it would silently
+     * rewrite text nobody asked to change. Replacing byte spans leaves every
+     * untouched byte exactly as it was. */
+    char structure_err[CBM_SZ_256] = "";
+    if (cbm_adr_check_structure(existing.content, structure_err, (int)sizeof(structure_err)) !=
+        CBM_STORE_OK) {
+        cbm_store_adr_free(&existing);
+        (void)cbm_store_rollback(s);
+        store_set_error(s, structure_err);
+        return CBM_STORE_ERR;
     }
 
-    /* Render merged */
-    char *merged = cbm_adr_render(&sections);
-    cbm_adr_sections_free(&sections);
+    char *merged = heap_strdup(existing.content ? existing.content : "");
+    cbm_store_adr_free(&existing);
+    for (int i = 0; merged && i < count; i++) {
+        char *next = cbm_adr_splice_section(merged, keys[i], values[i]);
+        free(merged);
+        merged = next;
+    }
 
     if (!merged) {
         (void)cbm_store_rollback(s);
-        store_set_error(s, "failed to render merged ADR");
+        store_set_error(s, "failed to splice ADR section");
         return CBM_STORE_ERR;
     }
 

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -877,6 +877,47 @@ int cbm_adr_validate_content(const char *content, char *errbuf, int errbuf_size)
 int cbm_adr_validate_section_keys(const char **keys, int count, char *errbuf, int errbuf_size);
 void cbm_adr_sections_free(cbm_adr_sections_t *s);
 
+/* ── ADR section headings (the splice model) ────────────────────
+ *
+ * A section write must not rebuild the document. cbm_adr_parse_sections() +
+ * cbm_adr_render() is a lossy model — it drops everything before the first
+ * heading, drops headings it does not recognise, and reorders what is left —
+ * so rebuilding from it silently rewrites text nobody asked to change. These
+ * functions locate a heading's byte span instead, so a write replaces that
+ * span and leaves every other byte of the document exactly as it was.
+ *
+ * A heading is a line of the form "## NAME" that is NOT inside a fenced code
+ * block. NAME is matched EXACTLY, including case: "## Purpose" and
+ * "## PURPOSE" are different sections, because folding them would silently
+ * merge two blocks the author chose to keep apart. The six canonical names
+ * are a convention (see ADR_EMPTY_HINT), not a privilege: any name that
+ * round-trips is a section, and none of them gets ordering priority. */
+typedef struct {
+    const char *name; /* into the source buffer; NOT NUL-terminated */
+    int name_len;
+    size_t heading_start; /* offset of the first '#' of the heading line */
+    size_t body_start;    /* offset just past the heading line's newline */
+    size_t body_end;      /* offset of the next heading, or end of document */
+} cbm_adr_heading_t;
+
+/* Reports every heading in document order. Returns CBM_STORE_ERR without
+ * calling `cb` when the document has an unterminated code fence: its structure
+ * is ambiguous, and guessing could splice into a code sample. */
+int cbm_adr_scan_headings(const char *content, void (*cb)(void *ctx, const cbm_adr_heading_t *h),
+                          void *ctx);
+
+/* CBM_STORE_ERR + message when the document cannot be spliced safely. */
+int cbm_adr_check_structure(const char *content, char *errbuf, int errbuf_size);
+
+/* Replaces the body of `name`, or appends the section when it is absent.
+ * Returns a new document (caller frees), or NULL on bad input, an unterminated
+ * fence, or OOM. Bytes outside the replaced span are preserved exactly, and
+ * splicing the same name and body twice is byte-identical to doing it once. */
+char *cbm_adr_splice_section(const char *content, const char *name, const char *body);
+
+/* Rejects names that could not round-trip through a "## NAME" heading. */
+int cbm_adr_validate_section_name(const char *name, char *errbuf, int errbuf_size);
+
 /* ── Search helpers (exposed for testing) ───────────────────────── */
 
 /* Convert a glob pattern to SQL LIKE pattern. Caller must free result. */

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -5847,6 +5847,285 @@ TEST(tool_manage_adr_rejects_removed_sections_argument) {
     PASS();
 }
 
+/* mode='set_sections' rewrites only the named sections. mode='update' replaces
+ * the whole document, so adding one entry costs a full re-send and every byte
+ * the caller did not mean to touch survives only as well as that round-trip. */
+TEST(tool_manage_adr_set_sections_replaces_only_named) {
+    const char *project = "adr-sec-named";
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    ASSERT_EQ(cbm_store_upsert_project(st, project, "/tmp/adr-sec-named"), CBM_STORE_OK);
+    cbm_mcp_server_set_project(srv, project);
+    ASSERT_EQ(cbm_store_adr_store(st, project, "## PURPOSE\nOriginal purpose.\n\n## STACK\nC."),
+              CBM_STORE_OK);
+
+    /* A section write is a mutation: it must take the per-project lease, or it
+     * runs concurrently with an index through a query-only store handle. */
+    mcp_mutation_guard_probe_t probe = {0};
+    cbm_mcp_server_set_project_mutation_guard(srv, mcp_mutation_guard_probe_begin,
+                                              mcp_mutation_guard_probe_end, &probe);
+
+    char *resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                                     "{\"project\":\"adr-sec-named\",\"mode\":\"set_sections\","
+                                     "\"section_updates\":{\"PATTERNS\":\"- Pipeline stages.\"}}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "sections_updated"));
+    ASSERT_NULL(strstr(resp, "\"isError\":true"));
+    free(resp);
+    ASSERT_EQ(probe.begin_count, 1);
+    ASSERT_EQ(probe.end_count, 1);
+    ASSERT_STR_EQ(probe.begin_projects[0], project);
+
+    /* The sections nobody named survive verbatim, and the named one landed. */
+    cbm_adr_t adr;
+    memset(&adr, 0, sizeof(adr));
+    ASSERT_EQ(cbm_store_adr_get(st, project, &adr), CBM_STORE_OK);
+    ASSERT_NOT_NULL(adr.content);
+    ASSERT_NOT_NULL(strstr(adr.content, "## PURPOSE\nOriginal purpose."));
+    ASSERT_NOT_NULL(strstr(adr.content, "## STACK\nC."));
+    ASSERT_NOT_NULL(strstr(adr.content, "## PATTERNS\n- Pipeline stages."));
+    cbm_store_adr_free(&adr);
+
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
+/* THE reason this shape was chosen over a whole-document append: applying the
+ * same request twice must leave the document byte-identical. An MCP client that
+ * loses a response and retries would silently duplicate an appended chunk. */
+TEST(tool_manage_adr_set_sections_is_idempotent) {
+    const char *project = "adr-sec-idem";
+    const char *request = "{\"project\":\"adr-sec-idem\",\"mode\":\"set_sections\","
+                          "\"section_updates\":{\"PATTERNS\":\"- Pipeline stages.\"}}";
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    ASSERT_EQ(cbm_store_upsert_project(st, project, "/tmp/adr-sec-idem"), CBM_STORE_OK);
+    cbm_mcp_server_set_project(srv, project);
+    ASSERT_EQ(cbm_store_adr_store(st, project, "## PURPOSE\nOriginal purpose.\n\n## STACK\nC."),
+              CBM_STORE_OK);
+
+    char *resp = cbm_mcp_handle_tool(srv, "manage_adr", request);
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "sections_updated"));
+    free(resp);
+
+    cbm_adr_t first;
+    memset(&first, 0, sizeof(first));
+    ASSERT_EQ(cbm_store_adr_get(st, project, &first), CBM_STORE_OK);
+    ASSERT_NOT_NULL(first.content);
+    char *after_first = strdup(first.content);
+    ASSERT_NOT_NULL(after_first);
+    cbm_store_adr_free(&first);
+
+    /* Replay the identical request — the lost-response retry. */
+    resp = cbm_mcp_handle_tool(srv, "manage_adr", request);
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "sections_updated"));
+    ASSERT_NULL(strstr(resp, "\"isError\":true"));
+    free(resp);
+
+    cbm_adr_t second;
+    memset(&second, 0, sizeof(second));
+    ASSERT_EQ(cbm_store_adr_get(st, project, &second), CBM_STORE_OK);
+    ASSERT_NOT_NULL(second.content);
+    ASSERT_STR_EQ(second.content, after_first);
+    /* And the body is present exactly once, not appended twice. */
+    const char *hit = strstr(second.content, "- Pipeline stages.");
+    ASSERT_NOT_NULL(hit);
+    ASSERT_NULL(strstr(hit + 1, "- Pipeline stages."));
+    cbm_store_adr_free(&second);
+    free(after_first);
+
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
+/* A project with no ADR yet degrades to a plain create rather than erroring:
+ * the store primitive requires an existing row, so the handler seeds one. */
+TEST(tool_manage_adr_set_sections_creates_when_absent) {
+    const char *project = "adr-sec-new";
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    ASSERT_EQ(cbm_store_upsert_project(st, project, "/tmp/adr-sec-new"), CBM_STORE_OK);
+    cbm_mcp_server_set_project(srv, project);
+
+    char *resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                                     "{\"project\":\"adr-sec-new\",\"mode\":\"set_sections\","
+                                     "\"section_updates\":{\"PURPOSE\":\"Only entry.\"}}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "sections_updated"));
+    ASSERT_NULL(strstr(resp, "\"isError\":true"));
+    free(resp);
+
+    cbm_adr_t adr;
+    memset(&adr, 0, sizeof(adr));
+    ASSERT_EQ(cbm_store_adr_get(st, project, &adr), CBM_STORE_OK);
+    /* Exact match: a create must not leave a leading separator behind. */
+    ASSERT_STR_EQ(adr.content, "## PURPOSE\nOnly entry.");
+    cbm_store_adr_free(&adr);
+
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
+/* set_sections without section_updates must fail loudly. Falling through to
+ * 'get' would hand a caller that meant to write a success-shaped read — and it
+ * must not take the mutation lease on the way to being rejected. */
+TEST(tool_manage_adr_set_sections_without_updates_errors) {
+    const char *project = "adr-sec-missing";
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    ASSERT_EQ(cbm_store_upsert_project(st, project, "/tmp/adr-sec-missing"), CBM_STORE_OK);
+    cbm_mcp_server_set_project(srv, project);
+    ASSERT_EQ(cbm_store_adr_store(st, project, "## PURPOSE\nUntouched.\n"), CBM_STORE_OK);
+
+    mcp_mutation_guard_probe_t probe = {0};
+    cbm_mcp_server_set_project_mutation_guard(srv, mcp_mutation_guard_probe_begin,
+                                              mcp_mutation_guard_probe_end, &probe);
+
+    char *resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                                     "{\"project\":\"adr-sec-missing\",\"mode\":\"set_sections\"}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "missing_section_updates"));
+    ASSERT_NOT_NULL(strstr(resp, "No ADR write was performed"));
+    ASSERT_NOT_NULL(strstr(resp, "\"isError\":true"));
+    ASSERT_NULL(strstr(resp, "adr_hint"));
+    free(resp);
+    ASSERT_EQ(probe.begin_count, 0);
+    ASSERT_EQ(probe.end_count, 0);
+
+    cbm_adr_t adr;
+    memset(&adr, 0, sizeof(adr));
+    ASSERT_EQ(cbm_store_adr_get(st, project, &adr), CBM_STORE_OK);
+    ASSERT_STR_EQ(adr.content, "## PURPOSE\nUntouched.\n");
+    cbm_store_adr_free(&adr);
+
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
+/* An empty body would render a heading with nothing under it — a content
+ * deletion wearing the response shape of an update. A non-canonical name would
+ * be parsed back as body text of the section above it, so writing it twice
+ * would duplicate it: both are rejected before any store is opened. */
+TEST(tool_manage_adr_set_sections_rejects_empty_and_unknown_sections) {
+    const char *project = "adr-sec-guards";
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    ASSERT_EQ(cbm_store_upsert_project(st, project, "/tmp/adr-sec-guards"), CBM_STORE_OK);
+    cbm_mcp_server_set_project(srv, project);
+    ASSERT_EQ(cbm_store_adr_store(st, project, "## PURPOSE\nUntouched.\n"), CBM_STORE_OK);
+
+    char *resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                                     "{\"project\":\"adr-sec-guards\",\"mode\":\"set_sections\","
+                                     "\"section_updates\":{\"PURPOSE\":\"\"}}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "empty_section_content"));
+    ASSERT_NOT_NULL(strstr(resp, "\"isError\":true"));
+    free(resp);
+
+    resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                               "{\"project\":\"adr-sec-guards\",\"mode\":\"set_sections\","
+                               "\"section_updates\":{\"DECISIONS\":\"- Chose SQLite.\"}}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "invalid_section_name"));
+    ASSERT_NOT_NULL(strstr(resp, "DECISIONS"));
+    ASSERT_NOT_NULL(strstr(resp, "\"isError\":true"));
+    free(resp);
+
+    resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                               "{\"project\":\"adr-sec-guards\",\"mode\":\"set_sections\","
+                               "\"section_updates\":{}}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "invalid_section_updates"));
+    ASSERT_NOT_NULL(strstr(resp, "\"isError\":true"));
+    free(resp);
+
+    /* Every rejection left the stored ADR byte-identical. */
+    cbm_adr_t adr;
+    memset(&adr, 0, sizeof(adr));
+    ASSERT_EQ(cbm_store_adr_get(st, project, &adr), CBM_STORE_OK);
+    ASSERT_STR_EQ(adr.content, "## PURPOSE\nUntouched.\n");
+    cbm_store_adr_free(&adr);
+
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
+/* CBM_ADR_MAX_LENGTH is enforced on this path — mode='update' bypasses it, so
+ * exposing an incremental writer without the cap would make unbounded growth
+ * cheap. The rejected merge must also roll back to the byte-identical prior
+ * document rather than leaving a half-applied write. */
+TEST(tool_manage_adr_set_sections_rejects_oversize) {
+    const char *project = "adr-sec-cap";
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    ASSERT_EQ(cbm_store_upsert_project(st, project, "/tmp/adr-sec-cap"), CBM_STORE_OK);
+    cbm_mcp_server_set_project(srv, project);
+    ASSERT_EQ(cbm_store_adr_store(st, project, "## PURPOSE\nSmall.\n"), CBM_STORE_OK);
+
+    size_t huge_len = (size_t)CBM_ADR_MAX_LENGTH + 100;
+    char *huge = malloc(huge_len + 1);
+    ASSERT_NOT_NULL(huge);
+    memset(huge, 'x', huge_len);
+    huge[huge_len] = '\0';
+
+    size_t args_len = huge_len + 256;
+    char *args = malloc(args_len);
+    ASSERT_NOT_NULL(args);
+    snprintf(args, args_len,
+             "{\"project\":\"adr-sec-cap\",\"mode\":\"set_sections\","
+             "\"section_updates\":{\"STACK\":\"%s\"}}",
+             huge);
+
+    char *resp = cbm_mcp_handle_tool(srv, "manage_adr", args);
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "write_error"));
+    ASSERT_NOT_NULL(strstr(resp, "exceeds"));
+    ASSERT_NOT_NULL(strstr(resp, "\"isError\":true"));
+    free(resp);
+    free(args);
+    free(huge);
+
+    cbm_adr_t adr;
+    memset(&adr, 0, sizeof(adr));
+    ASSERT_EQ(cbm_store_adr_get(st, project, &adr), CBM_STORE_OK);
+    ASSERT_STR_EQ(adr.content, "## PURPOSE\nSmall.\n");
+    cbm_store_adr_free(&adr);
+
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
+/* The mode must be advertised, or callers never learn it exists and keep
+ * paying for whole-document rewrites. */
+TEST(tool_manage_adr_set_sections_is_advertised) {
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    char *resp = cbm_mcp_server_handle(
+        srv, "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{}}");
+    ASSERT_NOT_NULL(resp);
+    const char *adr_tool = strstr(resp, "manage_adr");
+    ASSERT_NOT_NULL(adr_tool);
+    ASSERT_NOT_NULL(strstr(adr_tool, "set_sections"));
+    ASSERT_NOT_NULL(strstr(adr_tool, "section_updates"));
+    free(resp);
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
 TEST(tool_manage_adr_mutation_guard_balances_success) {
     const char *project = "guard-adr-success";
     cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
@@ -13163,6 +13442,13 @@ SUITE(mcp) {
     RUN_TEST(tool_manage_adr_get_with_existing_adr);
     RUN_TEST(tool_manage_adr_unified_backend_issue256);
     RUN_TEST(tool_manage_adr_rejects_removed_sections_argument);
+    RUN_TEST(tool_manage_adr_set_sections_replaces_only_named);
+    RUN_TEST(tool_manage_adr_set_sections_is_idempotent);
+    RUN_TEST(tool_manage_adr_set_sections_creates_when_absent);
+    RUN_TEST(tool_manage_adr_set_sections_without_updates_errors);
+    RUN_TEST(tool_manage_adr_set_sections_rejects_empty_and_unknown_sections);
+    RUN_TEST(tool_manage_adr_set_sections_rejects_oversize);
+    RUN_TEST(tool_manage_adr_set_sections_is_advertised);
     RUN_TEST(tool_index_repository_reports_store_backed_adr);
     RUN_TEST(tool_index_repository_resolves_root_path_from_project_name_issue1211);
     RUN_TEST(tool_index_repository_unknown_project_name_still_requires_repo_path);

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -6012,11 +6012,11 @@ TEST(tool_manage_adr_set_sections_without_updates_errors) {
     PASS();
 }
 
-/* An empty body would render a heading with nothing under it — a content
- * deletion wearing the response shape of an update. A non-canonical name would
- * be parsed back as body text of the section above it, so writing it twice
- * would duplicate it: both are rejected before any store is opened. */
-TEST(tool_manage_adr_set_sections_rejects_empty_and_unknown_sections) {
+/* An empty body would leave a heading with nothing under it — a content
+ * deletion wearing the response shape of an update. A name that cannot survive
+ * a "## NAME" round-trip would scan back as a different heading or as none, so
+ * writing it twice would duplicate it. Both are refused before a store opens. */
+TEST(tool_manage_adr_set_sections_rejects_unwritable_sections) {
     const char *project = "adr-sec-guards";
     cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
     ASSERT_NOT_NULL(srv);
@@ -6034,12 +6034,21 @@ TEST(tool_manage_adr_set_sections_rejects_empty_and_unknown_sections) {
     ASSERT_NOT_NULL(strstr(resp, "\"isError\":true"));
     free(resp);
 
+    /* A '#'-leading name would render "## # PURPOSE" and scan back different. */
     resp = cbm_mcp_handle_tool(srv, "manage_adr",
                                "{\"project\":\"adr-sec-guards\",\"mode\":\"set_sections\","
-                               "\"section_updates\":{\"DECISIONS\":\"- Chose SQLite.\"}}");
+                               "\"section_updates\":{\"# PURPOSE\":\"x\"}}");
     ASSERT_NOT_NULL(resp);
     ASSERT_NOT_NULL(strstr(resp, "invalid_section_name"));
-    ASSERT_NOT_NULL(strstr(resp, "DECISIONS"));
+    ASSERT_NOT_NULL(strstr(resp, "\"isError\":true"));
+    free(resp);
+
+    /* A newline in the name would forge a second heading line. */
+    resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                               "{\"project\":\"adr-sec-guards\",\"mode\":\"set_sections\","
+                               "\"section_updates\":{\"A\\nB\":\"x\"}}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "invalid_section_name"));
     ASSERT_NOT_NULL(strstr(resp, "\"isError\":true"));
     free(resp);
 
@@ -6056,6 +6065,201 @@ TEST(tool_manage_adr_set_sections_rejects_empty_and_unknown_sections) {
     memset(&adr, 0, sizeof(adr));
     ASSERT_EQ(cbm_store_adr_get(st, project, &adr), CBM_STORE_OK);
     ASSERT_STR_EQ(adr.content, "## PURPOSE\nUntouched.\n");
+    cbm_store_adr_free(&adr);
+
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
+/* The use case the whole change exists for: add an entry under its own
+ * heading, and be able to retry it. Under the old canonical-only rules this
+ * was the exact request that would have corrupted an ADR. */
+TEST(tool_manage_adr_set_sections_adds_custom_heading) {
+    const char *project = "adr-sec-custom";
+    const char *request = "{\"project\":\"adr-sec-custom\",\"mode\":\"set_sections\","
+                          "\"section_updates\":{\"DECISIONS\":\"- Chose SQLite.\"}}";
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    ASSERT_EQ(cbm_store_upsert_project(st, project, "/tmp/adr-sec-custom"), CBM_STORE_OK);
+    cbm_mcp_server_set_project(srv, project);
+    ASSERT_EQ(cbm_store_adr_store(st, project, "## PURPOSE\nFoo"), CBM_STORE_OK);
+
+    char *resp = cbm_mcp_handle_tool(srv, "manage_adr", request);
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "sections_updated"));
+    ASSERT_NULL(strstr(resp, "\"isError\":true"));
+    free(resp);
+
+    cbm_adr_t adr;
+    memset(&adr, 0, sizeof(adr));
+    ASSERT_EQ(cbm_store_adr_get(st, project, &adr), CBM_STORE_OK);
+    ASSERT_STR_EQ(adr.content, "## PURPOSE\nFoo\n\n## DECISIONS\n- Chose SQLite.");
+    cbm_store_adr_free(&adr);
+
+    /* Retry the identical request: byte-identical, not duplicated. */
+    resp = cbm_mcp_handle_tool(srv, "manage_adr", request);
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "sections_updated"));
+    free(resp);
+
+    memset(&adr, 0, sizeof(adr));
+    ASSERT_EQ(cbm_store_adr_get(st, project, &adr), CBM_STORE_OK);
+    ASSERT_STR_EQ(adr.content, "## PURPOSE\nFoo\n\n## DECISIONS\n- Chose SQLite.");
+    cbm_store_adr_free(&adr);
+
+    /* And it is now a real section the write path can target again. */
+    resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                               "{\"project\":\"adr-sec-custom\",\"mode\":\"set_sections\","
+                               "\"section_updates\":{\"DECISIONS\":\"- Chose DuckDB.\"}}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "sections_updated"));
+    free(resp);
+
+    memset(&adr, 0, sizeof(adr));
+    ASSERT_EQ(cbm_store_adr_get(st, project, &adr), CBM_STORE_OK);
+    ASSERT_STR_EQ(adr.content, "## PURPOSE\nFoo\n\n## DECISIONS\n- Chose DuckDB.");
+    cbm_store_adr_free(&adr);
+
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
+/* Regression for real data loss: rebuilding the document from parsed sections
+ * dropped the preamble, dropped a mis-cased heading together with its whole
+ * block, and reordered what survived. Splicing leaves all of it alone. */
+TEST(tool_manage_adr_set_sections_preserves_preamble_and_order) {
+    const char *project = "adr-sec-preserve";
+    /* The fenced block sits inside the mis-cased section, NOT the one being
+     * written: a section's body runs to the next heading, so rewriting STACK
+     * would legitimately replace a fence that belonged to STACK. */
+    const char *stored = "Notes before any heading.\n\n"
+                         "## Purpose\nMis-cased but real.\n\n"
+                         "```md\n## Example\nfenced sample\n```\n\n"
+                         "## STACK\nC and SQLite.\n\n"
+                         "## PURPOSE\nCanonical one.";
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    ASSERT_EQ(cbm_store_upsert_project(st, project, "/tmp/adr-sec-preserve"), CBM_STORE_OK);
+    cbm_mcp_server_set_project(srv, project);
+    ASSERT_EQ(cbm_store_adr_store(st, project, stored), CBM_STORE_OK);
+
+    char *resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                                     "{\"project\":\"adr-sec-preserve\",\"mode\":\"set_sections\","
+                                     "\"section_updates\":{\"STACK\":\"C only.\"}}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "sections_updated"));
+    free(resp);
+
+    cbm_adr_t adr;
+    memset(&adr, 0, sizeof(adr));
+    ASSERT_EQ(cbm_store_adr_get(st, project, &adr), CBM_STORE_OK);
+    ASSERT_STR_EQ(adr.content, "Notes before any heading.\n\n"
+                               "## Purpose\nMis-cased but real.\n\n"
+                               "```md\n## Example\nfenced sample\n```\n\n"
+                               "## STACK\nC only.\n\n"
+                               "## PURPOSE\nCanonical one.");
+    cbm_store_adr_free(&adr);
+
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
+/* An unterminated fence hides every heading after it, so a write would append
+ * a duplicate heading rather than replace the real one. Refuse, explicitly,
+ * and leave the document alone. */
+TEST(tool_manage_adr_set_sections_refuses_unterminated_fence) {
+    const char *project = "adr-sec-fence";
+    const char *stored = "## PURPOSE\nFoo\n\n```\nunclosed sample\n\n## STACK\nBar";
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    ASSERT_EQ(cbm_store_upsert_project(st, project, "/tmp/adr-sec-fence"), CBM_STORE_OK);
+    cbm_mcp_server_set_project(srv, project);
+    ASSERT_EQ(cbm_store_adr_store(st, project, stored), CBM_STORE_OK);
+
+    char *resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                                     "{\"project\":\"adr-sec-fence\",\"mode\":\"set_sections\","
+                                     "\"section_updates\":{\"STACK\":\"New bar.\"}}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "write_error"));
+    ASSERT_NOT_NULL(strstr(resp, "code fence"));
+    ASSERT_NOT_NULL(strstr(resp, "\"isError\":true"));
+    free(resp);
+
+    cbm_adr_t adr;
+    memset(&adr, 0, sizeof(adr));
+    ASSERT_EQ(cbm_store_adr_get(st, project, &adr), CBM_STORE_OK);
+    ASSERT_STR_EQ(adr.content, stored);
+    cbm_store_adr_free(&adr);
+
+    /* mode='sections' reports the same ambiguity rather than a partial list. */
+    resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                               "{\"project\":\"adr-sec-fence\",\"mode\":\"sections\"}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "unterminated_code_fence"));
+    free(resp);
+
+    cbm_mcp_server_free(srv);
+    PASS();
+}
+
+/* mode='sections' and the section write path must agree on what a heading is.
+ * They used to disagree — 'sections' listed every '#'-prefixed line, including
+ * ones inside code fences that no write could ever target — and two components
+ * disagreeing about what a section is is how a section write came to be able
+ * to destroy one. */
+TEST(tool_manage_adr_sections_agrees_with_write_path) {
+    const char *project = "adr-sec-agree";
+    const char *stored = "Preamble.\n\n"
+                         "# Title\n\n"
+                         "## PURPOSE\nFoo\n\n"
+                         "### Sub\n\n"
+                         "```md\n## Fenced\n```\n\n"
+                         "## DECISIONS\nBar";
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    cbm_store_t *st = cbm_mcp_server_store(srv);
+    ASSERT_NOT_NULL(st);
+    ASSERT_EQ(cbm_store_upsert_project(st, project, "/tmp/adr-sec-agree"), CBM_STORE_OK);
+    cbm_mcp_server_set_project(srv, project);
+    ASSERT_EQ(cbm_store_adr_store(st, project, stored), CBM_STORE_OK);
+
+    char *resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                                     "{\"project\":\"adr-sec-agree\",\"mode\":\"sections\"}");
+    ASSERT_NOT_NULL(resp);
+    /* Listed: exactly the two headings the write path can target. */
+    ASSERT_NOT_NULL(strstr(resp, "## PURPOSE"));
+    ASSERT_NOT_NULL(strstr(resp, "## DECISIONS"));
+    /* Not listed: a fenced '##', a '#' title, a '###' subheading. */
+    ASSERT_NULL(strstr(resp, "## Fenced"));
+    ASSERT_NULL(strstr(resp, "# Title"));
+    ASSERT_NULL(strstr(resp, "### Sub"));
+    free(resp);
+
+    /* Every listed heading is writable, and the unlisted ones stay as text. */
+    resp = cbm_mcp_handle_tool(srv, "manage_adr",
+                               "{\"project\":\"adr-sec-agree\",\"mode\":\"set_sections\","
+                               "\"section_updates\":{\"DECISIONS\":\"New bar\"}}");
+    ASSERT_NOT_NULL(resp);
+    ASSERT_NOT_NULL(strstr(resp, "sections_updated"));
+    free(resp);
+
+    /* The '#', '###' and fenced lines are body text of PURPOSE, and writing a
+     * different section leaves every byte of them alone. */
+    cbm_adr_t adr;
+    memset(&adr, 0, sizeof(adr));
+    ASSERT_EQ(cbm_store_adr_get(st, project, &adr), CBM_STORE_OK);
+    ASSERT_STR_EQ(adr.content, "Preamble.\n\n"
+                               "# Title\n\n"
+                               "## PURPOSE\nFoo\n\n"
+                               "### Sub\n\n"
+                               "```md\n## Fenced\n```\n\n"
+                               "## DECISIONS\nNew bar");
     cbm_store_adr_free(&adr);
 
     cbm_mcp_server_free(srv);
@@ -13446,7 +13650,11 @@ SUITE(mcp) {
     RUN_TEST(tool_manage_adr_set_sections_is_idempotent);
     RUN_TEST(tool_manage_adr_set_sections_creates_when_absent);
     RUN_TEST(tool_manage_adr_set_sections_without_updates_errors);
-    RUN_TEST(tool_manage_adr_set_sections_rejects_empty_and_unknown_sections);
+    RUN_TEST(tool_manage_adr_set_sections_rejects_unwritable_sections);
+    RUN_TEST(tool_manage_adr_set_sections_adds_custom_heading);
+    RUN_TEST(tool_manage_adr_set_sections_preserves_preamble_and_order);
+    RUN_TEST(tool_manage_adr_set_sections_refuses_unterminated_fence);
+    RUN_TEST(tool_manage_adr_sections_agrees_with_write_path);
     RUN_TEST(tool_manage_adr_set_sections_rejects_oversize);
     RUN_TEST(tool_manage_adr_set_sections_is_advertised);
     RUN_TEST(tool_index_repository_reports_store_backed_adr);

--- a/tests/test_store_arch.c
+++ b/tests/test_store_arch.c
@@ -1011,6 +1011,103 @@ TEST(adr_splice_preserves_untouched_bytes) {
     PASS();
 }
 
+/* Line endings. Every other ADR fixture in this file uses \n, so nothing
+ * exercised a CRLF-stored document — and CI could not have caught that,
+ * because the fixtures are LF whichever platform runs them.
+ *
+ * The exposure is specific to splicing: the old rebuild normalised everything
+ * on the way out, so ending confusion was invisible. A byte-span replacement
+ * can cut mid-"\r\n" or miscount a separator run, and byte-identity is the
+ * property this design exists to provide.
+ *
+ * Contract: bytes that already exist are never rewritten, so each line keeps
+ * whatever ending it had. Text this code writes itself — the separator before
+ * an appended section and the "## NAME" line — follows the document's majority
+ * ending, LF on a tie. A caller's body is inserted verbatim; rewriting the
+ * bytes a caller supplied would be the same silent modification this whole
+ * change removes. */
+TEST(adr_splice_preserves_line_endings) {
+    /* CRLF throughout: untouched bytes keep their \r\n. */
+    CHECK_SPLICE("## PURPOSE\r\nFoo\r\n\r\n## STACK\r\nBar", "STACK", "New bar",
+                 "## PURPOSE\r\nFoo\r\n\r\n## STACK\r\nNew bar");
+
+    /* The separator run before the next heading survives as CRLF, not as the
+     * two bare newlines a naive walk-back would leave. */
+    CHECK_SPLICE("## A\r\nx\r\n\r\n## B\r\ny", "A", "z", "## A\r\nz\r\n\r\n## B\r\ny");
+
+    /* A trailing CRLF on the document is preserved as CRLF. */
+    CHECK_SPLICE("## A\r\nx\r\n", "A", "z", "## A\r\nz\r\n");
+
+    /* Appending to a CRLF document writes CRLF — a bare \n here would leave a
+     * mixed document that neither the author nor the tool asked for. */
+    CHECK_SPLICE("## PURPOSE\r\nFoo", "DECISIONS", "- New.",
+                 "## PURPOSE\r\nFoo\r\n\r\n## DECISIONS\r\n- New.");
+
+    /* One existing trailing break means one more is added, counting \r\n as a
+     * single break rather than as two characters. */
+    CHECK_SPLICE("## PURPOSE\r\nFoo\r\n", "DECISIONS", "- New.",
+                 "## PURPOSE\r\nFoo\r\n\r\n## DECISIONS\r\n- New.");
+
+    /* A document already ending in a CRLF blank line gains no extra break. */
+    CHECK_SPLICE("## PURPOSE\r\nFoo\r\n\r\n", "DECISIONS", "- New.",
+                 "## PURPOSE\r\nFoo\r\n\r\n## DECISIONS\r\n- New.");
+
+    /* LF documents are unaffected by any of the above. */
+    CHECK_SPLICE("## PURPOSE\nFoo\n", "DECISIONS", "- New.",
+                 "## PURPOSE\nFoo\n\n## DECISIONS\n- New.");
+    PASS();
+}
+
+/* Mixed endings are what real files become through editors and merges. Lines
+ * that already exist keep their own endings; the majority decides only what
+ * this code writes itself. */
+TEST(adr_splice_mixed_line_endings) {
+    /* Majority CRLF (2 of 3) -> the appended block is CRLF, and the one bare
+     * LF line in the middle is left exactly as it was. */
+    CHECK_SPLICE("## PURPOSE\r\nFoo\nBar\r\n", "DECISIONS", "- New.",
+                 "## PURPOSE\r\nFoo\nBar\r\n\r\n## DECISIONS\r\n- New.");
+
+    /* Majority LF (2 of 3) -> the appended block is LF, and the lone CRLF line
+     * survives untouched. */
+    CHECK_SPLICE("## PURPOSE\nFoo\r\nBar\n", "DECISIONS", "- New.",
+                 "## PURPOSE\nFoo\r\nBar\n\n## DECISIONS\n- New.");
+
+    /* A tie falls to LF. */
+    CHECK_SPLICE("## PURPOSE\r\nFoo\n", "DECISIONS", "- New.",
+                 "## PURPOSE\r\nFoo\n\n## DECISIONS\n- New.");
+
+    /* Replacing a section in a mixed document rewrites nothing around it. */
+    CHECK_SPLICE("## PURPOSE\r\nFoo\n\n## STACK\nBar\r\n", "STACK", "New",
+                 "## PURPOSE\r\nFoo\n\n## STACK\nNew\r\n");
+    PASS();
+}
+
+/* "## PURPOSE\r\n" must locate exactly as "## PURPOSE\n" does. The scanner
+ * trims \r from heading names, but trimming and matching are different claims
+ * and only one of them was pinned. */
+TEST(adr_splice_matches_headings_across_line_endings) {
+    adr_name_collect_t c;
+    memset(&c, 0, sizeof(c));
+    ASSERT_EQ(cbm_adr_scan_headings("## PURPOSE\r\nFoo\r\n\r\n## STACK\r\nBar",
+                                    adr_collect_names, &c),
+              CBM_STORE_OK);
+    ASSERT_STR_EQ(c.buf, "[PURPOSE][STACK]");
+
+    /* A fenced block with CRLF still hides its heading, and still closes. */
+    memset(&c, 0, sizeof(c));
+    ASSERT_EQ(cbm_adr_scan_headings("## PURPOSE\r\nFoo\r\n\r\n```md\r\n## Example\r\n```"
+                                    "\r\n\r\n## STACK\r\nBar",
+                                    adr_collect_names, &c),
+              CBM_STORE_OK);
+    ASSERT_STR_EQ(c.buf, "[PURPOSE][STACK]");
+
+    /* And an unterminated CRLF fence is still refused. */
+    char errbuf[256];
+    ASSERT_TRUE(cbm_adr_check_structure("## PURPOSE\r\nFoo\r\n\r\n```\r\nopen\r\n", errbuf,
+                                        sizeof(errbuf)) != CBM_STORE_OK);
+    PASS();
+}
+
 /* The original use case: add an entry under its own heading. */
 TEST(adr_splice_appends_arbitrary_heading) {
     CHECK_SPLICE("## PURPOSE\nFoo", "DECISIONS", "- Chose SQLite.",
@@ -1620,6 +1717,9 @@ SUITE(store_arch) {
     RUN_TEST(adr_validate_keys_accepts_arbitrary_names);
     RUN_TEST(adr_validate_keys_rejects_unroundtrippable);
     RUN_TEST(adr_splice_preserves_untouched_bytes);
+    RUN_TEST(adr_splice_preserves_line_endings);
+    RUN_TEST(adr_splice_mixed_line_endings);
+    RUN_TEST(adr_splice_matches_headings_across_line_endings);
     RUN_TEST(adr_splice_appends_arbitrary_heading);
     RUN_TEST(adr_splice_is_idempotent);
     RUN_TEST(adr_splice_matches_case_exactly);

--- a/tests/test_store_arch.c
+++ b/tests/test_store_arch.c
@@ -908,12 +908,181 @@ TEST(adr_validate_keys_valid) {
     PASS();
 }
 
-TEST(adr_validate_keys_invalid) {
-    const char *keys[] = {"PURPOSE", "STACKS", "CUSTOM"};
+/* Section names are no longer restricted to the canonical six — those are a
+ * convention now, so "STACKS" and "CUSTOM" are ordinary sections. What is
+ * still refused is a name that could not round-trip through a "## NAME" line:
+ * such a name scans back as a different heading or as none, so a second
+ * identical write would append a duplicate instead of being a no-op. */
+TEST(adr_validate_keys_accepts_arbitrary_names) {
+    const char *keys[] = {"PURPOSE", "STACKS", "CUSTOM", "Decisions (2026)"};
     char errbuf[256];
-    ASSERT_TRUE(cbm_adr_validate_section_keys(keys, 3, errbuf, sizeof(errbuf)) != CBM_STORE_OK);
-    ASSERT_TRUE(strstr(errbuf, "STACKS") != NULL);
-    ASSERT_TRUE(strstr(errbuf, "CUSTOM") != NULL);
+    ASSERT_EQ(cbm_adr_validate_section_keys(keys, 4, errbuf, sizeof(errbuf)), CBM_STORE_OK);
+    PASS();
+}
+
+TEST(adr_validate_keys_rejects_unroundtrippable) {
+    char errbuf[256];
+    const char *empty[] = {""};
+    ASSERT_TRUE(cbm_adr_validate_section_keys(empty, 1, errbuf, sizeof(errbuf)) != CBM_STORE_OK);
+
+    const char *hashed[] = {"# PURPOSE"};
+    ASSERT_TRUE(cbm_adr_validate_section_keys(hashed, 1, errbuf, sizeof(errbuf)) != CBM_STORE_OK);
+
+    const char *newline[] = {"PUR\nPOSE"};
+    ASSERT_TRUE(cbm_adr_validate_section_keys(newline, 1, errbuf, sizeof(errbuf)) != CBM_STORE_OK);
+
+    const char *padded[] = {" PURPOSE "};
+    ASSERT_TRUE(cbm_adr_validate_section_keys(padded, 1, errbuf, sizeof(errbuf)) != CBM_STORE_OK);
+
+    char toolong[128];
+    memset(toolong, 'X', sizeof(toolong) - 1);
+    toolong[sizeof(toolong) - 1] = '\0';
+    const char *big[] = {toolong};
+    ASSERT_TRUE(cbm_adr_validate_section_keys(big, 1, errbuf, sizeof(errbuf)) != CBM_STORE_OK);
+    PASS();
+}
+
+/* ── Splice: bytes outside the target span never change ─────────── */
+
+typedef struct {
+    char buf[512];
+    int n;
+} adr_name_collect_t;
+
+static void adr_collect_names(void *ctx, const cbm_adr_heading_t *h) {
+    adr_name_collect_t *c = (adr_name_collect_t *)ctx;
+    c->n += snprintf(c->buf + c->n, sizeof(c->buf) - (size_t)c->n, "[%.*s]", h->name_len, h->name);
+}
+
+static int adr_check_splice(const char *in, const char *name, const char *body,
+                            const char *expect) {
+    char *out = cbm_adr_splice_section(in, name, body);
+    ASSERT_NOT_NULL(out);
+    if (strcmp(out, expect) != 0) {
+        printf("  %sFAIL%s %s: splice(\"%s\")\n    in     >>>%s<<<\n    got    >>>%s<<<\n"
+               "    expect >>>%s<<<\n",
+               tf_red(), tf_reset(), __FILE__, name, in, out, expect);
+        free(out);
+        return 1;
+    }
+    free(out);
+    return 0;
+}
+
+#define CHECK_SPLICE(in, name, body, expect)                                                       \
+    do {                                                                                           \
+        if (adr_check_splice((in), (name), (body), (expect)) != 0) {                               \
+            return 1;                                                                              \
+        }                                                                                          \
+    } while (0)
+
+/* THE acceptance property. Every document below is a case where rebuilding
+ * from cbm_adr_parse_sections() would have rewritten or destroyed text: a
+ * preamble (dropped), a mis-cased heading (dropped with its whole block), an
+ * unrecognised heading in prose (absorbed), a fenced '##' (absorbed), and
+ * out-of-canonical-order sections (reordered). Splicing touches only the
+ * target span, so each survives byte-for-byte. */
+TEST(adr_splice_preserves_untouched_bytes) {
+    /* Preamble before the first heading. */
+    CHECK_SPLICE("Some preamble.\n\n## PURPOSE\nFoo", "PURPOSE", "New foo",
+                 "Some preamble.\n\n## PURPOSE\nNew foo");
+
+    /* Mis-cased heading: a real section now, and untouched when not targeted. */
+    CHECK_SPLICE("## Purpose\nFoo\n\n## STACK\nBar", "STACK", "New bar",
+                 "## Purpose\nFoo\n\n## STACK\nNew bar");
+
+    /* A heading in prose that the old parser absorbed into the section above. */
+    CHECK_SPLICE("## PURPOSE\nFoo\n## CUSTOM\nStill here\n\n## STACK\nBar", "STACK", "New bar",
+                 "## PURPOSE\nFoo\n## CUSTOM\nStill here\n\n## STACK\nNew bar");
+
+    /* Fenced code containing a '##' line. */
+    CHECK_SPLICE("## PURPOSE\nFoo\n\n```md\n## Example\n```\n\n## STACK\nBar", "STACK", "New bar",
+                 "## PURPOSE\nFoo\n\n```md\n## Example\n```\n\n## STACK\nNew bar");
+
+    /* Sections stored out of canonical order keep the author's order. */
+    CHECK_SPLICE("## STACK\nBar\n\n## PURPOSE\nFoo", "PURPOSE", "New foo",
+                 "## STACK\nBar\n\n## PURPOSE\nNew foo");
+
+    /* The separator run before the next heading is preserved exactly. */
+    CHECK_SPLICE("## A\nx\n\n\n## B\ny", "A", "z", "## A\nz\n\n\n## B\ny");
+
+    /* A trailing newline on the document is preserved. */
+    CHECK_SPLICE("## A\nx\n", "A", "z", "## A\nz\n");
+    PASS();
+}
+
+/* The original use case: add an entry under its own heading. */
+TEST(adr_splice_appends_arbitrary_heading) {
+    CHECK_SPLICE("## PURPOSE\nFoo", "DECISIONS", "- Chose SQLite.",
+                 "## PURPOSE\nFoo\n\n## DECISIONS\n- Chose SQLite.");
+    /* A document already ending in a blank line does not gain another. */
+    CHECK_SPLICE("## PURPOSE\nFoo\n\n", "DECISIONS", "- Chose SQLite.",
+                 "## PURPOSE\nFoo\n\n## DECISIONS\n- Chose SQLite.");
+    /* An empty document becomes a plain create with no leading separator. */
+    CHECK_SPLICE("", "PURPOSE", "Only entry.", "## PURPOSE\nOnly entry.");
+    PASS();
+}
+
+/* Splicing twice must be byte-identical to splicing once — including for a
+ * non-canonical heading, the case that would have corrupted an ADR under the
+ * old rules. Trailing newlines on the body are normalised so the separator run
+ * cannot grow by a blank line on every repeat. */
+TEST(adr_splice_is_idempotent) {
+    const char *doc = "## PURPOSE\nFoo\n\n## STACK\nBar";
+    char *once = cbm_adr_splice_section(doc, "DECISIONS", "- Chose SQLite.\n");
+    ASSERT_NOT_NULL(once);
+    char *twice = cbm_adr_splice_section(once, "DECISIONS", "- Chose SQLite.\n");
+    ASSERT_NOT_NULL(twice);
+    ASSERT_STR_EQ(twice, once);
+    char *thrice = cbm_adr_splice_section(twice, "DECISIONS", "- Chose SQLite.\n");
+    ASSERT_NOT_NULL(thrice);
+    ASSERT_STR_EQ(thrice, once);
+    free(once);
+    free(twice);
+    free(thrice);
+    PASS();
+}
+
+/* Names match exactly, including case: folding them would silently merge two
+ * blocks the author chose to keep apart. */
+TEST(adr_splice_matches_case_exactly) {
+    CHECK_SPLICE("## Purpose\nLower\n\n## PURPOSE\nUpper", "PURPOSE", "New",
+                 "## Purpose\nLower\n\n## PURPOSE\nNew");
+    CHECK_SPLICE("## Purpose\nLower\n\n## PURPOSE\nUpper", "Purpose", "New",
+                 "## Purpose\nNew\n\n## PURPOSE\nUpper");
+    PASS();
+}
+
+/* A '##' line inside a fenced code block is a code sample, not a heading —
+ * and '#' / '###' are not section headings at any position. */
+TEST(adr_splice_ignores_heading_inside_fence) {
+    adr_name_collect_t c;
+    memset(&c, 0, sizeof(c));
+    ASSERT_EQ(cbm_adr_scan_headings(
+                  "## PURPOSE\nFoo\n\n```md\n## Example\n```\n\n### Sub\n# Title\n\n## STACK\nBar",
+                  adr_collect_names, &c),
+              CBM_STORE_OK);
+    ASSERT_STR_EQ(c.buf, "[PURPOSE][STACK]");
+    PASS();
+}
+
+/* An unterminated fence hides every heading after it, so an update would
+ * append a duplicate rather than replace. Refuse instead of guessing. */
+TEST(adr_splice_refuses_unterminated_fence) {
+    const char *doc = "## PURPOSE\nFoo\n\n```\nunclosed sample\n\n## STACK\nBar";
+    char errbuf[256];
+    ASSERT_TRUE(cbm_adr_check_structure(doc, errbuf, sizeof(errbuf)) != CBM_STORE_OK);
+    ASSERT_TRUE(strstr(errbuf, "code fence") != NULL);
+
+    adr_name_collect_t c;
+    memset(&c, 0, sizeof(c));
+    ASSERT_TRUE(cbm_adr_scan_headings(doc, adr_collect_names, &c) != CBM_STORE_OK);
+    ASSERT_EQ(c.n, 0);
+
+    ASSERT_NULL(cbm_adr_splice_section(doc, "STACK", "New bar"));
+
+    /* A closed fence is fine. */
+    ASSERT_EQ(cbm_adr_check_structure("## A\n```\nx\n```\n", errbuf, sizeof(errbuf)), CBM_STORE_OK);
     PASS();
 }
 
@@ -1448,7 +1617,14 @@ SUITE(store_arch) {
     RUN_TEST(adr_validate_missing_sections);
     RUN_TEST(adr_validate_empty);
     RUN_TEST(adr_validate_keys_valid);
-    RUN_TEST(adr_validate_keys_invalid);
+    RUN_TEST(adr_validate_keys_accepts_arbitrary_names);
+    RUN_TEST(adr_validate_keys_rejects_unroundtrippable);
+    RUN_TEST(adr_splice_preserves_untouched_bytes);
+    RUN_TEST(adr_splice_appends_arbitrary_heading);
+    RUN_TEST(adr_splice_is_idempotent);
+    RUN_TEST(adr_splice_matches_case_exactly);
+    RUN_TEST(adr_splice_ignores_heading_inside_fence);
+    RUN_TEST(adr_splice_refuses_unterminated_fence);
     RUN_TEST(adr_validate_keys_empty);
 
     /* Louvain */


### PR DESCRIPTION
Adds `manage_adr mode='set_sections'` — a retry-safe way to update named ADR sections — and fixes the document-rewriting it exposed. Distilled from #1243 with `Co-authored-by:` credit to @andis777, whose analysis and tests this builds on.

## Why sections rather than append

#1243 proposed whole-document `append`. It is **non-idempotent on client retry**: a lost response means a silently duplicated chunk. Section updates are retry-safe by construction — the same request twice produces the same document.

## The design that matters: splice, don't re-render

The first implementation merged by parsing the ADR, applying updates to the model, and re-rendering. **That silently destroyed content**, because `parse → render` is lossy today:

| document shape | old behaviour |
|---|---|
| preamble before the first heading | **dropped entirely** |
| `## Purpose` (wrong case) | not a heading → **whole block deleted** |
| `## CUSTOM` in prose | absorbed into the section above |
| fenced ` ```md / ## Example ` | absorbed |
| sections out of canonical order | silently reordered |
| multi-blank separator runs, trailing newline | collapsed / trimmed |

An ADR beginning `## Purpose` instead of `## PURPOSE` — an ordinary typo — would have lost that entire section on the first `set_sections` call. `mode='update'` never had this exposure because it writes the caller's bytes verbatim; the merge introduced it.

So the merge no longer rebuilds anything. `cbm_adr_splice_section` **locates the target heading's byte span and replaces only that span**, appending a block when the heading is absent. Nothing outside the span is reconstructed, so untouched bytes are byte-identical **by construction** rather than by care. Every row in that table is now a regression test asserting the exact expected document.

`cbm_adr_parse_sections` is untouched and **`TEST(adr_parse_sections_non_canonical)` passes unchanged** — documents parse exactly as they did. That test was the tripwire: wanting to edit it would have meant the design had drifted back toward re-rendering.

## Arbitrary headings now work

Custom headings are real sections, which is what the original request needed. `## DECISIONS` is simply a span to locate or a block to append — no format migration, because stored ADRs are never rewritten wholesale.

- **Exact case matching**: `## Purpose` and `## PURPOSE` are independently targetable in one document. Case-folding would silently merge two blocks a user deliberately kept apart.
- **Canonical sections become conventional, not privileged** — still the documented default set, but no ordering privilege and no required-presence. `cbm_adr_validate_section_keys` now rejects only names that cannot round-trip (empty, `#`-leading, newline-bearing, edge-whitespace, over-long).

## The fence locator, made refusable rather than destructive

A `##` inside a fenced block is a code sample, not a heading — pinned by test. An **unterminated** fence hides every heading after it, so a write would append a duplicate instead of replacing: that is **refused** with `write_error` naming the open fence, leaving the document byte-identical, and `mode='sections'` reports `unterminated_code_fence` rather than answering with a quietly partial list.

## One scanner, not two

`mode='sections'` previously used a different classifier from the store parser, so users were told `## CUSTOM` was a section while the store treated it as body text. `adr_list_sections_from_content` now calls the same `cbm_adr_scan_headings` the splice locates with, and a test pins that they agree — listing exactly the real headings on a document containing a preamble, `# Title`, `### Sub` and a fenced `## Fenced`, then writing one and asserting every unlisted line survives byte-for-byte.

## Three defects fixed along the way

1. **`write_request` classification** (`mcp.c`) — a new write mode absent from that list runs through a **query-only store handle with no mutation lease**. Asserted by a mutation-guard probe (`begin_count == 1`), not by reasoning; rejection paths assert `begin_count == 0` so a malformed write cannot block an index.
2. **Legacy-ADR data loss** — adding the mode to `write_request` *skips* the migration block that populates `legacy` (it is gated `!write_request` so it cannot block on the lease). The write path therefore reads the legacy file itself under the lease it already holds, rather than merging onto an empty document.
3. **Lost-update race** — `BEGIN IMMEDIATE` placed **inside** `cbm_store_adr_update_sections`, so it protects all three full-replace writers (MCP `update`, the UI at `http_server.c:939`, and the indexing pipeline at `pipeline.c:1763`), not just this call site.

## Verification

- `mcp store_arch store_nodes store_edges complexity httpd pipeline` → **700 passed, 7 skipped, 0 failed**.
- **Idempotence proved by revert**: breaking the merge to append-like produced exactly one failure — the idempotence test — confirming that test alone carries the property.
- **Three further surgical breaks** each failed the expected tests and only those: disabling fence awareness (4), dropping preserved separator runs (3), removing body newline normalisation (1). Reverted and green each time.
- All 13 new tests confirmed **by name** in runner output. Build exit code asserted before every run — it caught a test registered before its definition, where a stale binary would have reported the old result.
- Cap enforcement tested by observed failure, asserting the stored ADR is byte-identical afterwards (which also proves rollback).

## Known, not touched

`cbm_adr_validate_content` still requires all six canonical sections. It has zero production callers (tests only), so under "canonical is conventional" it is arguably stale — flagged rather than quietly redefined, since that was outside the decision made here.
