### PR TITLE
fix(tests): copy the runner, not /bin/cat, as the POSIX blocked image

### DIFF
--- a/tests/test_daemon_runtime.c
+++ b/tests/test_daemon_runtime.c
@@ -382,6 +382,9 @@ static bool runtime_test_copy_executable(const char *source, const char *destina
     return ok;
 }
 
+/* PATH must be a copy of this runner: the child runs the
+ * __cbm_runtime_image_holder mode, which blocks reading the release pipe
+ * wired to its stdin. */
 static pid_t runtime_test_spawn_blocked_executable(const char *path, int *release_fd_out) {
     int ready[2] = {-1, -1};
     int input[2] = {-1, -1};
@@ -427,7 +430,7 @@ static pid_t runtime_test_spawn_blocked_executable(const char *path, int *releas
     if (input[0] != STDIN_FILENO) {
         (void)posix_spawn_file_actions_addclose(&actions, input[0]);
     }
-    char *const child_argv[] = {(char *)path, NULL};
+    char *const child_argv[] = {(char *)path, "__cbm_runtime_image_holder", NULL};
     pid_t child = -1;
     if (posix_spawn(&child, path, &actions, NULL, child_argv, environ) != 0) {
         child = -1;
@@ -4518,10 +4521,20 @@ TEST(daemon_runtime_process_fingerprint_never_hashes_replacement_path) {
     int replacement_written =
         setup ? snprintf(replacement_path, sizeof(replacement_path), "%s/replacement", directory)
               : -1;
+    /* The copied image is this runner in holder mode, not a system utility:
+     * a multi-call coreutils /bin/cat (uutils) prints "unknown program" and
+     * exits when executed under the copied name. */
     setup = setup && image_written > 0 && image_written < (int)sizeof(image_path) &&
             replacement_written > 0 && replacement_written < (int)sizeof(replacement_path) &&
-            runtime_test_copy_executable("/bin/cat", image_path) &&
-            runtime_test_copy_executable("/bin/echo", replacement_path);
+            runtime_test_copy_self_image(image_path);
+
+    FILE *replacement_file = setup ? cbm_fopen(replacement_path, "wb") : NULL;
+    bool replacement_written_ok =
+        replacement_file && fputs("cbm-posix-replacement-image", replacement_file) >= 0;
+    if (replacement_file) {
+        replacement_written_ok = fclose(replacement_file) == 0 && replacement_written_ok;
+    }
+    setup = setup && replacement_written_ok;
 
     char original[CBM_DAEMON_BUILD_FINGERPRINT_SIZE] = {0};
     char replacement[CBM_DAEMON_BUILD_FINGERPRINT_SIZE] = {0};

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -503,9 +503,19 @@ static int tf_maybe_run_runtime_image_holder(int argc, char **argv) {
     Sleep(INFINITE);
     return 25;
 #else
-    (void)argc;
-    (void)argv;
-    return -1;
+    /* POSIX copied-image holder: block reading stdin until the parent closes
+     * the release pipe, exactly like the cat(1) donor this replaced. A system
+     * utility cannot serve as the copied image — a multi-call coreutils
+     * binary (uutils cat) refuses to execute under the copied name. */
+    if (argc != 2 || strcmp(argv[1], "__cbm_runtime_image_holder") != 0) {
+        return -1;
+    }
+    char release[16];
+    ssize_t count;
+    do {
+        count = read(STDIN_FILENO, release, sizeof(release));
+    } while (count > 0 || (count < 0 && errno == EINTR));
+    return count == 0 ? 0 : 25;
 #endif
 }
 


### PR DESCRIPTION
## Problem

`daemon_runtime_process_fingerprint_never_hashes_replacement_path` (POSIX variant) copies `/bin/cat` to a temp file named `image` and executes the copy. On Ubuntu 25.10+/26.04 — and any system with uutils/Rust coreutils — `/bin/cat` is a multi-call binary. A copy invoked under the name `image` prints `coreutils: unknown program 'image'` and exits 1, so the test fails at `ASSERT(setup)`.

Reproduced on WSL Ubuntu 26.04 (uutils coreutils 0.8.0):

```
$ cp /bin/cat "$d/image" && echo hi | "$d/image"
coreutils: unknown program 'image'
exit=1
```

## Fix

Mirror the Windows variant of the same test, which already copies the test runner and parks it in a `__cbm_runtime_image_holder` argv mode:

- `tests/test_main.c` — the `__cbm_runtime_image_holder` mode gains a POSIX branch: block reading stdin until EOF, exactly the behaviour the `cat` donor provided.
- `tests/test_daemon_runtime.c` — `runtime_test_spawn_blocked_executable` passes the holder argument; its target must now be a copy of the runner (it has exactly one caller). The POSIX fixture copies the runner via `runtime_test_copy_self_image` instead of `/bin/cat`.
- The `/bin/echo` replacement donor is gone too. It was only hashed, never executed — and on a uutils system `cat` and `echo` can be the same multi-call bytes, which would break the fixture's `original != replacement` precondition. The replacement is now a small data file, mirroring the Windows variant.

No macOS signing change is needed: the image copy stays byte-identical to the runner, and the identical-copy fixture already proves such a copy executes.

## Verification

`scripts/test.sh --suites daemon_runtime BUILD_DIR=build/wsl` on WSL Ubuntu 26.04 (uutils coreutils 0.8.0): **44 passed / 0 failed**, including `daemon_runtime_process_fingerprint_never_hashes_replacement_path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
