### PR TITLE
fix(extract): drop cgo's `import "C"` pseudo-package

### DIFF
--- a/internal/cbm/extract_imports.c
+++ b/internal/cbm/extract_imports.c
@@ -133,6 +133,19 @@ static void parse_go_import_spec(CBMExtractCtx *ctx, TSNode spec) {
         return;
     }
 
+    /* cgo: `import "C"` names the cgo PSEUDO-package, not a real one — "C" is
+     * reserved by go/build and no package with that import path can exist.
+     * Emitting it as an ordinary import makes the import resolver fall through
+     * to its symbol-name fallback (cbm_pipeline_resolve_import_node Strategy 3,
+     * pass_pkgmap.c), which matches the literal name "C" against every project
+     * node called C and picks the lexicographically smallest: on a real Go repo
+     * all 27 cgo files pointed their IMPORTS edge at the same unrelated `C`
+     * member of a test helper. Drop it — the C side is not a graph package, and
+     * the file's remaining imports are unaffected. */
+    if (strcmp(path, "C") == 0) {
+        return;
+    }
+
     TSNode name_node = ts_node_child_by_field_name(spec, TS_FIELD("name"));
     const char *local_name =
         !ts_node_is_null(name_node) ? cbm_node_text(a, name_node, ctx->source) : path_last(a, path);

--- a/tests/test_extraction.c
+++ b/tests/test_extraction.c
@@ -3015,6 +3015,25 @@ TEST(go_imports) {
     PASS();
 }
 
+/* cgo's `import "C"` is a pseudo-package, not a real import: keeping it lets the
+ * import resolver name-match "C" onto an arbitrary project symbol called C. The
+ * real imports of the same file must survive. */
+TEST(go_cgo_pseudo_import_dropped) {
+    CBMFileResult *r = extract("package m\n\n/*\nstatic int helper(void) { return 1; }\n*/\n"
+                               "import \"C\"\n\nimport \"fmt\"\n\n"
+                               "func Run() { fmt.Println(C.helper()) }\n",
+                               CBM_LANG_GO, "t", "cgo.go");
+    ASSERT_NOT_NULL(r);
+    ASSERT_FALSE(r->has_error);
+    ASSERT(has_import(r, "fmt"));
+    for (int i = 0; i < r->imports.count; i++) {
+        ASSERT_NOT_NULL(r->imports.items[i].module_path);
+        ASSERT_TRUE(strcmp(r->imports.items[i].module_path, "C") != 0);
+    }
+    cbm_free_result(r);
+    PASS();
+}
+
 /* #1935: Go struct fields were never extracted — find_class_body() returns the
  * struct_type node, whose only named child is a field_declaration_list, so the
  * member loop matched nothing and every field was silently skipped (0 Field
@@ -6752,6 +6771,7 @@ SUITE(extraction) {
     RUN_TEST(python_imports);
     RUN_TEST(js_imports);
     RUN_TEST(go_imports);
+    RUN_TEST(go_cgo_pseudo_import_dropped);
     RUN_TEST(extract_go_struct_fields_have_nodes);
     RUN_TEST(java_imports);
     RUN_TEST(rust_imports);


### PR DESCRIPTION
Fixes #1926

## Problem

`import "C"` is not an import. `"C"` is reserved by `go/build`; no package with that
import path can exist. The clause only tells the Go toolchain to compile the
immediately preceding comment block as C.

The Go import parser treats it as an ordinary import spec, so every cgo file's
import list — and therefore the per-file import map that call resolution
consults — carries a package that cannot exist. Dropping it at extraction is the
fix: Go-specific knowledge belongs in the Go import parser rather than in the
language-agnostic resolver.

### History: the false-edge symptom this PR originally led with

When #1926 was filed (2026-08-30), the pseudo-import also produced false `IMPORTS`
edges: it fell through Strategies 1 and 2 and landed in the Strategy 3 symbol-name
fallback (`src/pipeline/pass_pkgmap.c`), which bound all **27** cgo files of the
measured Go+C repository to the same unrelated `C` member of a test helper.

That measurement **predates `7d76b88f`** ("fix(pipeline): never bind a Go import to
a symbol", merged 2026-08-31 via #1938), which gates Strategy 3 off for Go entirely.
Re-measured on current `main` (`8972ea69`) against the same repository — which now
carries **54** `import "C"` files: `IMPORTS` edges with target `C` (by node name or
by `local_name`/`module` property): **0**. The Go `IMPORTS` target histogram is
100% `Folder` (2,303 edges). The false edges are gone exactly as the Strategy-3
gating predicts, so this PR no longer removes any edge; its effect is confined to
the extraction layer.

## Change

`internal/cbm/extract_imports.c`, `parse_go_import_spec()` — skip the spec when the
import path is exactly `"C"`, before the import is pushed. The guard cannot lose a
real import: `go/build` reserves the path, so no resolvable package can ever be
spelled `"C"`.

## Effect on current main

- The file's import list, and the per-file import map derived from it, no longer
  name a package that cannot exist — so import-closure reasoning (e.g. the
  penalty logic in `unique_name` resolution) never consults a phantom package.
- Graph shape is unchanged: the repository-level `IMPORTS` count with target `C`
  is 0 both before and after this change on current main; the pre-#1938 history
  above is what the original description measured.

## Test

`tests/test_extraction.c` — `go_cgo_pseudo_import_dropped`.

Reproduce-first (extraction-level, so it stays RED-capable regardless of the
resolver gating): RED without the extractor change —

```
go_cgo_pseudo_import_dropped   FAIL tests/test_extraction.c:2881:
  ASSERT(strcmp(r->imports.items[i].module_path, "C") != 0)
  318 passed, 1 failed
```

GREEN with it — `319 passed`.

The test also asserts the same file's real `fmt` import survives, so the fix cannot
regress into dropping the whole import block.

## Checks

- `scripts/test.sh --suites extraction` — 319 passed, 0 failed.
- `clang-format` clean on both edited hunks.
- `scripts/lint.sh` could not complete locally: `clang-tidy` and `cppcheck` are not
  installed on this machine. Relying on CI for those two legs.
