### PR TITLE
chore(deps): bump github/codeql-action init+analyze to v4.37.9 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y zlib1g-dev
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: c-cpp
           build-mode: manual
@@ -38,6 +38,6 @@ jobs:
         run: scripts/build.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:c-cpp"


### PR DESCRIPTION
Dependabot split this bump across two PRs — #1898 (`init`) and #1900 (`analyze`) — but `codeql-action` requires every step in a workflow to run the same version. Either PR alone produces a mismatch, and `analyze` fails fast with:

```
##[error]Loaded a configuration file for version '4.37.4', but running version '4.37.9'
```

So neither dependabot PR can ever be green on its own, and merging either one would leave `main`'s CodeQL job broken for every subsequent PR in the queue.

This bumps both pins in a single commit.

**Pin verification:** `cdf488f595d80d6e07e03d4674febd5ab45fa938` is the commit that the annotated tag `v4.37.9` dereferences to in `github/codeql-action`.

`.github/workflows/codeql.yml` is the only workflow using `init`/`analyze`; `scorecard.yml` uses only `upload-sarif` and was bumped independently in #1899.

Supersedes #1898 and #1900.