### PR TITLE
ci(lsan-macos): pin the Homebrew LLVM toolchain to llvm@22

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -311,8 +311,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Pinned: the unversioned `llvm` formula tracks Homebrew stable, so the
+      # leg's compiler changed under us when stable moved 22 -> 23 (a new
+      # -Wunused-but-set-global under -Werror broke the build on whichever
+      # runner drew the 23 bottle, and passed on the ones that drew 22). A
+      # test verdict must be a function of the code, not of the image snapshot;
+      # moving to a newer major is a deliberate one-line bump here.
       - name: Install LSan-capable toolchain
-        run: brew install llvm ccache
+        run: brew install llvm@22 ccache
 
       - name: Compiler cache (content-verified, restore)
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -327,7 +333,7 @@ jobs:
         env:
           ASAN_OPTIONS: "detect_leaks=1:halt_on_error=1"
         run: |
-          LLVM_PREFIX="$(brew --prefix llvm)"
+          LLVM_PREFIX="$(brew --prefix llvm@22)"
           scripts/test.sh CC="$LLVM_PREFIX/bin/clang" CXX="$LLVM_PREFIX/bin/clang++"
 
       - name: Compiler cache (save)


### PR DESCRIPTION
## Why

`test-lsan-macos` installs the unversioned `llvm` formula, which tracks Homebrew stable. Stable moved 22.1.8 → 23.1.0 today, so the leg's compiler now depends on which bottle the runner image happens to draw:

- run 33745916176 (#1811, 11:xx UTC) poured **23.1.0** and died at compile — `src/cli/cli.c:1768: -Wunused-but-set-global` under `-Werror`, a diagnostic new in Clang 23
- the run an hour earlier poured **22.1.8** and built fine

Same code, two verdicts. That is exactly the shape the suite is not allowed to have: a test's result must be a function of the code, not of the image snapshot.

## What

Two lines: `brew install llvm@22 ccache` and `brew --prefix llvm@22`, plus a comment saying why. `llvm@22` is at 22.1.8 — the version every green run of this leg has used so far, and the version the local `make -f Makefile.cbm test-lsan` / diag lanes are on.

Moving to a newer major becomes a deliberate edit of these two lines instead of an accident of the runner.

## Relation to #2027

#2027 fixes today's diagnostic so `main` compiles under both majors. This PR is about determinism of the leg; the two are independent and can land in either order.

## Scope flags (CI change)

- gating: unchanged (same job, same required status)
- cost: unchanged (one brew install either way; the versioned bottle is prebuilt)
- flake surface: reduced (one fewer environment-dependent input)
- trigger scope: unchanged
