### PR TITLE
docs: name the history-growth cost of the team artifact, and how to bound it

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,13 @@ Commit a single compressed file to your repo and your teammates skip the reindex
   - **Best** (`zstd -9` + index strip + `VACUUM INTO`) — written on explicit `index_repository`
   - **Fast** (`zstd -3`) — written by the watcher for low-latency incremental updates
 - **Bootstrap**: when no local DB exists but the artifact is present, `index_repository` imports the artifact first, then runs incremental indexing — avoiding the full reindex cost
-- **No merge pain**: a `.gitattributes` line with `merge=ours` is auto-created on first export, so concurrent edits don't produce conflicts on the binary artifact
+- **No merge pain**: a `.codebase-memory/.gitattributes` line with `merge=ours` is auto-created on first export, so concurrent edits don't produce conflicts on the binary artifact
+- **Commit it deliberately**: the artifact is rewritten on every index, including the watcher's Fast tier, and git stores each rewrite as a full new blob. Committing every refresh is what turns a 20 MB file into gigabytes of history — one team reached ~6 GB across ~350 commits of this single path. Pick a cadence (a release, a milestone, a nightly job) rather than committing every save.
+- **Git LFS, if it must move on every commit**: track it from the **repo-root** `.gitattributes` and leave the auto-created `.codebase-memory/.gitattributes` in place — the nearer file goes on supplying `merge=ours`, and only `filter` comes from the root:
+  ```gitattributes
+  .codebase-memory/graph.db.zst filter=lfs diff=lfs merge=lfs -text
+  ```
+  Track only the `.zst`; `artifact.json` is small and carries the schema version. The attribute applies to future commits only, so a repo that already has the blobs in history needs `git-filter-repo` to rewrite them first. Two costs to weigh before adopting it: GitHub meters LFS storage and bandwidth, and its objects cannot be pruned without contacting support; and every teammate needs `git lfs install` — without it their checkout leaves a pointer file where the artifact should be, the integrity-checked import refuses it, and they fall back to a full reindex.
 - **Optional**: never committed unless you want it. Add `.codebase-memory/` to `.gitignore` if you prefer everyone to reindex from scratch.
 
 The result is similar in spirit to graphify's `graphify-out/` directory, but as a single compressed file with explicit two-tier export, integrity-checked import, and zero merge friction.


### PR DESCRIPTION
Distilled from #1697.

@angusgastle hit this on a real monorepo: the team-shared artifact regenerates on every index, they committed each regeneration, and history reached ~6 GB across ~350 commits of that one path. They measured it, rewrote it out with `git-filter-repo`, and reported a ~10x clone reduction afterwards. That is a real cost the README never warned about, and finding it is their credit.

This lands the guidance with two corrections.

**The instruction as written would not have worked.** #1697 said to replace the auto-created `merge=ours` line with `.codebase-memory/graph.db.zst filter=lfs …`. That line lives in `.codebase-memory/.gitattributes` with the bare pattern `graph.db.zst`, and a slash-bearing pattern inside that file anchors to `.codebase-memory/.codebase-memory/` — it matches nothing. Following it would silently leave LFS disengaged *and* drop `merge=ours`, which is worse than doing nothing, and `ensure_gitattributes` is `O_EXCL` create-only-if-absent (`src/pipeline/artifact.c:776`) so nothing repairs it later. The tracking line belongs in the repo-root `.gitattributes`, alongside the auto-created file rather than instead of it: gitattributes resolve per attribute from the nearest file outward, so `merge=ours` keeps coming from `.codebase-memory/` and only `filter=lfs` comes from the root.

**LFS is not free, and a recommendation we own should say so.** It relocates the bloat to a metered store — GitHub bills LFS storage and bandwidth, LFS objects cannot be pruned without contacting support, and a teammate without `git lfs install` checks out a pointer file, which the integrity-checked import refuses, dropping them back to the full reindex the artifact exists to avoid.

So the cheaper fix leads: **don't commit every regeneration.** LFS follows, for teams that genuinely need the artifact to move on every commit.

Also names the file the `merge=ours` line is written to. The old bullet said only "a `.gitattributes` line", which is what made the wrong placement the natural reading.

Docs only; no code paths touched.
