### PR TITLE
smoke(8al-node): load the Pi extension with the modules the Pi host provides

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2339,6 +2339,35 @@ if command -v node >/dev/null 2>&1; then
   PI_NODE=$(command -v node)
   PI_PROBE_DIR="$TMPDIR/pi-node-probe"
   mkdir -p "$PI_PROBE_DIR"
+  # The extension is loaded by the Pi host, not by bare Node, so the probe
+  # provides what that host provides: Node's builtins plus the packages Pi
+  # ships to extensions (`typebox` — Pi's schema library for tool
+  # parameters). Every import the generated file makes must come from that
+  # set, otherwise it loads in this probe and fails in a real install with
+  # ERR_MODULE_NOT_FOUND. The typebox stub is a Proxy: any Type.X(...) call
+  # returns a descriptor, so the probe never depends on which helpers the
+  # emitter uses; it only exercises the tool lifecycle.
+  PI_HOST_PACKAGES="typebox"
+  mkdir -p "$PI_PROBE_DIR/node_modules/typebox"
+  cat >"$PI_PROBE_DIR/node_modules/typebox/package.json" <<'PITYPEBOXPKG'
+{ "name": "typebox", "version": "0.0.0-smoke-stub", "type": "module", "exports": "./index.mjs" }
+PITYPEBOXPKG
+  cat >"$PI_PROBE_DIR/node_modules/typebox/index.mjs" <<'PITYPEBOXSTUB'
+export const Type = new Proxy({}, {
+  get: (_target, helper) => (...args) => ({ smokeStubHelper: String(helper), args }),
+});
+export default { Type };
+PITYPEBOXSTUB
+  PI_FOREIGN_IMPORTS=$(grep -oE "^import .* from '[^']+'" "$PI_EXTENSION" |
+    sed -E "s/.* from '([^']+)'/\1/" | grep -vE '^node:' |
+    grep -vxF -f <(
+      # shellcheck disable=SC2086
+      printf '%s\n' $PI_HOST_PACKAGES
+    ) || true)
+  if [ -n "$PI_FOREIGN_IMPORTS" ]; then
+    echo "FAIL 8al-node: generated Pi extension imports packages the Pi host does not provide: $(echo "$PI_FOREIGN_IMPORTS" | tr '\n' ' ')"
+    exit 1
+  fi
   python3 - "$PI_EXTENSION" "$PI_PROBE_DIR/cbmem.mjs" <<'PYPIADAPTER'
 import pathlib
 import sys


### PR DESCRIPTION
## Why

`pr-smoke` 8al-node imports the generated Pi extension in bare Node with an empty `node_modules`. That was a faithful stand-in for the Pi host only while the extension imported nothing but `node:` builtins. #1809 adds the first package import — `typebox`, Pi's schema library for tool parameters, a real Pi dependency (verified against pi-coding-agent 0.84.4 by its author) — and the probe can never resolve it:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'typebox' imported from .../pi-node-probe/cbmem.mjs
FAIL 8al-node: generated Pi extension did not contain early-exit stdin errors
```

So the probe rejects a correct extension, and the failure message blames the wrong thing.

## What

Give the probe what the host gives the extension:

- a Proxy-backed `typebox` stub in the probe's `node_modules` — any `Type.X(...)` returns a descriptor, so the probe never has to track which helpers the emitter uses; it only exercises the tool lifecycle (EPIPE handling, JSON authority), exactly as before
- an explicit allowlist: every `import … from '<specifier>'` in the generated file must be a `node:` builtin or a package on `PI_HOST_PACKAGES` (currently `typebox`); anything else fails the probe **naming the specifier**. The empty `node_modules` used to give that "no surprise dependency" guarantee by accident; now it is an asserted contract with a readable failure.

Main's extension (only `node:child_process`) is unaffected.

## Verified

Ran only the 8al-node block against extensions generated by two binaries:

| extension | probe | result |
|---|---|---|
| main@5802ccdd | old | OK |
| main@5802ccdd | new | OK |
| #1809 (b026a690) | old | `ERR_MODULE_NOT_FOUND typebox` — the CI red |
| #1809 (b026a690) | new | OK |
| #1809 + injected `import lodash from 'lodash'` | new | `FAIL 8al-node: … packages the Pi host does not provide: lodash` |

## Scope flags (CI change)

- gating: unchanged (same smoke step, same venues; the C-only Linux image still SKIPs as whitelisted)
- cost: negligible (two small files written into the existing temp probe dir)
- flake surface: none added — no network, no install, no version resolution
- trigger scope: unchanged

Unblocks the maintainer-side half of #1809 (its remaining red, `test_agent_clients.c:1181`, is the PR's own and has been handed to the author).
