### PR TITLE
test(cli): stop the registry plan check depending on the developer's machine

### DIFF
--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -6561,8 +6561,19 @@ TEST(cli_agent_client_registry_routes_plan_install_and_uninstall) {
     char *plan = cbm_build_install_plan_json(tmpdir, binary_path);
     yyjson_doc *plan_doc = plan ? yyjson_read(plan, strlen(plan), 0) : NULL;
     yyjson_val *plan_root = plan_doc ? yyjson_doc_get_root(plan_doc) : NULL;
+    /* Neither of these agents has a plugin directory, so a planned path under
+     * one would be invented. Name the two directories rather than searching the
+     * whole plan for "/plugins/": OpenCode does ship a real plugin file, and
+     * agent detection finds a command in /usr/local/bin or /opt/homebrew/bin
+     * whatever HOME and PATH say, so a blanket search passes or fails according
+     * to what the developer happens to have installed. */
+    char qoder_plugins[700];
+    char pi_plugins[700];
+    snprintf(qoder_plugins, sizeof(qoder_plugins), "%s/plugins/", qoder_dir);
+    snprintf(pi_plugins, sizeof(pi_plugins), "%s/plugins/", pi_dir);
     bool plan_ok =
-        plan && !strstr(plan, "/plugins/") && !strstr(plan, "plugin_files") &&
+        plan && !strstr(plan, qoder_plugins) && !strstr(plan, pi_plugins) &&
+        !strstr(plan, "plugin_files") &&
         test_json_string_array_contains(plan_root, "config_files_planned", qoder_settings) &&
         test_json_string_array_contains(plan_root, "config_files_planned", amazon_config) &&
         test_json_string_array_contains(plan_root, "config_files_planned", roo_config) &&


### PR DESCRIPTION
## The problem

`cli_agent_client_registry_routes_plan_install_and_uninstall` builds a fixture with its own `HOME` and `PATH`, then asserts the whole install plan contains no path with `/plugins/` in it.

Agent detection does not stay inside `HOME` and `PATH`. `cbm_find_cli` also looks in `/usr/local/bin` and, on macOS, `/opt/homebrew/bin`. A developer with OpenCode installed there has it detected inside the fixture, and OpenCode ships a real plugin file — so the plan legitimately carries a `/plugins/` path and the assertion fails. On a machine without OpenCode the same assertion passes, which is why CI has never seen it.

## The change

Name the two directories the check actually meant — the fixture's Qoder and Pi directories, neither of which has a plugin directory, so a planned path under one would be invented:

```c
char qoder_plugins[700];
char pi_plugins[700];
snprintf(qoder_plugins, sizeof(qoder_plugins), "%s/plugins/", qoder_dir);
snprintf(pi_plugins, sizeof(pi_plugins), "%s/plugins/", pi_dir);
```

The check now tests the same thing regardless of what the developer has installed.

One file, `tests/test_cli.c`, 12 insertions and 1 deletion. **No production behaviour changes.** Searching well-known install directories is deliberate, so that install finds an agent whose command is not on the current `PATH` — that is not what this touches.

## Evidence

Run on a machine that has OpenCode installed, so the trigger condition is present.

Before, at `c38aa35c`:

```
FAIL tests/test_cli.c:6725: CLI install/plan/uninstall must route the agent-client
registry, preserve foreign entries, and keep Pi free of invented MCP configuration
  cli_registry_installs_kimi_rovo_amp_durable_context
  Detected agents: OpenCode Kimi Code CLI Rovo Dev CLI Amp
```

After, on this branch:

```
cli_agent_client_registry_routes_plan_install_and_uninstall
  Detected agents: OpenCode Qoder CLI Roo Code Amazon Q Developer IDE Pi Sourcegraph Cody
```

OpenCode is detected in the fixture in both runs, so the condition that provokes the failure is present either way. The assertion fires in the first and not in the second.

## One thing worth stating plainly

The `cli` suite has other failures on this machine that this change does not address and does not claim to. They vary between runs — the agent-client install and uninstall assertions cannot drain a cohort while a permanent daemon is running, so the set differs each time. `origin/main` itself reports 536 passed / 6 failed here, and three of those six print the same `Detected agents: OpenCode` line, at `tests/test_cli.c:9390` and `:9491` alongside the one fixed here.

So this fixes one instance of a wider pattern rather than the whole pattern. I did not extend it to the other two, because the right fix for each depends on what its own assertion means and I did not want to guess that on your behalf. Happy to follow up on those if the approach here is the one you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERsNp8UNLaixL4uUz7hRTX
