### PR TITLE
fix(coverage): stop reporting a duplicate range and a line past EOF (#963)

### DIFF
--- a/internal/cbm/cbm.c
+++ b/internal/cbm/cbm.c
@@ -794,12 +794,47 @@ typedef struct {
 } cbm_error_regions_t;
 
 static void cbm_error_regions_push(cbm_error_regions_t *acc, TSNode n) {
+    TSPoint start = ts_node_start_point(n);
+    TSPoint end = ts_node_end_point(n);
+    uint32_t start_line = start.row + 1;
+    uint32_t end_line = end.row + 1;
+
+    /* A node that ends at column 0 stopped right after the previous line's
+     * newline, so it holds no text on the row it points at. Counting that row
+     * named a line past the end of the file whenever the region ran to EOF:
+     * scripts/setup-windows.ps1 has 326 lines and reported "245-327". */
+    if (end.column == 0 && end.row > start.row) {
+        end_line = end.row;
+    }
+
+    /* One line can carry several error nodes, and repeating the same line range
+     * says nothing new. Line 113 of scripts/setup-windows.ps1 has two error
+     * nodes, at columns 25-29 and 31-32, and the report read "113-113,113-113".
+     * Drop the repeat.
+     *
+     * Only an EXACT repeat of the range already open is dropped. Do not merge
+     * ranges that merely overlap. Each range is judged separately later by
+     * cbm_region_is_recovered, which asks whether definitions starting inside
+     * that range cover it. Two ranges with the same numbers always get the same
+     * verdict, so collapsing them changes nothing. Two DIFFERENT ranges do not:
+     * merging 3-3 into 2-3 hands the wider range's covering definition to an
+     * error the definition does not explain, and a real parse failure then
+     * disappears from the report. tests/test_parse_coverage.c pins that case in
+     * perl_malformed_source_remains_partial_issue1838.
+     *
+     * This runs BEFORE the cap check, so a dropped repeat never counts as a
+     * range the cap threw away. */
+    if (acc->count > 0 && start_line == acc->starts[acc->count - 1] &&
+        end_line == acc->ends[acc->count - 1]) {
+        return;
+    }
+
     if (acc->count >= CBM_MAX_ERROR_REGIONS) {
         acc->dropped++;
         return;
     }
-    acc->starts[acc->count] = ts_node_start_point(n).row + 1;
-    acc->ends[acc->count] = ts_node_end_point(n).row + 1;
+    acc->starts[acc->count] = start_line;
+    acc->ends[acc->count] = end_line;
     acc->count++;
 }
 

--- a/tests/test_parse_coverage.c
+++ b/tests/test_parse_coverage.c
@@ -834,6 +834,51 @@ TEST(c_thread_local_grammar_limit_is_pinned_issue963) {
     PASS();
 }
 
+/* Two error nodes can sit on ONE line. Line 113 of scripts/setup-windows.ps1
+ * does exactly that, and the report used to read "113-113,113-113" — the same
+ * line named twice. A line range says nothing new the second time, so repeated
+ * or overlapping regions must collapse into one. */
+static const char *PS_TWO_ERRORS_ONE_LINE = "Write-Host \"start\"\n"             /* 1 */
+                                            "wsl.exe -- bash -c $Command 2>&1\n" /* 2 */
+                                            "Write-Host \"end\"\n";              /* 3 */
+
+/* An error region that runs to the end of the file stops just after the last
+ * newline. Tree-sitter calls that position row N, column 0 — a row that holds
+ * no text. Reading it as a line number named a line past the end of the file:
+ * scripts/setup-windows.ps1 has 326 lines and the report said "245-327". */
+static const char *PS_ERROR_TO_EOF = "} else {\n"             /* 1 */
+                                     "    if ($a) {\n"        /* 2 */
+                                     "        Write-Host x\n" /* 3 */
+                                     "}\n";                   /* 4 */
+
+TEST(coverage_repeated_error_line_reports_one_range_issue963) {
+    CBMFileResult *r =
+        cbm_extract_file(PS_TWO_ERRORS_ONE_LINE, (int)strlen(PS_TWO_ERRORS_ONE_LINE),
+                         CBM_LANG_POWERSHELL, "covproj", "two_errors.ps1", 0, NULL, NULL);
+    ASSERT_NOT_NULL(r);
+    ASSERT_TRUE(r->parse_incomplete);
+    ASSERT_NOT_NULL(r->error_ranges);
+    /* Line 2 carries two separate error nodes. It must be named once. */
+    ASSERT_STR_EQ(r->error_ranges, "2-2");
+    ASSERT_EQ(r->error_region_count, 1);
+    cbm_free_result(r);
+    PASS();
+}
+
+TEST(coverage_range_never_ends_past_the_last_line_issue963) {
+    int len = (int)strlen(PS_ERROR_TO_EOF);
+    CBMFileResult *r = cbm_extract_file(PS_ERROR_TO_EOF, len, CBM_LANG_POWERSHELL, "covproj",
+                                        "error_to_eof.ps1", 0, NULL, NULL);
+    ASSERT_NOT_NULL(r);
+    ASSERT_TRUE(r->parse_incomplete);
+    ASSERT_NOT_NULL(r->error_ranges);
+    /* The file has four lines and ends with a newline. Line 5 does not exist. */
+    ASSERT_STR_EQ(r->error_ranges, "1-4");
+    ASSERT_NULL(strstr(r->error_ranges, "5"));
+    cbm_free_result(r);
+    PASS();
+}
+
 SUITE(parse_coverage) {
     RUN_TEST(c_ifdef_split_brace_sets_parse_incomplete);
     RUN_TEST(c_ifdef_split_brace_neighbors_still_extracted);
@@ -870,4 +915,6 @@ SUITE(parse_coverage) {
     RUN_TEST(real_error_before_eof_still_flagged_with_trailing_blank_issue1746);
     RUN_TEST(width_bearing_error_at_eof_still_flagged_with_trailing_blank_issue1746);
     RUN_TEST(c_thread_local_grammar_limit_is_pinned_issue963);
+    RUN_TEST(coverage_repeated_error_line_reports_one_range_issue963);
+    RUN_TEST(coverage_range_never_ends_past_the_last_line_issue963);
 }


### PR DESCRIPTION
Two faults in one range string, both in `cbm_error_regions_push`. `scripts/setup-windows.ps1` has 326 lines and its parse-coverage report read:

```
113-113,113-113,245-327
```

The same line named twice, and an end line that does not exist. Found while building the coverage work in #1941 and filed rather than fixed there, at review request.

## The past-EOF end line

The tree-sitter node is `start=(244,2) end=(326,0)`. An end column of 0 means the node stopped right after the previous line's newline, so it holds no text on the row it points at. Adding 1 to that row to make it 1-based named a line past the end of the file whenever a region ran to EOF.

Fixed by clamping the end to the row above when the end column is 0 and the node spans more than one row.

## The duplicate range

Line 113 carries two separate ERROR nodes, at columns 25-29 and 31-32, and each pushed its own range. A line range is advice — "read these lines" — and it says nothing new the second time. Both copies also count against `CBM_MAX_ERROR_REGIONS`, so a file with many multi-error lines could be clipped while holding fewer distinct lines than the cap allows.

Fixed by dropping a range that **exactly repeats** the one already open — same start line and same end line. Ranges that merely overlap are left alone, and that distinction is the whole point.

Each range is judged later by `cbm_region_is_recovered`, which asks whether definitions starting inside the range cover it. Two ranges with identical numbers always get the same verdict, so dropping one changes nothing. Two different ranges do not: merging `3-3` into `2-3` hands the wider range's covering definition to an error that definition does not explain, and a real parse failure then disappears from a report whose only job is to be honest about failures. `perl_malformed_source_remains_partial_issue1838` pins that case.

The drop runs **before** the cap check, so a repeat that was never a distinct range is never counted as one the cap threw away.

The real file now reports `113-113,245-326`.

## Tests

Two, both proved RED first with the exact expected text:

| Test | Red output |
|:--|:--|
| `coverage_repeated_error_line_reports_one_range_issue963` | `"2-2,2-2"` != `"2-2"` |
| `coverage_range_never_ends_past_the_last_line_issue963` | `"1-5"` != `"1-4"` |

`parse_coverage`, `index_resilience` and `mcp`: 285 passed, 4 skipped. `make -f Makefile.cbm lint-format` clean.

## Stack order

This is the middle of three. #1941 merged as `aa44c28`, and this branch is now rebased onto it, so the diff here is exactly one commit — `e5c17de6`, `fix(coverage): stop reporting a duplicate range and a line past EOF`, touching only `internal/cbm/cbm.c` and `tests/test_parse_coverage.c`. #1968 stacks on this one and should merge after it.

| PR | Carries |
|:--|:--|
| ~~#1941~~ | the parse-coverage product work — merged as `aa44c28` |
| **this one** | the two range faults above |
| #1968 | the CI gate |

#1968 depends on this PR, not only on #1941: its allowlist entry quotes the post-fix figure of 25.2% for `setup-windows.ps1`, which is only true once the range above is corrected.

Closes #1965. Closes #1966. Part of #963.


