### PR TITLE
fix(ts): resolve inferred imported constructor receivers

### DIFF
--- a/internal/cbm/lsp/ts_lsp.c
+++ b/internal/cbm/lsp/ts_lsp.c
@@ -2176,10 +2176,19 @@ const CBMType *ts_eval_expr_type(TSLSPContext *ctx, TSNode node) {
         if (!ts_node_is_null(ctor)) {
             char *cname = node_text(ctx, ctor);
             if (cname) {
-                // Bare class name → qualify against module.
-                if (strchr(cname, '.') == NULL && ctx->module_qn) {
-                    const char *qn = cbm_arena_sprintf(ctx->arena, "%s.%s", ctx->module_qn, cname);
-                    result = cbm_type_named(ctx->arena, qn);
+                // Resolve lexical/import bindings before falling back to the
+                // current module. This preserves the imported class QN for
+                // inferred locals such as `const x = new ImportedClass()`.
+                if (strchr(cname, '.') == NULL) {
+                    const CBMType *bound = type_of_identifier(ctx, cname);
+                    if (bound && bound->kind == CBM_TYPE_NAMED &&
+                        bound->data.named.qualified_name) {
+                        result = bound;
+                    } else if (ctx->module_qn) {
+                        const char *qn =
+                            cbm_arena_sprintf(ctx->arena, "%s.%s", ctx->module_qn, cname);
+                        result = cbm_type_named(ctx->arena, qn);
+                    }
                 } else {
                     result = cbm_type_named(ctx->arena, cname);
                 }

--- a/tests/repro/repro_lsp_ts.c
+++ b/tests/repro/repro_lsp_ts.c
@@ -314,6 +314,14 @@ static const RFile kTsInferredImportedMethod[] = {
      "}\n"},
 };
 
+/* A standard-library class constructed through an inferred local variable must
+ * retain the bare stdlib QN so subsequent member dispatch finds Map.get. */
+static const char kTsInferredStdlibMethod[] =
+    "function lookup(id: string): string {\n"
+    "    const m = new Map<string, string>();\n"
+    "    return m.get(id);\n"
+    "}\n";
+
 /* lsp_ts_jsx — <Comp/> JSX element whose tag is a module-local component
  * function (ts_lsp.c:2643-2647). TSX only (jsx_mode); the tag's first letter is
  * uppercase so it is NOT treated as an intrinsic HTML element; it resolves via
@@ -395,6 +403,11 @@ TEST(repro_lsp_ts_inferred_import_receiver) {
         "lsp_ts_method");
 }
 
+TEST(repro_lsp_ts_inferred_stdlib_receiver) {
+    return assert_lsp_strategy("main.ts", kTsInferredStdlibMethod,
+                               "lsp_ts_method");
+}
+
 TEST(repro_lsp_ts_jsx) {
     return assert_lsp_strategy("app.tsx", kTsxJsx, "lsp_ts_jsx");
 }
@@ -429,6 +442,7 @@ SUITE(repro_lsp_ts) {
     RUN_TEST(repro_lsp_ts_namespace);
     RUN_TEST(repro_lsp_ts_import);
     RUN_TEST(repro_lsp_ts_inferred_import_receiver);
+    RUN_TEST(repro_lsp_ts_inferred_stdlib_receiver);
     RUN_TEST(repro_lsp_ts_jsx);
     RUN_TEST(repro_lsp_ts_jsx_import);
     RUN_TEST(repro_lsp_ts_default);

--- a/tests/repro/repro_lsp_ts.c
+++ b/tests/repro/repro_lsp_ts.c
@@ -297,6 +297,23 @@ static const RFile kTsImport[] = {
      "function caller(v: number): number { return helper(v); }\n"},
 };
 
+/* An imported class constructed through an inferred local variable must retain
+ * the imported class QN for subsequent member dispatch.  The explicit type
+ * annotation path already covers this shape; this fixture isolates inference.
+ */
+static const RFile kTsInferredImportedMethod[] = {
+    {"store.ts",
+     "export class WidgetStore {\n"
+     "    findById(id: string): string { return id; }\n"
+     "}\n"},
+    {"service.ts",
+     "import { WidgetStore } from \"./store\";\n"
+     "function load(id: string): string {\n"
+     "    const store = new WidgetStore();\n"
+     "    return store.findById(id);\n"
+     "}\n"},
+};
+
 /* lsp_ts_jsx — <Comp/> JSX element whose tag is a module-local component
  * function (ts_lsp.c:2643-2647). TSX only (jsx_mode); the tag's first letter is
  * uppercase so it is NOT treated as an intrinsic HTML element; it resolves via
@@ -370,6 +387,14 @@ TEST(repro_lsp_ts_import) {
         "lsp_ts_import");
 }
 
+TEST(repro_lsp_ts_inferred_import_receiver) {
+    return assert_lsp_strategy_files(
+        kTsInferredImportedMethod,
+        (int)(sizeof(kTsInferredImportedMethod) /
+              sizeof(kTsInferredImportedMethod[0])),
+        "lsp_ts_method");
+}
+
 TEST(repro_lsp_ts_jsx) {
     return assert_lsp_strategy("app.tsx", kTsxJsx, "lsp_ts_jsx");
 }
@@ -403,6 +428,7 @@ SUITE(repro_lsp_ts) {
     RUN_TEST(repro_lsp_ts_method);
     RUN_TEST(repro_lsp_ts_namespace);
     RUN_TEST(repro_lsp_ts_import);
+    RUN_TEST(repro_lsp_ts_inferred_import_receiver);
     RUN_TEST(repro_lsp_ts_jsx);
     RUN_TEST(repro_lsp_ts_jsx_import);
     RUN_TEST(repro_lsp_ts_default);


### PR DESCRIPTION
## What does this PR do?

Fixes #1974.

When TypeScript infers a local variable from `new Foo()`, resolve the constructor through the existing lexical/import type lookup before falling back to the current module. This preserves the imported class qualified name, so calls such as `store.findById()` produce the expected `CALLS` edge without changing explicitly annotated locals.

The same lookup also preserves the bare qualified names registered for TypeScript standard-library classes. Inferred `new Map<string, string>()` locals can therefore dispatch `m.get(id)` to the registered `Map.get` method instead of falling back to weak name-only resolution.

## Validation

- `ASAN_OPTIONS=detect_leaks=0 make -f Makefile.cbm test` — passed.
- `ASAN_OPTIONS=detect_leaks=0 make -f Makefile.cbm test-focused TEST_SUITES=ts_lsp` — passed (303 tests, including the inferred-stdlib receiver regression).
- `cppcheck` — passed.
- `git diff --check` — passed.
- `scripts/lint.sh --ci` — blocked by pre-existing clang-format violations in `src/mcp/mcp.c`, `src/pipeline/pipeline_incremental.c`, and `src/cli/cli.c`; no violation was reported for the changed implementation file.
- `make -f Makefile.cbm security` — static, binary-string, and UI audits passed; the existing robustness suite reported 26/32 due to input timeouts, and install/network checks are environment-limited in WSL.

## Checklist

- [x] Every commit is signed off (`git commit -s`).
- [x] Tests pass locally (with the repository's known sanitizer leak baseline disabled).
- [ ] Lint passes (blocked by unrelated existing format drift described above).
- [x] New behavior is covered by reproduce-first regression tests for imported and standard-library constructors.

## AI assistance

This change was prepared with AI assistance. The implementation, regression fixtures, and local validation should be reviewed by maintainers.
