### PR TITLE
fix(cli): drop the POSIX probe-counter store that Clang 23 rejects

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -1765,14 +1765,25 @@ static bool cbm_json_mcp_command_path_probe_safe(const char *command) {
 #endif
 
 #ifdef CBM_CLI_ENABLE_TEST_API
+#ifdef _WIN32
 static CBM_TLS int *g_mcp_command_path_probe_counter = NULL;
+#endif
 
 bool cbm_mcp_command_path_probe_safe_for_testing(const char *command, bool windows) {
     return cbm_json_mcp_command_path_probe_safe_for_platform(command, windows);
 }
 
 void cbm_set_mcp_command_path_probe_counter_for_testing(int *counter) {
+#ifdef _WIN32
     g_mcp_command_path_probe_counter = counter;
+#else
+    /* The command-path classifier (cbm_json_mcp_probe_command_path) is compiled
+     * for Windows only, so on POSIX there is no probe to count. The tests still
+     * install a counter on every platform and assert it stays at zero; a pointer
+     * stored here but never read is what Clang 23 rejects under -Werror
+     * (-Wunused-but-set-global). */
+    (void)counter;
+#endif
 }
 #endif
 


### PR DESCRIPTION
## What breaks

Since today, `brew install llvm` on the macOS LSan leg pours **LLVM 23.1.0** (the formula's new stable) instead of 22.1.8 — which bottle a runner gets depends on its Homebrew snapshot, so the leg is now red-or-green by draw. Under Clang 23 the test-runner build dies at:

```
src/cli/cli.c:1768:21: error: variable 'g_mcp_command_path_probe_counter' set but not used [-Werror,-Wunused-but-set-global]
```

First seen on #1811's run 33745916176 (reported by @pcristin — thank you). Any PR whose LSan runner draws the 23.1.0 bottle hits it.

## Why

`g_mcp_command_path_probe_counter` is only read inside `cbm_json_mcp_probe_command_path`, which is compiled for Windows alone (`cli.c:1968-2014`). On POSIX test builds the setter stored a pointer nothing ever read. Clang 23 is right: on POSIX the store is dead.

## Fix

Keep the counter where a probe can happen (Windows); make the POSIX setter an explicit no-op with the reason in place. The three `test_cli.c` tests that install a counter keep asserting it stays at zero on every platform — on POSIX that is exactly what "there is no classifier" means, so the assertion keeps its meaning rather than being relaxed.

## Verification

- **Smallest failing arena, reproduced**: `origin/main` `src/cli/cli.c` compiled with clang 23.1.1 and the Makefile's `CFLAGS_TEST` → the CI diagnostic verbatim. Same compile with this change → clean.
- **Widened**: all 105 built `src` TUs and all 155 test + extraction TUs compile clean under clang 23 with the same flags.
- `cli` suite with Homebrew LLVM 22.1.8: 292 passed. `clang-format --dry-run --Werror`: clean.

Not touched here: whether `_test.yml` should pin the formula (`llvm@22`) rather than float — that is a CI-scope choice and separate from making the code correct under the newer compiler.
