### PR TITLE
perf(ui): make the graph UI usable on very large projects (435k nodes / 4.2M edges)

### DIFF
--- a/graph-ui/src/components/EdgeLines.test.ts
+++ b/graph-ui/src/components/EdgeLines.test.ts
@@ -1,0 +1,130 @@
+/* @vitest-environment jsdom */
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import * as THREE from "three";
+import {
+  createEdgeBuffers,
+  fillEdgeBuffers,
+  useEdgeGeometry,
+} from "./EdgeLines";
+import type { GraphEdge, GraphNode } from "../lib/types";
+
+function node(id: number, x = 0): GraphNode {
+  return { id, x, y: 0, z: 0, label: "Function", name: `n${id}`, size: 1, color: "#fff" };
+}
+
+const NODES: GraphNode[] = [node(1, 0), node(2, 10), node(3, 20)];
+const EDGES: GraphEdge[] = [
+  { source: 1, target: 2, type: "CALLS" },
+  { source: 2, target: 3, type: "IMPORTS" },
+];
+
+describe("createEdgeBuffers / fillEdgeBuffers", () => {
+  it("allocates position/color attributes sized to capacity", () => {
+    const buf = createEdgeBuffers(2);
+    expect(buf.geometry.getAttribute("position").array.length).toBe(2 * 6);
+    expect(buf.geometry.getAttribute("color").array.length).toBe(2 * 6);
+    expect(buf.capacity).toBe(2);
+  });
+
+  it("fills positions/colors and sets the draw range to the valid edge count", () => {
+    const buf = createEdgeBuffers(EDGES.length);
+    const validCount = fillEdgeBuffers(buf, NODES, EDGES, null, undefined);
+    expect(validCount).toBe(2);
+    expect(buf.geometry.drawRange).toEqual({ start: 0, count: 4 });
+
+    const positions = buf.positionAttr.array as Float32Array;
+    /* First edge: node 1 (x=0) -> node 2 (x=10) */
+    expect(positions[0]).toBe(0);
+    expect(positions[3]).toBe(10);
+  });
+
+  it("skips edges with a dangling endpoint and still fills the valid ones", () => {
+    const buf = createEdgeBuffers(3);
+    const edgesWithDangling: GraphEdge[] = [
+      { source: 1, target: 999, type: "CALLS" },
+      ...EDGES,
+    ];
+    const validCount = fillEdgeBuffers(buf, NODES, edgesWithDangling, null, undefined);
+    expect(validCount).toBe(2);
+  });
+
+  it("refills the SAME TypedArray in place — no reallocation for equal capacity", () => {
+    const buf = createEdgeBuffers(EDGES.length);
+    const positionsArray = buf.positionAttr.array;
+    const colorsArray = buf.colorAttr.array;
+    fillEdgeBuffers(buf, NODES, EDGES, null, undefined);
+    fillEdgeBuffers(buf, NODES, EDGES, new Set([1, 2]), undefined);
+    expect(buf.positionAttr.array).toBe(positionsArray);
+    expect(buf.colorAttr.array).toBe(colorsArray);
+  });
+});
+
+describe("useEdgeGeometry", () => {
+  it("reuses the same geometry instance across re-renders when capacity doesn't grow (e.g. a brightness-only change)", () => {
+    const { result, rerender } = renderHook(
+      ({ highlightedIds }: { highlightedIds: Set<number> | null }) =>
+        useEdgeGeometry(NODES, EDGES, highlightedIds, undefined),
+      { initialProps: { highlightedIds: null as Set<number> | null } },
+    );
+
+    const first = result.current;
+    expect(first).toBeInstanceOf(THREE.BufferGeometry);
+
+    /* Simulate a brightness slider tick: brightness is applied to the
+     * material, not the geometry, so it is not even a hook input — but we
+     * also verify that re-rendering with the SAME edges/nodes/highlight
+     * (as happens on every brightness change) keeps the same geometry. */
+    rerender({ highlightedIds: null });
+    expect(result.current).toBe(first);
+
+    /* A highlight change refills in place too (same edge count → same
+     * capacity), so it must not allocate a new geometry either. */
+    rerender({ highlightedIds: new Set([1]) });
+    expect(result.current).toBe(first);
+  });
+
+  it("disposes the geometry when the capacity grows (new geometry replaces the old, disposed one)", () => {
+    const { result, rerender } = renderHook(
+      ({ edges }: { edges: GraphEdge[] }) =>
+        useEdgeGeometry(NODES, edges, null, undefined),
+      { initialProps: { edges: EDGES } },
+    );
+
+    const first = result.current;
+    const disposeSpy = vi.spyOn(first, "dispose");
+
+    const biggerEdges: GraphEdge[] = [
+      ...EDGES,
+      { source: 3, target: 1, type: "CALLS" },
+      { source: 1, target: 3, type: "IMPORTS" },
+    ];
+    rerender({ edges: biggerEdges });
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+    expect(result.current).not.toBe(first);
+  });
+
+  it("disposes the current geometry on unmount", () => {
+    const { result, unmount } = renderHook(() =>
+      useEdgeGeometry(NODES, EDGES, null, undefined),
+    );
+    const disposeSpy = vi.spyOn(result.current, "dispose");
+    unmount();
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("fills the geometry exactly once on mount (initializer, not initializer + effect)", () => {
+    /* createEdgeBuffers calls setDrawRange(0, 0) once at construction; a
+     * single fillEdgeBuffers call adds exactly one more setDrawRange call.
+     * A double fill (mount initializer + the effect's first, unguarded run)
+     * would show up as a third call. */
+    const setDrawRangeSpy = vi.spyOn(
+      THREE.BufferGeometry.prototype,
+      "setDrawRange",
+    );
+    renderHook(() => useEdgeGeometry(NODES, EDGES, null, undefined));
+    expect(setDrawRangeSpy).toHaveBeenCalledTimes(2);
+    setDrawRangeSpy.mockRestore();
+  });
+});

--- a/graph-ui/src/components/EdgeLines.tsx
+++ b/graph-ui/src/components/EdgeLines.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import type { GraphNode, GraphEdge } from "../lib/types";
 import { edgeIntensityScale } from "../lib/density";
@@ -8,8 +8,8 @@ interface EdgeLinesProps {
   edges: GraphEdge[];
   highlightedIds: Set<number> | null;
   opacity?: number;
-  /* User edge-brightness multiplier (see DisplaySettings). Layered on top of
-   * the automatic density scale. */
+  /* User edge-brightness multiplier (see DisplaySettings). Applied to the
+   * material color, never to the geometry buffers — see EdgeBuffers below. */
   brightness?: number;
   /* When set, edge.target is looked up in this array instead of `nodes`.
    * Used for cross-galaxy edges where source lives in the primary graph
@@ -51,6 +51,202 @@ const EDGE_TYPE_COLORS: Record<string, string> = {
 
 const DEFAULT_EDGE_COLOR = "#1C8585";
 
+/* ── Allocate-once / refill-in-place geometry management ──────────────
+ *
+ * The naive approach (a fresh THREE.BufferGeometry + two new Float32Arrays
+ * on every dependency change, handed to <lineSegments geometry={...}>) leaks:
+ * R3F does not dispose a geometry passed as a prop (only geometries it
+ * constructs itself via JSX), and three.js keeps a strong reference to every
+ * attribute of an undisposed geometry in WebGLBindingStates. On a
+ * 435k-node/4.2M-edge graph that is ~400MB of JS heap + ~200MB of GPU memory
+ * per brightness-slider tick, never reclaimed (#2039).
+ *
+ * Instead we keep one BufferGeometry per "capacity" (the largest edge count
+ * seen so far), preallocate its position/color attributes for that capacity,
+ * and on every data change just refill the live TypedArrays in place and
+ * adjust the draw range — no new geometry, no new attribute, no GC pressure.
+ * The geometry is only replaced (and the old one disposed) when the edge
+ * count grows past the current capacity, and it is always disposed on
+ * unmount. */
+
+interface EdgeBuffers {
+  geometry: THREE.BufferGeometry;
+  positionAttr: THREE.BufferAttribute;
+  colorAttr: THREE.BufferAttribute;
+  /** Number of edge "slots" currently allocated (each slot = one line = 2
+   * vertices = 6 floats per attribute). */
+  capacity: number;
+}
+
+export function createEdgeBuffers(capacity: number): EdgeBuffers {
+  const geometry = new THREE.BufferGeometry();
+  const positionAttr = new THREE.BufferAttribute(
+    new Float32Array(Math.max(1, capacity) * 6),
+    3,
+  );
+  const colorAttr = new THREE.BufferAttribute(
+    new Float32Array(Math.max(1, capacity) * 6),
+    3,
+  );
+  positionAttr.setUsage(THREE.DynamicDrawUsage);
+  colorAttr.setUsage(THREE.DynamicDrawUsage);
+  geometry.setAttribute("position", positionAttr);
+  geometry.setAttribute("color", colorAttr);
+  geometry.setDrawRange(0, 0);
+  return { geometry, positionAttr, colorAttr, capacity: Math.max(1, capacity) };
+}
+
+/** Refill `buffers`' position/color attributes in place from the given
+ * edges (never allocating new TypedArrays). Returns the number of valid
+ * (rendered) edges. Density scaling (automatic, edge-count based) is baked
+ * into the vertex colors here; the user brightness multiplier is NOT — it is
+ * applied on the material instead, so the slider never touches this data. */
+export function fillEdgeBuffers(
+  buffers: EdgeBuffers,
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  highlightedIds: Set<number> | null,
+  targetNodes: GraphNode[] | undefined,
+): number {
+  const densityScale = edgeIntensityScale(edges.length);
+  const srcMap = new Map<number, number>();
+  for (let i = 0; i < nodes.length; i++) {
+    srcMap.set(nodes[i].id, i);
+  }
+  const tgtArr = targetNodes ?? nodes;
+  const tgtMap = targetNodes ? new Map<number, number>() : srcMap;
+  if (targetNodes) {
+    for (let i = 0; i < targetNodes.length; i++) {
+      tgtMap.set(targetNodes[i].id, i);
+    }
+  }
+
+  const hasHighlight = highlightedIds && highlightedIds.size > 0;
+  const positions = buffers.positionAttr.array as Float32Array;
+  const colors = buffers.colorAttr.array as Float32Array;
+  const edgeColor = new THREE.Color();
+  let validCount = 0;
+
+  for (const edge of edges) {
+    const si = srcMap.get(edge.source);
+    const ti = tgtMap.get(edge.target);
+    if (si === undefined || ti === undefined) continue;
+
+    const s = nodes[si];
+    const t = tgtArr[ti];
+
+    const sHL = !hasHighlight || highlightedIds.has(s.id);
+    const tHL = !hasHighlight || highlightedIds.has(t.id);
+    if (hasHighlight && !sHL && !tHL) continue;
+
+    const sameCluster =
+      getClusterKey(s.file_path) === getClusterKey(t.file_path);
+
+    /* Intensity based on cluster membership and highlight.
+     * With additive blending + dark background, these glow nicely. */
+    let intensity = sameCluster ? 0.25 : 0.06;
+    if (hasHighlight) {
+      /* A selection stays at full strength (never density-scaled) so it
+       * pops against the dimmed rest; only the un-selected bulk is scaled. */
+      intensity = sHL && tHL ? 0.5 : 0.04 * densityScale;
+    } else {
+      intensity *= densityScale;
+    }
+
+    const off = validCount * 6;
+    positions[off] = s.x;
+    positions[off + 1] = s.y;
+    positions[off + 2] = s.z;
+    positions[off + 3] = t.x;
+    positions[off + 4] = t.y;
+    positions[off + 5] = t.z;
+
+    /* Color from edge TYPE (correlates with edge type filter) */
+    edgeColor.set(EDGE_TYPE_COLORS[edge.type] ?? DEFAULT_EDGE_COLOR);
+    colors[off] = edgeColor.r * intensity;
+    colors[off + 1] = edgeColor.g * intensity;
+    colors[off + 2] = edgeColor.b * intensity;
+    colors[off + 3] = edgeColor.r * intensity;
+    colors[off + 4] = edgeColor.g * intensity;
+    colors[off + 5] = edgeColor.b * intensity;
+    validCount++;
+  }
+
+  buffers.positionAttr.needsUpdate = true;
+  buffers.colorAttr.needsUpdate = true;
+  buffers.geometry.setDrawRange(0, validCount * 2);
+  return validCount;
+}
+
+/** Owns one EdgeBuffers for the lifetime of the component, growing (and
+ * disposing the previous geometry) only when the edge count exceeds the
+ * current capacity, and disposing on unmount. Brightness is intentionally
+ * NOT a dependency — it never touches the geometry. */
+export function useEdgeGeometry(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  highlightedIds: Set<number> | null,
+  targetNodes: GraphNode[] | undefined,
+): THREE.BufferGeometry {
+  /* Records the exact (by-reference) deps the mount initializer below filled
+   * the buffers with, so the effect's first run — which always fires with
+   * those same references, since it belongs to the same render — can skip
+   * redoing that fill. Without this, a 4.2M-edge mount fills the buffers
+   * twice: once synchronously (to avoid a one-tick empty-frame flash) and
+   * once more in the effect. */
+  const initialFillDeps = useRef<
+    | [GraphNode[], GraphEdge[], Set<number> | null, GraphNode[] | undefined]
+    | null
+  >(null);
+
+  const [buffers, setBuffers] = useState<EdgeBuffers>(() => {
+    /* Fill synchronously on first mount (not just in the effect below) so
+     * the first painted frame already has data instead of a one-tick flash
+     * of an empty draw range. */
+    const buf = createEdgeBuffers(edges.length);
+    fillEdgeBuffers(buf, nodes, edges, highlightedIds, targetNodes);
+    initialFillDeps.current = [nodes, edges, highlightedIds, targetNodes];
+    return buf;
+  });
+  /* Mirrors the latest `buffers` so the unmount cleanup (empty deps) always
+   * disposes the current geometry, not the one captured at mount time. */
+  const latest = useRef(buffers);
+  latest.current = buffers;
+
+  useEffect(() => {
+    const init = initialFillDeps.current;
+    initialFillDeps.current = null;
+    if (
+      init &&
+      init[0] === nodes &&
+      init[1] === edges &&
+      init[2] === highlightedIds &&
+      init[3] === targetNodes
+    ) {
+      /* Same references the initializer just filled with — skip the
+       * redundant refill. */
+      return;
+    }
+    setBuffers((prev) => {
+      let buf = prev;
+      if (edges.length > buf.capacity) {
+        prev.geometry.dispose();
+        buf = createEdgeBuffers(edges.length);
+      }
+      fillEdgeBuffers(buf, nodes, edges, highlightedIds, targetNodes);
+      return buf;
+    });
+  }, [nodes, edges, highlightedIds, targetNodes]);
+
+  useEffect(() => {
+    return () => {
+      latest.current.geometry.dispose();
+    };
+  }, []);
+
+  return buffers.geometry;
+}
+
 export function EdgeLines({
   nodes,
   edges,
@@ -59,90 +255,30 @@ export function EdgeLines({
   brightness = 1.0,
   targetNodes,
 }: EdgeLinesProps) {
-  const geometry = useMemo(() => {
-    /* Shrink per-edge glow as the edge count grows so the additively-blended
-     * center doesn't saturate to white; the user multiplier rides on top. */
-    const densityScale = edgeIntensityScale(edges.length) * brightness;
-    const srcMap = new Map<number, number>();
-    for (let i = 0; i < nodes.length; i++) {
-      srcMap.set(nodes[i].id, i);
-    }
-    const tgtArr = targetNodes ?? nodes;
-    const tgtMap = targetNodes ? new Map<number, number>() : srcMap;
-    if (targetNodes) {
-      for (let i = 0; i < targetNodes.length; i++) {
-        tgtMap.set(targetNodes[i].id, i);
-      }
-    }
-
-    const hasHighlight = highlightedIds && highlightedIds.size > 0;
-    const positions = new Float32Array(edges.length * 6);
-    const colors = new Float32Array(edges.length * 6);
-    let validCount = 0;
-
-    for (const edge of edges) {
-      const si = srcMap.get(edge.source);
-      const ti = tgtMap.get(edge.target);
-      if (si === undefined || ti === undefined) continue;
-
-      const s = nodes[si];
-      const t = tgtArr[ti];
-
-      const sHL = !hasHighlight || highlightedIds.has(s.id);
-      const tHL = !hasHighlight || highlightedIds.has(t.id);
-      if (hasHighlight && !sHL && !tHL) continue;
-
-      const sameCluster =
-        getClusterKey(s.file_path) === getClusterKey(t.file_path);
-
-      /* Intensity based on cluster membership and highlight.
-       * With additive blending + dark background, these glow nicely. */
-      let intensity = sameCluster ? 0.25 : 0.06;
-      if (hasHighlight) {
-        /* A selection stays at full strength (never density-scaled) so it
-         * pops against the dimmed rest; only the un-selected bulk is scaled. */
-        intensity = sHL && tHL ? 0.5 : 0.04 * densityScale;
-      } else {
-        intensity *= densityScale;
-      }
-
-      const off = validCount * 6;
-      positions[off] = s.x;
-      positions[off + 1] = s.y;
-      positions[off + 2] = s.z;
-      positions[off + 3] = t.x;
-      positions[off + 4] = t.y;
-      positions[off + 5] = t.z;
-
-      /* Color from edge TYPE (correlates with edge type filter) */
-      const edgeColor = new THREE.Color(
-        EDGE_TYPE_COLORS[edge.type] ?? DEFAULT_EDGE_COLOR,
-      );
-      colors[off] = edgeColor.r * intensity;
-      colors[off + 1] = edgeColor.g * intensity;
-      colors[off + 2] = edgeColor.b * intensity;
-      colors[off + 3] = edgeColor.r * intensity;
-      colors[off + 4] = edgeColor.g * intensity;
-      colors[off + 5] = edgeColor.b * intensity;
-      validCount++;
-    }
-
-    const geo = new THREE.BufferGeometry();
-    geo.setAttribute(
-      "position",
-      new THREE.BufferAttribute(positions.slice(0, validCount * 6), 3),
-    );
-    geo.setAttribute(
-      "color",
-      new THREE.BufferAttribute(colors.slice(0, validCount * 6), 3),
-    );
-    return geo;
-  }, [nodes, edges, highlightedIds, targetNodes, brightness]);
+  const geometry = useEdgeGeometry(nodes, edges, highlightedIds, targetNodes);
 
   return (
-    <lineSegments geometry={geometry}>
+    /* frustumCulled={false}, not a computeBoundingSphere() call after every
+     * fill: geometry.boundingSphere is computed lazily once (by Line's
+     * raycast or by WebGLRenderer's frustum check) and then goes stale on
+     * every in-place refill above, same as NodePoints — but unlike
+     * NodePoints, these lineSegments have no pointer handlers, so raycast
+     * accuracy doesn't matter here, only "don't let a stale sphere
+     * frustum-cull the whole edge cloud" does. Opting out of culling is
+     * cheaper than rescanning a potentially multi-million-vertex buffer on
+     * every highlight/filter change just to keep the sphere fresh, and
+     * matches NodeCloud's InstancedMesh path, which already does the same. */
+    <lineSegments geometry={geometry} frustumCulled={false}>
+      {/* LineBasicMaterial multiplies the vertex color by material.color
+       * when vertexColors is set, so the brightness slider rides entirely on
+       * this tiny material uniform — it never touches the (potentially
+       * millions-of-floats) geometry attributes above. A new array literal
+       * each render is intentional: it is what makes R3F re-apply `.set()`
+       * on the material's color, since mutating a stable Color instance in
+       * place would not be detected by R3F's prop diff. */}
       <lineBasicMaterial
         vertexColors
+        color={[brightness, brightness, brightness]}
         transparent
         opacity={opacity}
         blending={THREE.AdditiveBlending}

--- a/graph-ui/src/components/GraphTab.edgeSampling.test.tsx
+++ b/graph-ui/src/components/GraphTab.edgeSampling.test.tsx
@@ -1,0 +1,90 @@
+/* @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GraphTab } from "./GraphTab";
+import type { GraphData } from "../lib/types";
+
+/* GraphScene renders a WebGL <Canvas> which jsdom can't run — stub it out.
+ * This also means the test below never actually exercises EdgeLines; it
+ * targets GraphTab's own wiring (graphIndex / highlight / detail panel),
+ * which is exactly what the regression was in. */
+vi.mock("./GraphScene", () => ({
+  GraphScene: () => null,
+  computeCameraTarget: () => null,
+}));
+
+/* Force the edge render budget down to 1 so a tiny two-edge test graph
+ * already exercises the "most edges got sampled away for rendering" path,
+ * without needing a million-edge fixture. sampleEdges' real (deterministic,
+ * stride-based) implementation is kept. */
+vi.mock("../lib/edgeBudget", async () => {
+  const actual =
+    await vi.importActual<typeof import("../lib/edgeBudget")>(
+      "../lib/edgeBudget",
+    );
+  return { ...actual, EDGE_RENDER_LIMIT: 1 };
+});
+
+/* bar (id 2) has one inbound edge (foo -> bar) and one outbound edge
+ * (bar -> baz). With EDGE_RENDER_LIMIT mocked to 1, only one of the two
+ * edges survives sampling for EdgeLines — but graphIndex, the highlight set,
+ * and NodeDetailPanel's connections must still see both, since they read
+ * the unsampled filtered edge list. */
+const DATA: GraphData = {
+  nodes: [
+    { id: 1, x: 0, y: 0, z: 0, label: "Function", name: "foo", file_path: "src/foo.ts", size: 1, color: "#fff" },
+    { id: 2, x: 1, y: 0, z: 0, label: "Function", name: "bar", file_path: "src/bar.ts", size: 1, color: "#fff" },
+    { id: 3, x: 2, y: 0, z: 0, label: "Function", name: "baz", file_path: "src/baz.ts", size: 1, color: "#fff" },
+  ],
+  edges: [
+    { source: 1, target: 2, type: "CALLS" },
+    { source: 2, target: 3, type: "CALLS" },
+  ],
+  total_nodes: 3,
+};
+
+function mockLayoutFetch(data: GraphData) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.startsWith("/api/layout")) {
+      return new Response(JSON.stringify(data), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("{}", { status: 200 });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+describe("GraphTab edge render sampling does not affect connectivity", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("still highlights and lists all direct connections for a node whose edges were sampled away for rendering", async () => {
+    mockLayoutFetch(DATA);
+    render(<GraphTab project="demo" />);
+
+    expect(await screen.findByText("Filters")).toBeInTheDocument();
+
+    /* Select bar (id 2), which connects to both foo and baz. */
+    fireEvent.click(screen.getByRole("button", { name: /src/ }));
+    fireEvent.click(screen.getByRole("button", { name: /^bar/ }));
+
+    /* Highlight must include bar + foo + baz, even though the render
+     * budget only kept one of the two edges for EdgeLines. */
+    expect(screen.getByText("3 selected")).toBeInTheDocument();
+
+    /* The detail panel must show both connections, not "No connections". */
+    expect(screen.getByRole("heading", { name: "bar" })).toBeInTheDocument();
+    expect(screen.queryByText("No connections")).not.toBeInTheDocument();
+    expect(screen.getByText("References")).toBeInTheDocument();
+    expect(screen.getByText("Referenced by")).toBeInTheDocument();
+
+    /* Total connection count (Out + In) is 2. */
+    const total = screen.getByText("Total").parentElement;
+    expect(total).toHaveTextContent("2");
+  });
+});

--- a/graph-ui/src/components/GraphTab.test.ts
+++ b/graph-ui/src/components/GraphTab.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { formatGraphLimitNotice } from "./GraphTab";
+import {
+  formatGraphLimitNotice,
+  formatEdgeLimitNotice,
+  type FilteredGraphData,
+} from "./GraphTab";
 import type { GraphData } from "../lib/types";
 
 describe("formatGraphLimitNotice", () => {
@@ -32,5 +36,39 @@ describe("formatGraphLimitNotice", () => {
     } satisfies GraphData;
 
     expect(formatGraphLimitNotice(data)).toBeNull();
+  });
+});
+
+describe("formatEdgeLimitNotice", () => {
+  it("reports when edges were sampled down to the render budget", () => {
+    const data = {
+      nodes: [],
+      edges: Array.from({ length: 1_000_000 }, (_, i) => ({
+        source: i,
+        target: i + 1,
+        type: "CALLS",
+      })),
+      total_nodes: 0,
+      edgeFilterTotal: 4_200_000,
+    } satisfies FilteredGraphData;
+
+    expect(formatEdgeLimitNotice(data)).toBe(
+      "Rendering 1,000,000 of 4,200,000 edges (render budget). Use filters to narrow further.",
+    );
+  });
+
+  it("stays quiet when every filtered edge is rendered", () => {
+    const data = {
+      nodes: [],
+      edges: [],
+      total_nodes: 0,
+      edgeFilterTotal: 0,
+    } satisfies FilteredGraphData;
+
+    expect(formatEdgeLimitNotice(data)).toBeNull();
+  });
+
+  it("stays quiet for null data", () => {
+    expect(formatEdgeLimitNotice(null)).toBeNull();
   });
 });

--- a/graph-ui/src/components/GraphTab.tsx
+++ b/graph-ui/src/components/GraphTab.tsx
@@ -27,6 +27,7 @@ import { ResizeHandle } from "./ResizeHandle";
 import { ErrorBoundary } from "./ErrorBoundary";
 import type { GraphNode, GraphData, RepoInfo } from "../lib/types";
 import { colorForStatus } from "../lib/colors";
+import { EDGE_RENDER_LIMIT, sampleEdges } from "../lib/edgeBudget";
 
 /* Persist panel widths */
 function loadWidth(key: string, fallback: number): number {
@@ -62,6 +63,19 @@ interface GraphTabProps {
 export function formatGraphLimitNotice(data: GraphData | null): string | null {
   if (!data || data.total_nodes <= data.nodes.length) return null;
   return `Showing ${data.nodes.length.toLocaleString("en-US")} of ${data.total_nodes.toLocaleString("en-US")} nodes (${data.edges.length.toLocaleString("en-US")} edges). Raise the node budget or use filters.`;
+}
+
+/** Filtered graph data, plus how many edges matched the current filters
+ * before the render budget (EDGE_RENDER_LIMIT) sampled them down. */
+export interface FilteredGraphData extends GraphData {
+  edgeFilterTotal: number;
+}
+
+export function formatEdgeLimitNotice(
+  data: FilteredGraphData | null,
+): string | null {
+  if (!data || data.edgeFilterTotal <= data.edges.length) return null;
+  return `Rendering ${data.edges.length.toLocaleString("en-US")} of ${data.edgeFilterTotal.toLocaleString("en-US")} edges (render budget). Use filters to narrow further.`;
 }
 
 export function GraphTab({ project }: GraphTabProps) {
@@ -130,7 +144,7 @@ export function GraphTab({ project }: GraphTabProps) {
   }, [data]);
 
   /* Compute filtered data */
-  const filteredData: GraphData | null = useMemo(() => {
+  const filteredData: FilteredGraphData | null = useMemo(() => {
     if (!data) return null;
 
     /* Status-based filters (dead-code view) */
@@ -147,28 +161,44 @@ export function GraphTab({ project }: GraphTabProps) {
 
     const nodes = data.nodes.filter(keep).map(paint);
     const nodeIds = new Set(nodes.map((n) => n.id));
-    const edges = data.edges.filter(
+    const filteredEdges = data.edges.filter(
       (e) =>
         enabledEdgeTypes.has(e.type) &&
         nodeIds.has(e.source) &&
         nodeIds.has(e.target),
     );
+    /* Cap what actually reaches EdgeLines — a deterministic sample so the
+     * geometry buffers built downstream stay bounded on huge graphs (#2039)
+     * regardless of how many edges survived filtering. */
+    const edges = sampleEdges(filteredEdges, EDGE_RENDER_LIMIT);
 
     const linked_projects = data.linked_projects?.map((lp) => {
       const lpNodes = lp.nodes.filter(keep).map(paint);
       const lpIds = new Set(lpNodes.map((n) => n.id));
-      const lpEdges = lp.edges.filter(
-        (e) =>
-          enabledEdgeTypes.has(e.type) && lpIds.has(e.source) && lpIds.has(e.target),
+      const lpEdges = sampleEdges(
+        lp.edges.filter(
+          (e) =>
+            enabledEdgeTypes.has(e.type) && lpIds.has(e.source) && lpIds.has(e.target),
+        ),
+        EDGE_RENDER_LIMIT,
       );
-      const crossEdges = lp.cross_edges.filter(
-        (e) =>
-          enabledEdgeTypes.has(e.type) && nodeIds.has(e.source) && lpIds.has(e.target),
+      const crossEdges = sampleEdges(
+        lp.cross_edges.filter(
+          (e) =>
+            enabledEdgeTypes.has(e.type) && nodeIds.has(e.source) && lpIds.has(e.target),
+        ),
+        EDGE_RENDER_LIMIT,
       );
       return { ...lp, nodes: lpNodes, edges: lpEdges, cross_edges: crossEdges };
     });
 
-    return { nodes, edges, total_nodes: data.total_nodes, linked_projects };
+    return {
+      nodes,
+      edges,
+      total_nodes: data.total_nodes,
+      linked_projects,
+      edgeFilterTotal: filteredEdges.length,
+    };
   }, [
     data,
     enabledLabels,
@@ -178,6 +208,7 @@ export function GraphTab({ project }: GraphTabProps) {
     hideEntryPoints,
     hideTests,
   ]);
+  const edgeLimitNotice = formatEdgeLimitNotice(filteredData);
 
   /* Re-read the persisted budget when the project changes… */
   useEffect(() => {
@@ -481,6 +512,9 @@ export function GraphTab({ project }: GraphTabProps) {
               )}
               {limitNotice && (
                 <p className="text-amber-300/80 mt-0.5">{limitNotice}</p>
+              )}
+              {edgeLimitNotice && (
+                <p className="text-amber-300/80 mt-0.5">{edgeLimitNotice}</p>
               )}
               {highlightedIds && highlightedIds.size > 0 && (
                 <p className="text-cyan-400/50 mt-0.5">

--- a/graph-ui/src/components/GraphTab.tsx
+++ b/graph-ui/src/components/GraphTab.tsx
@@ -28,6 +28,7 @@ import { ErrorBoundary } from "./ErrorBoundary";
 import type { GraphNode, GraphData, RepoInfo } from "../lib/types";
 import { colorForStatus } from "../lib/colors";
 import { EDGE_RENDER_LIMIT, sampleEdges } from "../lib/edgeBudget";
+import { buildGraphIndex } from "../lib/graphIndex";
 
 /* Persist panel widths */
 function loadWidth(key: string, fallback: number): number {
@@ -161,33 +162,29 @@ export function GraphTab({ project }: GraphTabProps) {
 
     const nodes = data.nodes.filter(keep).map(paint);
     const nodeIds = new Set(nodes.map((n) => n.id));
-    const filteredEdges = data.edges.filter(
+    /* NOT sampled here — this is the full filtered edge list, used for the
+     * adjacency index (graphIndex below), the highlight-on-click set, the
+     * detail panel's connections, and the HUD edge count. Only the copy
+     * handed to GraphScene/EdgeLines (see `renderData` below) is sampled;
+     * sampling here would silently drop a clicked node's connections
+     * whenever they happened to fall outside the render budget (#2039). */
+    const edges = data.edges.filter(
       (e) =>
         enabledEdgeTypes.has(e.type) &&
         nodeIds.has(e.source) &&
         nodeIds.has(e.target),
     );
-    /* Cap what actually reaches EdgeLines — a deterministic sample so the
-     * geometry buffers built downstream stay bounded on huge graphs (#2039)
-     * regardless of how many edges survived filtering. */
-    const edges = sampleEdges(filteredEdges, EDGE_RENDER_LIMIT);
 
     const linked_projects = data.linked_projects?.map((lp) => {
       const lpNodes = lp.nodes.filter(keep).map(paint);
       const lpIds = new Set(lpNodes.map((n) => n.id));
-      const lpEdges = sampleEdges(
-        lp.edges.filter(
-          (e) =>
-            enabledEdgeTypes.has(e.type) && lpIds.has(e.source) && lpIds.has(e.target),
-        ),
-        EDGE_RENDER_LIMIT,
+      const lpEdges = lp.edges.filter(
+        (e) =>
+          enabledEdgeTypes.has(e.type) && lpIds.has(e.source) && lpIds.has(e.target),
       );
-      const crossEdges = sampleEdges(
-        lp.cross_edges.filter(
-          (e) =>
-            enabledEdgeTypes.has(e.type) && nodeIds.has(e.source) && lpIds.has(e.target),
-        ),
-        EDGE_RENDER_LIMIT,
+      const crossEdges = lp.cross_edges.filter(
+        (e) =>
+          enabledEdgeTypes.has(e.type) && nodeIds.has(e.source) && lpIds.has(e.target),
       );
       return { ...lp, nodes: lpNodes, edges: lpEdges, cross_edges: crossEdges };
     });
@@ -197,7 +194,7 @@ export function GraphTab({ project }: GraphTabProps) {
       edges,
       total_nodes: data.total_nodes,
       linked_projects,
-      edgeFilterTotal: filteredEdges.length,
+      edgeFilterTotal: edges.length,
     };
   }, [
     data,
@@ -208,7 +205,37 @@ export function GraphTab({ project }: GraphTabProps) {
     hideEntryPoints,
     hideTests,
   ]);
-  const edgeLimitNotice = formatEdgeLimitNotice(filteredData);
+
+  /* What actually reaches EdgeLines: filteredData's edges (main, linked-
+   * project, and cross edges), deterministically sampled down to the render
+   * budget so the geometry buffers built downstream stay bounded on huge
+   * graphs (#2039). Everything else (graphIndex, highlights, the detail
+   * panel, the HUD edge count) reads the unsampled filteredData above, so a
+   * clicked node's connections are never silently dropped just because they
+   * fell outside the render sample. */
+  const renderData: FilteredGraphData | null = useMemo(() => {
+    if (!filteredData) return null;
+    return {
+      ...filteredData,
+      edges: sampleEdges(filteredData.edges, EDGE_RENDER_LIMIT),
+      linked_projects: filteredData.linked_projects?.map((lp) => ({
+        ...lp,
+        edges: sampleEdges(lp.edges, EDGE_RENDER_LIMIT),
+        cross_edges: sampleEdges(lp.cross_edges, EDGE_RENDER_LIMIT),
+      })),
+    };
+  }, [filteredData]);
+  const edgeLimitNotice = formatEdgeLimitNotice(renderData);
+
+  /* One id→node map + per-node connection-list index, built once per
+   * filteredData change instead of NodeDetailPanel rebuilding a Map and
+   * scanning every edge on each click. Reused below for the highlight
+   * (connectedIds) computation too. Built from the unsampled filteredData —
+   * see the comment above renderData. */
+  const graphIndex = useMemo(
+    () => buildGraphIndex(filteredData),
+    [filteredData],
+  );
 
   /* Re-read the persisted budget when the project changes… */
   useEffect(() => {
@@ -306,17 +333,18 @@ export function GraphTab({ project }: GraphTabProps) {
 
       setSelectedNode(node);
 
-      /* Highlight the node and its direct connections */
+      /* Highlight the node and its direct connections — using the
+       * precomputed per-node connection list instead of scanning every
+       * edge on each click. */
       const connectedIds = new Set([node.id]);
-      for (const edge of filteredData.edges) {
-        if (edge.source === node.id) connectedIds.add(edge.target);
-        if (edge.target === node.id) connectedIds.add(edge.source);
+      for (const conn of graphIndex.connectionsByNode.get(node.id) ?? []) {
+        connectedIds.add(conn.node.id);
       }
       setHighlightedIds(connectedIds);
       setSelectedPath(node.file_path ?? null);
       setCameraTarget(computeCameraTarget(filteredData.nodes, connectedIds));
     },
-    [filteredData, missedSkeleton],
+    [filteredData, missedSkeleton, graphIndex],
   );
 
   const handleNavigateToNode = useCallback(
@@ -488,7 +516,10 @@ export function GraphTab({ project }: GraphTabProps) {
           <>
             <ErrorBoundary>
               <GraphScene
-                data={filteredData}
+                /* Sampled-for-rendering copy — see the renderData comment
+                 * above. Always in sync with filteredData (same nullity),
+                 * which is guaranteed non-null by the guard above. */
+                data={renderData!}
                 missed={showMissedSkeleton ? missedSkeleton : null}
                 highlightedIds={highlightedIds}
                 cameraTarget={cameraTarget}
@@ -615,8 +646,7 @@ export function GraphTab({ project }: GraphTabProps) {
             ) : (
               <NodeDetailPanel
                 node={selectedNode}
-                allNodes={filteredData.nodes}
-                allEdges={filteredData.edges}
+                graphIndex={graphIndex}
                 project={project}
                 repoInfo={repoInfo}
                 onClose={() => {

--- a/graph-ui/src/components/NodeCloud.test.ts
+++ b/graph-ui/src/components/NodeCloud.test.ts
@@ -1,0 +1,114 @@
+/* @vitest-environment jsdom */
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import * as THREE from "three";
+import {
+  createPointBuffers,
+  fillPointBuffers,
+  usePointGeometry,
+} from "./NodeCloud";
+import type { GraphNode } from "../lib/types";
+
+function node(id: number, x = 0): GraphNode {
+  return { id, x, y: 0, z: 0, label: "Function", name: `n${id}`, size: 1, color: "#80a0ff" };
+}
+
+const NODES: GraphNode[] = [node(1, 0), node(2, 10), node(3, 20)];
+
+describe("createPointBuffers / fillPointBuffers", () => {
+  it("allocates position/color attributes sized to capacity", () => {
+    const buf = createPointBuffers(3);
+    expect(buf.geometry.getAttribute("position").array.length).toBe(3 * 3);
+    expect(buf.geometry.getAttribute("color").array.length).toBe(3 * 3);
+    expect(buf.capacity).toBe(3);
+  });
+
+  it("fills positions and sets the draw range to the node count", () => {
+    const buf = createPointBuffers(3);
+    fillPointBuffers(buf, NODES, null, 1, 1);
+    expect(buf.geometry.drawRange).toEqual({ start: 0, count: 3 });
+    const positions = buf.positionAttr.array as Float32Array;
+    expect(positions[3]).toBe(10);
+    expect(positions[6]).toBe(20);
+  });
+
+  it("refills the SAME TypedArray in place across calls", () => {
+    const buf = createPointBuffers(3);
+    const positionsArray = buf.positionAttr.array;
+    fillPointBuffers(buf, NODES, null, 1, 1);
+    fillPointBuffers(buf, NODES, new Set([1]), 1, 1);
+    expect(buf.positionAttr.array).toBe(positionsArray);
+  });
+
+  it("recomputes the bounding sphere on every fill, even an in-place refill with unchanged capacity", () => {
+    /* Points.raycast() only computes geometry.boundingSphere lazily when it
+     * is null — a stale sphere left over from an earlier fill would break
+     * hover/click raycasting and could frustum-cull the whole cloud once the
+     * node positions move away from it. */
+    const buf = createPointBuffers(3);
+    fillPointBuffers(buf, NODES, null, 1, 1);
+    expect(buf.geometry.boundingSphere).not.toBeNull();
+    const firstCenterX = buf.geometry.boundingSphere!.center.x;
+
+    const movedNodes = NODES.map((n) => ({ ...n, x: n.x + 1000 }));
+    fillPointBuffers(buf, movedNodes, null, 1, 1);
+
+    expect(buf.geometry.boundingSphere).not.toBeNull();
+    expect(buf.geometry.boundingSphere!.center.x).not.toBe(firstCenterX);
+    expect(buf.geometry.boundingSphere!.center.x).toBeGreaterThan(500);
+  });
+});
+
+describe("usePointGeometry", () => {
+  it("reuses the same geometry instance when the node count doesn't grow", () => {
+    const { result, rerender } = renderHook(
+      ({ opacity }: { opacity: number }) =>
+        usePointGeometry(NODES, null, opacity, 1),
+      { initialProps: { opacity: 1 } },
+    );
+
+    const first = result.current;
+    expect(first).toBeInstanceOf(THREE.BufferGeometry);
+
+    rerender({ opacity: 0.5 });
+    expect(result.current).toBe(first);
+  });
+
+  it("disposes the geometry when node count grows past capacity", () => {
+    const { result, rerender } = renderHook(
+      ({ nodes }: { nodes: GraphNode[] }) => usePointGeometry(nodes, null, 1, 1),
+      { initialProps: { nodes: NODES } },
+    );
+
+    const first = result.current;
+    const disposeSpy = vi.spyOn(first, "dispose");
+
+    rerender({ nodes: [...NODES, node(4, 30)] });
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+    expect(result.current).not.toBe(first);
+  });
+
+  it("disposes the current geometry on unmount", () => {
+    const { result, unmount } = renderHook(() =>
+      usePointGeometry(NODES, null, 1, 1),
+    );
+    const disposeSpy = vi.spyOn(result.current, "dispose");
+    unmount();
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("fills the geometry exactly once on mount (initializer, not initializer + effect)", () => {
+    /* createPointBuffers calls setDrawRange(0, 0) once at construction; a
+     * single fillPointBuffers call adds exactly one more setDrawRange call.
+     * A double fill (mount initializer + the effect's first, unguarded run)
+     * would show up as a third call. */
+    const setDrawRangeSpy = vi.spyOn(
+      THREE.BufferGeometry.prototype,
+      "setDrawRange",
+    );
+    renderHook(() => usePointGeometry(NODES, null, 1, 1));
+    expect(setDrawRangeSpy).toHaveBeenCalledTimes(2);
+    setDrawRangeSpy.mockRestore();
+  });
+});

--- a/graph-ui/src/components/NodeCloud.tsx
+++ b/graph-ui/src/components/NodeCloud.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useThree } from "@react-three/fiber";
 import * as THREE from "three";
 import type { GraphNode } from "../lib/types";
@@ -72,7 +72,125 @@ function getPointSprite(): THREE.CanvasTexture {
   return pointSprite;
 }
 
-/* ── Point-sprite mode for very large clouds ──────────────────── */
+/* ── Point-sprite mode: allocate-once / refill-in-place geometry ──────
+ *
+ * Same failure mode as EdgeLines (#2039): a fresh BufferGeometry + fresh
+ * Float32Arrays on every render, previously handed to declarative JSX
+ * (<bufferGeometry><bufferAttribute args={[positions,3]}/>...), orphans the
+ * previously-uploaded GPU buffer every time `args` changes (R3F reconstructs
+ * the attribute instance, but plain BufferAttribute has no dispose() to
+ * release its WebGL buffer). We own the geometry directly instead: allocate
+ * once per capacity, refill the same TypedArrays in place, and dispose
+ * explicitly on growth/unmount. */
+
+interface PointBuffers {
+  geometry: THREE.BufferGeometry;
+  positionAttr: THREE.BufferAttribute;
+  colorAttr: THREE.BufferAttribute;
+  capacity: number;
+}
+
+export function createPointBuffers(capacity: number): PointBuffers {
+  const geometry = new THREE.BufferGeometry();
+  const n = Math.max(1, capacity);
+  const positionAttr = new THREE.BufferAttribute(new Float32Array(n * 3), 3);
+  const colorAttr = new THREE.BufferAttribute(new Float32Array(n * 3), 3);
+  positionAttr.setUsage(THREE.DynamicDrawUsage);
+  colorAttr.setUsage(THREE.DynamicDrawUsage);
+  geometry.setAttribute("position", positionAttr);
+  geometry.setAttribute("color", colorAttr);
+  geometry.setDrawRange(0, 0);
+  return { geometry, positionAttr, colorAttr, capacity: n };
+}
+
+export function fillPointBuffers(
+  buffers: PointBuffers,
+  nodes: GraphNode[],
+  highlightedIds: Set<number> | null,
+  opacity: number,
+  boost: number,
+): void {
+  const positions = buffers.positionAttr.array as Float32Array;
+  const colors = buffers.colorAttr.array as Float32Array;
+  const tempColor = new THREE.Color();
+  for (let i = 0; i < nodes.length; i++) {
+    const n = nodes[i];
+    positions[i * 3] = n.x;
+    positions[i * 3 + 1] = n.y;
+    positions[i * 3 + 2] = n.z;
+    const [r, g, b] = nodeColor(n, highlightedIds, opacity, boost, tempColor);
+    colors[i * 3] = r;
+    colors[i * 3 + 1] = g;
+    colors[i * 3 + 2] = b;
+  }
+  buffers.positionAttr.needsUpdate = true;
+  buffers.colorAttr.needsUpdate = true;
+  buffers.geometry.setDrawRange(0, nodes.length);
+  /* Points.raycast() computes geometry.boundingSphere lazily ONLY the first
+   * time it is null — mutating positions in place afterward (as every
+   * refill here does) leaves that sphere stale, which can break hover/click
+   * raycasting and even frustum-cull the whole cloud once the node set has
+   * moved outside it. Recompute on every refill (cheap relative to the fill
+   * itself, and NodePoints only exists above POINT_MODE_THRESHOLD anyway). */
+  buffers.geometry.computeBoundingSphere();
+}
+
+export function usePointGeometry(
+  nodes: GraphNode[],
+  highlightedIds: Set<number> | null,
+  opacity: number,
+  boost: number,
+): THREE.BufferGeometry {
+  /* Records the exact (by-reference) deps the mount initializer below filled
+   * the buffers with, so the effect's first run — which always fires with
+   * those same references, since it belongs to the same render — can skip
+   * redoing that fill (see EdgeLines.useEdgeGeometry for the same pattern). */
+  const initialFillDeps = useRef<
+    [GraphNode[], Set<number> | null, number, number] | null
+  >(null);
+
+  const [buffers, setBuffers] = useState<PointBuffers>(() => {
+    const buf = createPointBuffers(nodes.length);
+    fillPointBuffers(buf, nodes, highlightedIds, opacity, boost);
+    initialFillDeps.current = [nodes, highlightedIds, opacity, boost];
+    return buf;
+  });
+  const latest = useRef(buffers);
+  latest.current = buffers;
+
+  useEffect(() => {
+    const init = initialFillDeps.current;
+    initialFillDeps.current = null;
+    if (
+      init &&
+      init[0] === nodes &&
+      init[1] === highlightedIds &&
+      init[2] === opacity &&
+      init[3] === boost
+    ) {
+      /* Same references the initializer just filled with — skip the
+       * redundant refill. */
+      return;
+    }
+    setBuffers((prev) => {
+      let buf = prev;
+      if (nodes.length > buf.capacity) {
+        prev.geometry.dispose();
+        buf = createPointBuffers(nodes.length);
+      }
+      fillPointBuffers(buf, nodes, highlightedIds, opacity, boost);
+      return buf;
+    });
+  }, [nodes, highlightedIds, opacity, boost]);
+
+  useEffect(() => {
+    return () => {
+      latest.current.geometry.dispose();
+    };
+  }, []);
+
+  return buffers.geometry;
+}
 
 function NodePoints({
   nodes,
@@ -83,6 +201,7 @@ function NodePoints({
   boost,
 }: Required<NodeCloudProps>) {
   const { raycaster } = useThree();
+  const geometry = usePointGeometry(nodes, highlightedIds, opacity, boost);
 
   /* Widen the raycast threshold while points are on screen */
   useEffect(() => {
@@ -93,27 +212,9 @@ function NodePoints({
     };
   }, [raycaster]);
 
-  const { positions, colors } = useMemo(() => {
-    const positions = new Float32Array(nodes.length * 3);
-    const colors = new Float32Array(nodes.length * 3);
-    const tempColor = new THREE.Color();
-    for (let i = 0; i < nodes.length; i++) {
-      const n = nodes[i];
-      positions[i * 3] = n.x;
-      positions[i * 3 + 1] = n.y;
-      positions[i * 3 + 2] = n.z;
-      const [r, g, b] = nodeColor(n, highlightedIds, opacity, boost, tempColor);
-      colors[i * 3] = r;
-      colors[i * 3 + 1] = g;
-      colors[i * 3 + 2] = b;
-    }
-    return { positions, colors };
-  }, [nodes, highlightedIds, opacity, boost]);
-
   return (
     <points
-      /* Remount when the buffer size changes so stale attributes never linger */
-      key={nodes.length}
+      geometry={geometry}
       onPointerOver={(e) => {
         e.stopPropagation();
         if (e.index !== undefined && e.index < nodes.length) {
@@ -128,10 +229,6 @@ function NodePoints({
         }
       }}
     >
-      <bufferGeometry>
-        <bufferAttribute attach="attributes-position" args={[positions, 3]} />
-        <bufferAttribute attach="attributes-color" args={[colors, 3]} />
-      </bufferGeometry>
       <pointsMaterial
         vertexColors
         size={4}
@@ -160,9 +257,26 @@ function NodeSpheres({
   const tempColor = useMemo(() => new THREE.Color(), []);
   const detail = sphereDetail(nodes.length);
 
-  /* Build instance color attributes — dim non-highlighted nodes */
-  const colors = useMemo(() => {
-    const arr = new Float32Array(nodes.length * 3);
+  /* One InstancedBufferAttribute per nodes.length epoch — the instancedMesh
+   * below remounts (via `key`) when the count changes, which cleanly
+   * disposes geometry/material/attributes together through R3F's normal
+   * unmount path. Within an epoch, highlight/opacity/boost changes refill
+   * this SAME attribute's array in place (never replaced), attached via
+   * <primitive> so R3F never tries to reconstruct or auto-dispose it — see
+   * the EdgeLines/NodePoints comments for why replacing an attribute leaks
+   * its GPU buffer (#2039). */
+  const colorAttr = useMemo(() => {
+    const attr = new THREE.InstancedBufferAttribute(
+      new Float32Array(Math.max(1, nodes.length) * 3),
+      3,
+    );
+    attr.setUsage(THREE.DynamicDrawUsage);
+    return attr;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- capacity only, refilled below
+  }, [nodes.length]);
+
+  useEffect(() => {
+    const arr = colorAttr.array as Float32Array;
     for (let i = 0; i < nodes.length; i++) {
       const [r, g, b] = nodeColor(
         nodes[i],
@@ -175,8 +289,8 @@ function NodeSpheres({
       arr[i * 3 + 1] = g;
       arr[i * 3 + 2] = b;
     }
-    return arr;
-  }, [nodes, highlightedIds, tempColor, opacity, boost]);
+    colorAttr.needsUpdate = true;
+  }, [nodes, highlightedIds, opacity, boost, tempColor, colorAttr]);
 
   /* Node positions are static (the layout is server-computed), so instance
    * matrices only change with the node set or the highlight — never rebuild
@@ -201,7 +315,10 @@ function NodeSpheres({
 
   return (
     <instancedMesh
-      /* Remount when the instance count changes so buffers are re-sized */
+      /* Remount when the instance count changes so buffers are re-sized —
+       * this is a full unmount/remount (not an in-place attribute swap), so
+       * R3F's normal dispose-on-unmount path correctly frees the old
+       * geometry/material/instance buffers. */
       key={nodes.length}
       ref={meshRef}
       args={[undefined, undefined, nodes.length]}
@@ -222,10 +339,7 @@ function NodeSpheres({
     >
       <sphereGeometry args={detail} />
       <meshBasicMaterial vertexColors toneMapped={false} />
-      <instancedBufferAttribute
-        attach="geometry-attributes-color"
-        args={[colors, 3]}
-      />
+      <primitive object={colorAttr} attach="geometry-attributes-color" />
     </instancedMesh>
   );
 }

--- a/graph-ui/src/components/NodeDetailPanel.test.tsx
+++ b/graph-ui/src/components/NodeDetailPanel.test.tsx
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { NodeDetailPanel } from "./NodeDetailPanel";
+import { buildGraphIndex } from "../lib/graphIndex";
 import type { GraphNode, RepoInfo } from "../lib/types";
 
 /* Mock the RPC layer so "Show code" resolves without a backend. */
@@ -48,8 +49,7 @@ describe("NodeDetailPanel code preview + deep-link", () => {
     const { container } = render(
       <NodeDetailPanel
         node={NODE}
-        allNodes={[NODE]}
-        allEdges={[]}
+        graphIndex={buildGraphIndex({ nodes: [NODE], edges: [] })}
         project="demo"
         repoInfo={REPO}
         onClose={() => {}}
@@ -74,8 +74,7 @@ describe("NodeDetailPanel code preview + deep-link", () => {
     render(
       <NodeDetailPanel
         node={NODE}
-        allNodes={[NODE]}
-        allEdges={[]}
+        graphIndex={buildGraphIndex({ nodes: [NODE], edges: [] })}
         project="demo"
         repoInfo={REPO}
         onClose={() => {}}

--- a/graph-ui/src/components/NodeDetailPanel.tsx
+++ b/graph-ui/src/components/NodeDetailPanel.tsx
@@ -1,19 +1,17 @@
-import { useMemo, useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { colorForLabel } from "../lib/colors";
 import { callTool } from "../api/rpc";
-import type { GraphNode, GraphEdge, RepoInfo } from "../lib/types";
-
-interface Connection {
-  node: GraphNode;
-  edgeType: string;
-  direction: "inbound" | "outbound";
-}
+import type { GraphNode, RepoInfo } from "../lib/types";
+import type { Connection, GraphIndex } from "../lib/graphIndex";
 
 interface NodeDetailPanelProps {
   node: GraphNode;
-  allNodes: GraphNode[];
-  allEdges: GraphEdge[];
+  /* Precomputed per-node connection lists (see lib/graphIndex.ts) — built
+   * once per filteredData change in GraphTab instead of this panel rebuilding
+   * a node Map and scanning every edge on each click (O(nodes + edges) per
+   * click on a multi-million-edge graph). */
+  graphIndex: GraphIndex;
   project: string | null;
   repoInfo: RepoInfo | null;
   onClose: () => void;
@@ -47,8 +45,7 @@ function githubUrl(node: GraphNode, repoInfo: RepoInfo | null): string | null {
 
 export function NodeDetailPanel({
   node,
-  allNodes,
-  allEdges,
+  graphIndex,
   project,
   repoInfo,
   onClose,
@@ -85,22 +82,7 @@ export function NodeDetailPanel({
     }
   };
 
-  const connections = useMemo(() => {
-    const nodeMap = new Map<number, GraphNode>();
-    for (const n of allNodes) nodeMap.set(n.id, n);
-    const conns: Connection[] = [];
-    for (const edge of allEdges) {
-      if (edge.source === node.id) {
-        const t = nodeMap.get(edge.target);
-        if (t) conns.push({ node: t, edgeType: edge.type, direction: "outbound" });
-      }
-      if (edge.target === node.id) {
-        const s = nodeMap.get(edge.source);
-        if (s) conns.push({ node: s, edgeType: edge.type, direction: "inbound" });
-      }
-    }
-    return conns;
-  }, [node, allNodes, allEdges]);
+  const connections: Connection[] = graphIndex.connectionsByNode.get(node.id) ?? [];
 
   const outbound = connections.filter((c) => c.direction === "outbound");
   const inbound = connections.filter((c) => c.direction === "inbound");

--- a/graph-ui/src/components/NodeLabels.tsx
+++ b/graph-ui/src/components/NodeLabels.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
 import * as THREE from "three";
 import type { GraphNode } from "../lib/types";
+import { topKBySize } from "../lib/topK";
 
 interface NodeLabelsProps {
   nodes: GraphNode[];
@@ -138,13 +139,15 @@ export function NodeLabels({
     const hasHighlight = highlightedIds && highlightedIds.size > 0;
 
     if (hasHighlight) {
-      return nodes
-        .filter((n) => highlightedIds.has(n.id))
-        .sort((a, b) => b.size - a.size)
-        .slice(0, maxLabels);
+      return topKBySize(
+        nodes.filter((n) => highlightedIds.has(n.id)),
+        maxLabels,
+      );
     }
 
-    return [...nodes].sort((a, b) => b.size - a.size).slice(0, maxLabels);
+    /* Partial top-k selection instead of cloning + fully sorting every node
+     * (up to hundreds of thousands) just to keep the biggest `maxLabels`. */
+    return topKBySize(nodes, maxLabels);
   }, [nodes, highlightedIds, maxLabels]);
 
   return (

--- a/graph-ui/src/hooks/useGraphData.test.ts
+++ b/graph-ui/src/hooks/useGraphData.test.ts
@@ -2,10 +2,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   fetchLayout,
   clampNodeBudget,
+  internGraphStrings,
   GRAPH_RENDER_NODE_LIMIT,
   GRAPH_NODE_BUDGET_STEP,
   GRAPH_NODE_BUDGET_MAX,
 } from "./useGraphData";
+import type { GraphData } from "../lib/types";
 
 describe("fetchLayout", () => {
   afterEach(() => {
@@ -78,6 +80,86 @@ describe("fetchLayout", () => {
 
     expect(result.total_nodes).toBe(7);
     expect(seen).toEqual([half, payload.length]);
+  });
+
+  it("decodes correctly even when a chunk boundary splits a multi-byte UTF-8 character", async () => {
+    /* "café" — the é is a 2-byte UTF-8 sequence; split the payload so the
+     * chunk boundary lands inside it. Only correct with {stream: true}
+     * decoding across chunks. */
+    const payload = new TextEncoder().encode(
+      JSON.stringify({ nodes: [{ id: 1, x: 0, y: 0, z: 0, label: "café", name: "n", size: 1, color: "#fff" }], edges: [], total_nodes: 1 }),
+    );
+    const splitPoint = payload.indexOf(0xc3) + 1; // inside the 2-byte UTF-8 sequence
+    const chunks = [payload.slice(0, splitPoint), payload.slice(splitPoint)];
+    let read = 0;
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      headers: new Headers(),
+      body: {
+        getReader: () => ({
+          read: async () =>
+            read < chunks.length
+              ? { done: false, value: chunks[read++] }
+              : { done: true, value: undefined },
+        }),
+      },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchLayout("p", 5000, () => {});
+    expect(result.nodes[0].label).toBe("café");
+  });
+});
+
+describe("internGraphStrings", () => {
+  it("makes equal-valued node/edge strings share the same instance", () => {
+    const data: GraphData = {
+      nodes: [
+        { id: 1, x: 0, y: 0, z: 0, label: "Function", name: "a", size: 1, color: "#fff", status: "dead" },
+        { id: 2, x: 0, y: 0, z: 0, label: String("Function"), name: "b", size: 1, color: String("#fff"), status: String("dead") as GraphData["nodes"][number]["status"] },
+      ],
+      edges: [
+        { source: 1, target: 2, type: "CALLS" },
+        { source: 2, target: 1, type: String("CALLS") },
+      ],
+      total_nodes: 2,
+    };
+
+    const result = internGraphStrings(data);
+
+    expect(result.nodes[0].label).toBe(result.nodes[1].label);
+    expect(result.nodes[0].color).toBe(result.nodes[1].color);
+    expect(result.nodes[0].status).toBe(result.nodes[1].status);
+    expect(result.edges[0].type).toBe(result.edges[1].type);
+  });
+
+  it("interns strings inside linked_projects and missed_graph too", () => {
+    const data: GraphData = {
+      nodes: [],
+      edges: [],
+      total_nodes: 0,
+      linked_projects: [
+        {
+          project: "lp",
+          nodes: [{ id: 1, x: 0, y: 0, z: 0, label: "Function", name: "a", size: 1, color: "#fff" }],
+          edges: [{ source: 1, target: 1, type: "CALLS" }],
+          offset: { x: 0, y: 0, z: 0 },
+          cross_edges: [{ source: 1, target: 1, type: String("CALLS") }],
+        },
+      ],
+      missed_graph: {
+        nodes: [{ id: 2, x: 0, y: 0, z: 0, label: String("Function"), name: "b", size: 1, color: "#fff" }],
+        edges: [],
+        offset: { x: 0, y: 0, z: 0 },
+      },
+    };
+
+    const result = internGraphStrings(data);
+
+    expect(result.linked_projects![0].edges[0].type).toBe(
+      result.linked_projects![0].cross_edges[0].type,
+    );
+    expect(result.missed_graph!.nodes[0].label).toBe("Function");
   });
 });
 

--- a/graph-ui/src/hooks/useGraphData.ts
+++ b/graph-ui/src/hooks/useGraphData.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import type { GraphData } from "../lib/types";
+import type { GraphData, GraphEdge, GraphNode, NodeStatus } from "../lib/types";
 
 export interface LoadProgress {
   receivedBytes: number;
@@ -40,6 +40,48 @@ export function clampNodeBudget(value: number): number {
  *  only files the indexer could not fully cover, as their file structure. */
 export type GraphVariant = "code" | "missed";
 
+/** A 4.2M-edge graph has 4.2M freshly-parsed `type` strings (and similarly
+ * many node `label`/`color`/`status` strings) that are almost all one of a
+ * few dozen distinct values, but JSON.parse gives each occurrence its own
+ * string object. Intern them through a shared pool so the whole graph ends
+ * up referencing ~20 string instances instead of millions. Mutates the
+ * parsed objects in place (they are freshly parsed, not shared with
+ * anything else yet). */
+export function internGraphStrings(data: GraphData): GraphData {
+  const pool = new Map<string, string>();
+  const intern = (s: string): string => {
+    const existing = pool.get(s);
+    if (existing !== undefined) return existing;
+    pool.set(s, s);
+    return s;
+  };
+
+  const internNode = (n: GraphNode): GraphNode => {
+    n.label = intern(n.label);
+    n.color = intern(n.color);
+    if (n.status) n.status = intern(n.status) as NodeStatus;
+    return n;
+  };
+  const internEdge = (e: GraphEdge): GraphEdge => {
+    e.type = intern(e.type);
+    return e;
+  };
+
+  data.nodes.forEach(internNode);
+  data.edges.forEach(internEdge);
+  for (const lp of data.linked_projects ?? []) {
+    lp.nodes.forEach(internNode);
+    lp.edges.forEach(internEdge);
+    lp.cross_edges.forEach(internEdge);
+  }
+  if (data.missed_graph) {
+    data.missed_graph.nodes.forEach(internNode);
+    data.missed_graph.edges.forEach(internEdge);
+  }
+
+  return data;
+}
+
 export async function fetchLayout(
   project: string,
   maxNodes = GRAPH_RENDER_NODE_LIMIT,
@@ -58,30 +100,33 @@ export async function fetchLayout(
   /* Stream the body when possible so large budgets show live download
    * progress instead of a silent stall. */
   if (!res.body || !onProgress) {
-    return res.json();
+    return internGraphStrings(await res.json());
   }
 
   const lengthHeader = res.headers.get("content-length");
   const totalBytes = lengthHeader ? parseInt(lengthHeader, 10) || null : null;
   const reader = res.body.getReader();
-  const chunks: Uint8Array[] = [];
+  /* Decode each chunk to text as it arrives instead of buffering every raw
+   * byte chunk and merging them into one big Uint8Array before decoding —
+   * that merge step is a full extra copy of the payload (a 382MB response
+   * meant a 382MB Uint8Array copy, then a 382MB string, then the parsed
+   * object, all transiently live at once). Streaming the decode avoids the
+   * byte-level copy; only the (unavoidable) decoded string pieces + their
+   * join remain. */
+  const decoder = new TextDecoder();
+  const textChunks: string[] = [];
   let receivedBytes = 0;
 
   for (;;) {
     const { done, value } = await reader.read();
     if (done) break;
-    chunks.push(value);
     receivedBytes += value.length;
+    textChunks.push(decoder.decode(value, { stream: true }));
     onProgress({ receivedBytes, totalBytes });
   }
+  textChunks.push(decoder.decode());
 
-  const merged = new Uint8Array(receivedBytes);
-  let offset = 0;
-  for (const chunk of chunks) {
-    merged.set(chunk, offset);
-    offset += chunk.length;
-  }
-  return JSON.parse(new TextDecoder().decode(merged));
+  return internGraphStrings(JSON.parse(textChunks.join("")));
 }
 
 const NO_PROGRESS: LoadProgress = { receivedBytes: 0, totalBytes: null };

--- a/graph-ui/src/lib/edgeBudget.test.ts
+++ b/graph-ui/src/lib/edgeBudget.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { EDGE_RENDER_LIMIT, sampleEdges } from "./edgeBudget";
+import type { GraphEdge } from "./types";
+
+function edges(n: number): GraphEdge[] {
+  return Array.from({ length: n }, (_, i) => ({
+    source: i,
+    target: i + 1,
+    type: "CALLS",
+  }));
+}
+
+describe("EDGE_RENDER_LIMIT", () => {
+  it("is 1,000,000", () => {
+    expect(EDGE_RENDER_LIMIT).toBe(1_000_000);
+  });
+});
+
+describe("sampleEdges", () => {
+  it("keeps all edges (same reference, no copy) when under the limit", () => {
+    const input = edges(500);
+    const result = sampleEdges(input, 1000);
+    expect(result).toBe(input);
+    expect(result.length).toBe(500);
+  });
+
+  it("keeps all edges when exactly at the limit", () => {
+    const input = edges(1000);
+    const result = sampleEdges(input, 1000);
+    expect(result).toBe(input);
+  });
+
+  it("respects the limit when over it", () => {
+    const input = edges(10_000);
+    const result = sampleEdges(input, 1000);
+    expect(result.length).toBe(1000);
+  });
+
+  it("is deterministic — the same input always samples to the same output", () => {
+    const input = edges(4_200_000);
+    const a = sampleEdges(input, EDGE_RENDER_LIMIT);
+    const b = sampleEdges(input, EDGE_RENDER_LIMIT);
+    expect(a).toEqual(b);
+    expect(a.length).toBe(EDGE_RENDER_LIMIT);
+  });
+
+  it("spreads the sample across the full input range (stride sampling, not a prefix)", () => {
+    const input = edges(1000);
+    const result = sampleEdges(input, 100);
+    /* The last sampled edge should come from near the end of the input, not
+     * just the first 100 elements. */
+    const lastSourceIndex = result[result.length - 1].source;
+    expect(lastSourceIndex).toBeGreaterThan(900);
+  });
+
+  it("returns an empty array for a non-positive limit", () => {
+    expect(sampleEdges(edges(10), 0)).toEqual([]);
+    expect(sampleEdges(edges(10), -5)).toEqual([]);
+  });
+});

--- a/graph-ui/src/lib/edgeBudget.ts
+++ b/graph-ui/src/lib/edgeBudget.ts
@@ -1,0 +1,27 @@
+import type { GraphEdge } from "./types";
+
+/* Hard cap on edges actually handed to EdgeLines for rendering. Above this,
+ * every additional edge is still one more Float32Array(...*6) slot in the
+ * geometry buffers (see EdgeLines.tsx / #2039) — on a 4.2M-edge graph that is
+ * tens of megabytes of GPU-resident line data the user gets essentially no
+ * visual benefit from (additively-blended lines this dense already read as a
+ * flat wash). Down-sampling to a fixed budget keeps memory bounded
+ * regardless of how large the underlying graph is. */
+export const EDGE_RENDER_LIMIT = 1_000_000;
+
+/** Deterministically sample down to at most `limit` edges, preserving
+ * relative order. Uses a fixed stride over the input so the same input
+ * always yields the same sampled set — no randomness, no per-render churn —
+ * and every edge is kept untouched when the input is already at or under the
+ * limit (same array reference is returned, no allocation). */
+export function sampleEdges(edges: GraphEdge[], limit: number): GraphEdge[] {
+  if (limit <= 0) return [];
+  if (edges.length <= limit) return edges;
+
+  const stride = edges.length / limit;
+  const sampled = new Array<GraphEdge>(limit);
+  for (let i = 0; i < limit; i++) {
+    sampled[i] = edges[Math.floor(i * stride)];
+  }
+  return sampled;
+}

--- a/graph-ui/src/lib/graphIndex.test.ts
+++ b/graph-ui/src/lib/graphIndex.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildGraphIndex } from "./graphIndex";
+import type { GraphEdge, GraphNode } from "./types";
+
+function node(id: number): GraphNode {
+  return { id, x: 0, y: 0, z: 0, label: "Function", name: `n${id}`, size: 1, color: "#fff" };
+}
+
+describe("buildGraphIndex", () => {
+  it("indexes nodes by id", () => {
+    const nodes = [node(1), node(2)];
+    const index = buildGraphIndex({ nodes, edges: [] });
+    expect(index.nodeById.get(1)).toBe(nodes[0]);
+    expect(index.nodeById.get(2)).toBe(nodes[1]);
+  });
+
+  it("builds bidirectional connection lists from edges", () => {
+    const nodes = [node(1), node(2), node(3)];
+    const edges: GraphEdge[] = [
+      { source: 1, target: 2, type: "CALLS" },
+      { source: 3, target: 1, type: "IMPORTS" },
+    ];
+    const index = buildGraphIndex({ nodes, edges });
+
+    const fromOne = index.connectionsByNode.get(1) ?? [];
+    expect(fromOne).toHaveLength(2);
+    expect(fromOne).toContainEqual({ node: nodes[1], edgeType: "CALLS", direction: "outbound" });
+    expect(fromOne).toContainEqual({ node: nodes[2], edgeType: "IMPORTS", direction: "inbound" });
+
+    const fromTwo = index.connectionsByNode.get(2) ?? [];
+    expect(fromTwo).toEqual([{ node: nodes[0], edgeType: "CALLS", direction: "inbound" }]);
+  });
+
+  it("skips edges with a dangling endpoint", () => {
+    const nodes = [node(1)];
+    const edges: GraphEdge[] = [{ source: 1, target: 999, type: "CALLS" }];
+    const index = buildGraphIndex({ nodes, edges });
+    expect(index.connectionsByNode.get(1)).toBeUndefined();
+  });
+
+  it("returns empty maps for null/undefined data", () => {
+    expect(buildGraphIndex(null).nodeById.size).toBe(0);
+    expect(buildGraphIndex(undefined).connectionsByNode.size).toBe(0);
+  });
+});

--- a/graph-ui/src/lib/graphIndex.ts
+++ b/graph-ui/src/lib/graphIndex.ts
@@ -1,0 +1,57 @@
+import type { GraphData, GraphEdge, GraphNode } from "./types";
+
+export interface Connection {
+  node: GraphNode;
+  edgeType: string;
+  direction: "inbound" | "outbound";
+}
+
+export interface GraphIndex {
+  nodeById: Map<number, GraphNode>;
+  /** Precomputed per-node connection lists (both directions), built once per
+   * filteredData change instead of scanning every edge on every node click
+   * (NodeDetailPanel previously rebuilt a node Map and scanned all edges on
+   * every render — O(nodes + edges) per click on a 4.2M-edge graph). */
+  connectionsByNode: Map<number, Connection[]>;
+}
+
+function addConnection(
+  index: Map<number, Connection[]>,
+  id: number,
+  conn: Connection,
+) {
+  let list = index.get(id);
+  if (!list) {
+    list = [];
+    index.set(id, list);
+  }
+  list.push(conn);
+}
+
+export function buildGraphIndex(
+  data: Pick<GraphData, "nodes" | "edges"> | null | undefined,
+): GraphIndex {
+  const nodeById = new Map<number, GraphNode>();
+  const connectionsByNode = new Map<number, Connection[]>();
+  if (!data) return { nodeById, connectionsByNode };
+
+  for (const n of data.nodes) nodeById.set(n.id, n);
+
+  for (const edge of data.edges as GraphEdge[]) {
+    const s = nodeById.get(edge.source);
+    const t = nodeById.get(edge.target);
+    if (!s || !t) continue;
+    addConnection(connectionsByNode, edge.source, {
+      node: t,
+      edgeType: edge.type,
+      direction: "outbound",
+    });
+    addConnection(connectionsByNode, edge.target, {
+      node: s,
+      edgeType: edge.type,
+      direction: "inbound",
+    });
+  }
+
+  return { nodeById, connectionsByNode };
+}

--- a/graph-ui/src/lib/topK.test.ts
+++ b/graph-ui/src/lib/topK.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { topKBySize } from "./topK";
+
+function items(sizes: number[]): { size: number; id: number }[] {
+  return sizes.map((size, id) => ({ size, id }));
+}
+
+describe("topKBySize", () => {
+  it("returns all items sorted descending when k >= length", () => {
+    const result = topKBySize(items([3, 1, 4, 1, 5]), 10);
+    expect(result.map((i) => i.size)).toEqual([5, 4, 3, 1, 1]);
+  });
+
+  it("returns exactly the k largest items, sorted descending", () => {
+    const result = topKBySize(items([3, 1, 4, 1, 5, 9, 2, 6]), 3);
+    expect(result.map((i) => i.size)).toEqual([9, 6, 5]);
+  });
+
+  it("matches a full sort+slice for a larger random-ish input", () => {
+    const sizes = Array.from({ length: 500 }, (_, i) => (i * 37) % 211);
+    const expected = [...items(sizes)].sort((a, b) => b.size - a.size).slice(0, 20);
+    const result = topKBySize(items(sizes), 20);
+    expect(result.map((i) => i.size)).toEqual(expected.map((i) => i.size));
+  });
+
+  it("returns an empty array for k <= 0", () => {
+    expect(topKBySize(items([1, 2, 3]), 0)).toEqual([]);
+    expect(topKBySize(items([1, 2, 3]), -1)).toEqual([]);
+  });
+
+  it("handles ties without dropping items arbitrarily below k", () => {
+    const result = topKBySize(items([5, 5, 5, 1, 1]), 3);
+    expect(result.length).toBe(3);
+    expect(result.every((i) => i.size === 5)).toBe(true);
+  });
+});

--- a/graph-ui/src/lib/topK.ts
+++ b/graph-ui/src/lib/topK.ts
@@ -1,0 +1,58 @@
+/** Select the top-`k` items by `size` (descending) without sorting the whole
+ * input. NodeLabels previously did `[...nodes].sort(...).slice(0, k)` every
+ * render, which clones and fully sorts the entire node array (up to
+ * hundreds of thousands of nodes) just to keep the top 80. This keeps a
+ * bounded min-heap of size k instead — O(n log k) instead of O(n log n),
+ * and no full-array clone. */
+export function topKBySize<T extends { size: number }>(
+  items: T[],
+  k: number,
+): T[] {
+  if (k <= 0) return [];
+  if (items.length <= k) {
+    return [...items].sort((a, b) => b.size - a.size);
+  }
+
+  /* Min-heap of size k, keyed by `size` — keeps the k largest items seen so
+   * far; anything smaller than the current minimum is discarded in O(log k). */
+  const heap: T[] = [];
+
+  const siftUp = (start: number) => {
+    let i = start;
+    while (i > 0) {
+      const parent = (i - 1) >> 1;
+      if (heap[i].size < heap[parent].size) {
+        [heap[i], heap[parent]] = [heap[parent], heap[i]];
+        i = parent;
+      } else {
+        break;
+      }
+    }
+  };
+
+  const siftDown = (start: number) => {
+    let i = start;
+    for (;;) {
+      const l = i * 2 + 1;
+      const r = i * 2 + 2;
+      let smallest = i;
+      if (l < heap.length && heap[l].size < heap[smallest].size) smallest = l;
+      if (r < heap.length && heap[r].size < heap[smallest].size) smallest = r;
+      if (smallest === i) break;
+      [heap[i], heap[smallest]] = [heap[smallest], heap[i]];
+      i = smallest;
+    }
+  };
+
+  for (const item of items) {
+    if (heap.length < k) {
+      heap.push(item);
+      siftUp(heap.length - 1);
+    } else if (item.size > heap[0].size) {
+      heap[0] = item;
+      siftDown(0);
+    }
+  }
+
+  return heap.sort((a, b) => b.size - a.size);
+}

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -5531,23 +5531,22 @@ int cbm_store_search_by_degree(cbm_store_t *s, const char *project, int limit,
         sqlite3_finalize(cnt_stmt);
     }
 
-    const char *sql =
-        "SELECT n.id, n.project, n.label, n.name, n.qualified_name, "
-        "n.file_path, n.start_line, n.end_line, n.properties, "
-        "(SELECT COUNT(*) FROM edges e WHERE e.target_id = n.id AND "
-        "e.type IN ('CALLS', 'USAGE', 'CALL_REFERENCE', 'INHERITS', "
-        "'IMPLEMENTS')) AS in_deg, "
-        "(SELECT COUNT(*) FROM edges e WHERE e.source_id = n.id AND "
-        "e.type IN ('CALLS', 'USAGE', 'CALL_REFERENCE', 'INHERITS', "
-        "'IMPLEMENTS')) AS out_deg "
-        "FROM nodes n "
-        "LEFT JOIN (SELECT source_id AS id, COUNT(*) AS c FROM edges "
-        "  WHERE project = ?1 GROUP BY source_id) od ON od.id = n.id "
-        "LEFT JOIN (SELECT target_id AS id, COUNT(*) AS c FROM edges "
-        "  WHERE project = ?2 GROUP BY target_id) idg ON idg.id = n.id "
-        "WHERE n.project = ?3 "
-        "ORDER BY (IFNULL(od.c, 0) + IFNULL(idg.c, 0)) DESC, n.name, n.id "
-        "LIMIT ?4;";
+    const char *sql = "SELECT n.id, n.project, n.label, n.name, n.qualified_name, "
+                      "n.file_path, n.start_line, n.end_line, n.properties, "
+                      "(SELECT COUNT(*) FROM edges e WHERE e.target_id = n.id AND "
+                      "e.type IN ('CALLS', 'USAGE', 'CALL_REFERENCE', 'INHERITS', "
+                      "'IMPLEMENTS')) AS in_deg, "
+                      "(SELECT COUNT(*) FROM edges e WHERE e.source_id = n.id AND "
+                      "e.type IN ('CALLS', 'USAGE', 'CALL_REFERENCE', 'INHERITS', "
+                      "'IMPLEMENTS')) AS out_deg "
+                      "FROM nodes n "
+                      "LEFT JOIN (SELECT source_id AS id, COUNT(*) AS c FROM edges "
+                      "  WHERE project = ?1 GROUP BY source_id) od ON od.id = n.id "
+                      "LEFT JOIN (SELECT target_id AS id, COUNT(*) AS c FROM edges "
+                      "  WHERE project = ?2 GROUP BY target_id) idg ON idg.id = n.id "
+                      "WHERE n.project = ?3 "
+                      "ORDER BY (IFNULL(od.c, 0) + IFNULL(idg.c, 0)) DESC, n.name, n.id "
+                      "LIMIT ?4;";
 
     sqlite3_stmt *stmt = NULL;
     if (sqlite3_prepare_v2(s->db, sql, CBM_NOT_FOUND, &stmt, NULL) != SQLITE_OK) {

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -3187,6 +3187,127 @@ int cbm_store_find_edges_by_type(cbm_store_t *s, const char *project, const char
                               bind_proj_and_type, &b, out, count);
 }
 
+/* Stages `ids` into a private TEMP table so a membership test can use an
+ * index instead of a giant IN(?,?,...) placeholder list (SQLite's bound
+ * parameter count is comfortably below a max_nodes=10M sample) or a
+ * serialized id blob that would need building and re-parsing for the same
+ * effect. TEMP objects live in a separate, private schema — backed by memory
+ * per configure_pragmas' temp_store=MEMORY — so this also works against the
+ * read-only connections cbm_store_open_path_query hands query tools: only
+ * the temp schema is written, never the (possibly read-only) main DB file.
+ * INSERT OR IGNORE tolerates a duplicate id in the input rather than failing
+ * the whole call on the INTEGER PRIMARY KEY conflict. */
+static int stage_id_sample(cbm_store_t *s, const char *table, const int64_t *ids, int n_ids) {
+    char drop_sql[CBM_SZ_128];
+    char create_sql[CBM_SZ_128];
+    char insert_sql[CBM_SZ_128];
+    snprintf(drop_sql, sizeof(drop_sql), "DROP TABLE IF EXISTS temp.%s;", table);
+    snprintf(create_sql, sizeof(create_sql), "CREATE TEMP TABLE %s (id INTEGER PRIMARY KEY);",
+             table);
+    snprintf(insert_sql, sizeof(insert_sql), "INSERT OR IGNORE INTO temp.%s (id) VALUES (?1);",
+             table);
+
+    int rc = exec_sql(s, drop_sql);
+    if (rc != CBM_STORE_OK) {
+        return rc;
+    }
+    rc = exec_sql(s, create_sql);
+    if (rc != CBM_STORE_OK) {
+        return rc;
+    }
+
+    sqlite3_stmt *ins = NULL;
+    if (sqlite3_prepare_v2(s->db, insert_sql, CBM_NOT_FOUND, &ins, NULL) != SQLITE_OK) {
+        store_set_error_sqlite(s, "stage_id_sample insert prepare");
+        return CBM_STORE_ERR;
+    }
+    if (exec_sql(s, "BEGIN;") != CBM_STORE_OK) {
+        sqlite3_finalize(ins);
+        return CBM_STORE_ERR;
+    }
+    for (int i = 0; i < n_ids; i++) {
+        sqlite3_bind_int64(ins, SKIP_ONE, ids[i]);
+        int step_rc = sqlite3_step(ins);
+        sqlite3_reset(ins);
+        if (step_rc != SQLITE_DONE && step_rc != SQLITE_CONSTRAINT) {
+            store_set_error_sqlite(s, "stage_id_sample insert");
+            sqlite3_finalize(ins);
+            exec_sql(s, "ROLLBACK;");
+            return CBM_STORE_ERR;
+        }
+    }
+    sqlite3_finalize(ins);
+    return exec_sql(s, "COMMIT;");
+}
+
+int cbm_store_find_edges_among(cbm_store_t *s, const char *project, const int64_t *ids, int n_ids,
+                               cbm_edge_t **out, int *count) {
+    if (out) {
+        *out = NULL;
+    }
+    if (count) {
+        *count = 0;
+    }
+    if (!s || !s->db || !project || !ids || n_ids <= 0 || !out || !count) {
+        return CBM_STORE_ERR;
+    }
+
+    static const char *TMP_TABLE = "cbm_edges_among_ids";
+    int rc = stage_id_sample(s, TMP_TABLE, ids, n_ids);
+    if (rc != CBM_STORE_OK) {
+        return rc;
+    }
+
+    /* No properties column: layout doesn't use edge properties, and skipping
+     * it avoids a strdup+free per row across a potentially multi-million-edge
+     * project (the cost this function exists to cut). */
+    sqlite3_stmt *stmt = NULL;
+    if (sqlite3_prepare_v2(s->db,
+                           "SELECT e.source_id, e.target_id, e.type FROM edges e "
+                           "WHERE e.project = ?1 "
+                           "AND e.source_id IN (SELECT id FROM temp.cbm_edges_among_ids) "
+                           "AND e.target_id IN (SELECT id FROM temp.cbm_edges_among_ids);",
+                           CBM_NOT_FOUND, &stmt, NULL) != SQLITE_OK) {
+        store_set_error_sqlite(s, "find_edges_among prepare");
+        exec_sql(s, "DROP TABLE IF EXISTS temp.cbm_edges_among_ids;");
+        return CBM_STORE_ERR;
+    }
+    bind_text(stmt, SKIP_ONE, project);
+
+    int cap = ST_INIT_CAP_16;
+    int n = 0;
+    cbm_edge_t *arr = malloc((size_t)cap * sizeof(cbm_edge_t));
+
+    int scan_rc;
+    while ((scan_rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+        if (n >= cap) {
+            cap *= ST_GROWTH;
+            arr = safe_realloc(arr, (size_t)cap * sizeof(cbm_edge_t));
+        }
+        memset(&arr[n], 0, sizeof(cbm_edge_t));
+        arr[n].source_id = sqlite3_column_int64(stmt, 0);
+        arr[n].target_id = sqlite3_column_int64(stmt, SKIP_ONE);
+        arr[n].type = heap_strdup((const char *)sqlite3_column_text(stmt, PAIR_LEN));
+        n++;
+    }
+    if (scan_rc != SQLITE_DONE) { /* SCANCHK:among:stmt */
+        store_set_error_sqlite(s, "find_edges_among scan");
+        sqlite3_finalize(stmt);
+        cbm_store_free_edges(arr, n);
+        exec_sql(s, "DROP TABLE IF EXISTS temp.cbm_edges_among_ids;");
+        *out = NULL;
+        *count = 0;
+        return CBM_STORE_ERR;
+    }
+    sqlite3_finalize(stmt);
+    /* Don't leak the temp schema across calls sharing this handle. */
+    exec_sql(s, "DROP TABLE IF EXISTS temp.cbm_edges_among_ids;");
+
+    *out = arr;
+    *count = n;
+    return CBM_STORE_OK;
+}
+
 int cbm_store_count_edges(cbm_store_t *s, const char *project) {
     if (!s || !s->db) {
         return 0;
@@ -5362,6 +5483,106 @@ int cbm_store_search(cbm_store_t *s, const cbm_search_params_t *params, cbm_sear
 
     sqlite3_finalize(main_stmt);
     like_pool_free(&like_pool);
+
+    out->results = results;
+    out->count = n;
+    return CBM_STORE_OK;
+}
+
+/* Sample up to `limit` nodes for `project`, ordered by total degree (in+out,
+ * across ANY edge type) DESC, then name, then id — a dedicated, narrower
+ * sibling of cbm_store_search for callers that want a well-connected sample
+ * rather than an alphabetical page. cbm_store_search's own (name, id)
+ * pagination order is intentionally left untouched (it's a paginated public
+ * search API — changing its default would reorder every caller's pages);
+ * this is an explicit opt-in path used by cbm_layout_compute, whose
+ * alphabetical default sample of a large graph pulls almost no edges (most
+ * neighbors alphabetically-sampled nodes are related to fall outside the
+ * sample) — see #2039.
+ *
+ * Degree is computed via a GROUP BY over edges.source_id / edges.target_id
+ * (each an indexed prefix scan via idx_edges_source_type / idx_edges_target_type
+ * for the fixed project), not a per-row correlated COUNT subquery: the
+ * latter forces evaluating COUNT() for every node in the project just to
+ * sort before LIMIT applies, which measured slower on a 435k-node/4.2M-edge
+ * project (see the commit message for both timings).
+ *
+ * Populates *out exactly like cbm_store_search: out->total is the project's
+ * total node count (pre-LIMIT), in_degree/out_degree per result use the same
+ * CALLS/USAGE/CALL_REFERENCE/INHERITS/IMPLEMENTS family cbm_store_search
+ * reports. Free with cbm_store_search_free(). */
+int cbm_store_search_by_degree(cbm_store_t *s, const char *project, int limit,
+                               cbm_search_output_t *out) {
+    if (out) {
+        memset(out, 0, sizeof(*out));
+    }
+    if (!s || !s->db || !project || !out) {
+        return CBM_STORE_ERR;
+    }
+    int lim = limit > 0 ? limit : CBM_DEFAULT_SEARCH_LIMIT;
+
+    sqlite3_stmt *cnt_stmt = NULL;
+    if (sqlite3_prepare_v2(s->db, "SELECT COUNT(*) FROM nodes WHERE project = ?1;", CBM_NOT_FOUND,
+                           &cnt_stmt, NULL) == SQLITE_OK) {
+        bind_text(cnt_stmt, SKIP_ONE, project);
+        if (sqlite3_step(cnt_stmt) == SQLITE_ROW) {
+            out->total = sqlite3_column_int(cnt_stmt, 0);
+        }
+        sqlite3_finalize(cnt_stmt);
+    }
+
+    const char *sql =
+        "SELECT n.id, n.project, n.label, n.name, n.qualified_name, "
+        "n.file_path, n.start_line, n.end_line, n.properties, "
+        "(SELECT COUNT(*) FROM edges e WHERE e.target_id = n.id AND "
+        "e.type IN ('CALLS', 'USAGE', 'CALL_REFERENCE', 'INHERITS', "
+        "'IMPLEMENTS')) AS in_deg, "
+        "(SELECT COUNT(*) FROM edges e WHERE e.source_id = n.id AND "
+        "e.type IN ('CALLS', 'USAGE', 'CALL_REFERENCE', 'INHERITS', "
+        "'IMPLEMENTS')) AS out_deg "
+        "FROM nodes n "
+        "LEFT JOIN (SELECT source_id AS id, COUNT(*) AS c FROM edges "
+        "  WHERE project = ?1 GROUP BY source_id) od ON od.id = n.id "
+        "LEFT JOIN (SELECT target_id AS id, COUNT(*) AS c FROM edges "
+        "  WHERE project = ?2 GROUP BY target_id) idg ON idg.id = n.id "
+        "WHERE n.project = ?3 "
+        "ORDER BY (IFNULL(od.c, 0) + IFNULL(idg.c, 0)) DESC, n.name, n.id "
+        "LIMIT ?4;";
+
+    sqlite3_stmt *stmt = NULL;
+    if (sqlite3_prepare_v2(s->db, sql, CBM_NOT_FOUND, &stmt, NULL) != SQLITE_OK) {
+        store_set_error_sqlite(s, "search_by_degree prepare");
+        return CBM_STORE_ERR;
+    }
+    bind_text(stmt, SKIP_ONE, project);
+    bind_text(stmt, PAIR_LEN, project);
+    bind_text(stmt, CBM_SZ_3, project);
+    sqlite3_bind_int(stmt, CBM_SZ_4, lim);
+
+    int cap = ST_INIT_CAP_16;
+    int n = 0;
+    cbm_search_result_t *results = malloc(cap * sizeof(cbm_search_result_t));
+
+    int scan_rc;
+    while ((scan_rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+        if (n >= cap) {
+            cap *= ST_GROWTH;
+            results = safe_realloc(results, cap * sizeof(cbm_search_result_t));
+        }
+        memset(&results[n], 0, sizeof(cbm_search_result_t));
+        scan_node(stmt, &results[n].node);
+        results[n].in_degree = sqlite3_column_int(stmt, ST_COL_9);
+        results[n].out_degree = sqlite3_column_int(stmt, CBM_DECIMAL_BASE);
+        n++;
+    }
+    if (scan_rc != SQLITE_DONE) { /* SCANCHK:by_degree:stmt */
+        store_set_error_sqlite(s, "search_by_degree scan");
+        sqlite3_finalize(stmt);
+        out->results = results;
+        out->count = n;
+        return CBM_STORE_ERR;
+    }
+    sqlite3_finalize(stmt);
 
     out->results = results;
     out->count = n;

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -592,6 +592,18 @@ int cbm_store_find_edges_by_target_type(cbm_store_t *s, int64_t target_id, const
 int cbm_store_find_edges_by_type(cbm_store_t *s, const char *project, const char *type,
                                  cbm_edge_t **out, int *count);
 
+/* Find edges of ANY type in `project` whose source_id AND target_id are both
+ * in `ids` (n_ids entries) — e.g. a sampled node set for a rendered subgraph.
+ * Only id/source_id/target_id/type are populated (project and
+ * properties_json are left NULL); the caller doesn't need them and skipping
+ * properties avoids a strdup+free per row across a potentially multi-million-
+ * edge project. Works on a read-only store handle (cbm_store_open_path_query):
+ * membership is tested via a private TEMP table rather than a giant IN(...)
+ * placeholder list or a serialized id blob. Free the result with
+ * cbm_store_free_edges(). */
+int cbm_store_find_edges_among(cbm_store_t *s, const char *project, const int64_t *ids, int n_ids,
+                               cbm_edge_t **out, int *count);
+
 /* Count all edges in project. */
 int cbm_store_count_edges(cbm_store_t *s, const char *project);
 
@@ -697,6 +709,17 @@ void cbm_store_free_coverage(cbm_coverage_row_t *rows, int count);
 /* ── Search ─────────────────────────────────────────────────────── */
 
 int cbm_store_search(cbm_store_t *s, const cbm_search_params_t *params, cbm_search_output_t *out);
+
+/* Sample up to `limit` nodes for `project`, ordered by total degree (any
+ * edge type, in+out) DESC, then name, then id — for callers (e.g. the
+ * layout sampler) that want well-connected nodes rather than an
+ * alphabetical page. Does NOT change cbm_store_search's own (name, id)
+ * pagination order. Populates *out the same way cbm_store_search does
+ * (out->total = project's total node count, in_degree/out_degree per the
+ * CALLS/USAGE/CALL_REFERENCE/INHERITS/IMPLEMENTS family). Free with
+ * cbm_store_search_free(). */
+int cbm_store_search_by_degree(cbm_store_t *s, const char *project, int limit,
+                               cbm_search_output_t *out);
 
 /* Free a search output's allocated memory. */
 void cbm_store_search_free(cbm_search_output_t *out);

--- a/src/ui/http_server.c
+++ b/src/ui/http_server.c
@@ -1557,36 +1557,23 @@ static void handle_layout(cbm_http_conn_t *c, const cbm_http_req_t *req) {
     /* Capture primary cluster radius before freeing the layout. */
     double primary_radius = layout_radius(layout);
 
-    /* Build JSON: primary layout + linked_projects */
-    char *primary_json = cbm_layout_to_json(layout);
+    /* Build the primary layout directly into ONE yyjson_mut_doc — no
+     * encode-to-string + yyjson_read + yyjson_doc_mut_copy round trip. Every
+     * string field cbm_layout_to_mut_json adds is copied into mdoc's own
+     * arena, so `layout` can be freed immediately: mdoc holds no pointers
+     * into it. missed_graph/linked_projects (below) get attached to this
+     * same doc, and the whole thing is written to bytes exactly once, at
+     * the bottom of this function. */
+    yyjson_mut_doc *mdoc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *mroot = cbm_layout_to_mut_json(layout, mdoc);
     cbm_layout_free(layout);
-    if (!primary_json) {
+    if (!mroot) {
+        yyjson_mut_doc_free(mdoc);
         cbm_store_close(store);
         cbm_http_replyf(c, 500, g_cors_json, "{\"error\":\"JSON serialization failed\"}");
         return;
     }
-
-    /* Fast path: no satellites to attach. The missed skeleton only decorates
-     * the CODE graph — a graph=missed request already IS the miss graph. */
-    if (linked_count == 0 && missed_graph) {
-        cbm_store_close(store);
-        cbm_http_replyf(c, 200, g_cors_json, "%s", primary_json);
-        free(primary_json);
-        return;
-    }
-
-    /* Parse primary JSON and append missed_graph + linked_projects */
-    yyjson_doc *pdoc = yyjson_read(primary_json, strlen(primary_json), 0);
-    free(primary_json);
-    if (!pdoc) {
-        cbm_store_close(store);
-        cbm_http_replyf(c, 500, g_cors_json, "{\"error\":\"JSON parse failed\"}");
-        return;
-    }
-
-    yyjson_mut_doc *mdoc = yyjson_doc_mut_copy(pdoc, NULL);
-    yyjson_doc_free(pdoc);
-    yyjson_mut_val *mroot = yyjson_mut_doc_get_root(mdoc);
+    yyjson_mut_doc_set_root(mdoc, mroot);
 
     if (!missed_graph) {
         (void)attach_missed_graph(mdoc, mroot, store, project, primary_radius);
@@ -1733,14 +1720,29 @@ static void handle_layout(cbm_http_conn_t *c, const cbm_http_req_t *req) {
     cbm_store_close(store);
     yyjson_mut_obj_add_val(mdoc, mroot, "linked_projects", lp_arr);
 
+    /* Written exactly once, from the single doc built above — no second
+     * document, no re-parse. ALLOW_INVALID_UNICODE matches
+     * cbm_layout_to_mut_json's contents (identifiers can contain malformed
+     * UTF-8) and is strictly safer here than the old code's flags=0 write,
+     * since this doc's node/edge strings never survived a yyjson_read pass
+     * that could itself have choked on the same bytes. */
     size_t len = 0;
-    char *final_json = yyjson_mut_write(mdoc, 0, &len);
+    yyjson_write_err write_err = {0};
+    char *final_json =
+        yyjson_mut_write_opts(mdoc, YYJSON_WRITE_ALLOW_INVALID_UNICODE, NULL, &len, &write_err);
     yyjson_mut_doc_free(mdoc);
 
     if (final_json) {
-        cbm_http_replyf(c, 200, g_cors_json, "%s", final_json);
+        /* Binary-safe send of the already-built buffer — cbm_http_replyf's
+         * "%s" would vsnprintf-copy the whole (potentially multi-MB) body a
+         * second time just to hand it to the socket. */
+        cbm_http_reply_buf(c, 200, g_cors_json, final_json, len);
         free(final_json);
     } else {
+        char code[32];
+        snprintf(code, sizeof(code), "%u", write_err.code);
+        cbm_log_error("layout.json.fail", "code", code, "msg",
+                      write_err.msg ? write_err.msg : "unknown");
         cbm_http_replyf(c, 500, g_cors_json, "{\"error\":\"JSON write failed\"}");
     }
 }

--- a/src/ui/layout3d.c
+++ b/src/ui/layout3d.c
@@ -12,6 +12,7 @@
  */
 #include "foundation/constants.h"
 #include "ui/layout3d.h"
+#include "ui/layout3d_internal.h"
 #include "foundation/log.h"
 
 #include <yyjson/yyjson.h>
@@ -407,12 +408,27 @@ static void local_optimize(body_t *b, int n, const int *es, const int *ed, int n
     }
 }
 
-/* ── Call depth via BFS ───────────────────────────────────────── */
-
-static void compute_call_depth(int n, const int *es, const int *ed, int ne, const char **labels,
-                               int *depth) {
+/* ── Call depth via BFS (CSR adjacency) ──────────────────────────
+ *
+ * Builds a counting-sort CSR (compressed sparse row) index — offsets[n+1]
+ * plus adj[ne], keyed by source node index — so each dequeued node's
+ * outgoing edges are a direct O(degree) slice instead of a full
+ * `for (e=0;e<ne;e++) if (es[e]==c)` rescan of every edge. That rescan made
+ * the BFS O(n*ne); the CSR index makes it O(n+ne), which is the difference
+ * between seconds and minutes once a project graph reaches millions of
+ * edges. Traversal order (and therefore every depth value) is identical to
+ * the previous scan: adj[] preserves each source's edges in their original
+ * es/ed order, so ties resolve exactly as before.
+ *
+ * Declared non-static in layout3d_internal.h so tests can drive the BFS
+ * directly without a store-backed cbm_layout_compute() call.
+ */
+void cbm_layout_compute_call_depth(int n, const int *es, const int *ed, int ne,
+                                   const char **labels, int *depth) {
     for (int i = 0; i < n; i++)
         depth[i] = -1;
+    if (n <= 0)
+        return;
     int *q = malloc((size_t)n * sizeof(int));
     int head = 0, tail = 0;
     if (!q)
@@ -442,17 +458,50 @@ static void compute_call_depth(int n, const int *es, const int *ed, int ne, cons
             free(in_d);
         }
     }
+
+    /* Build CSR: offsets[i]..offsets[i+1] is node i's slice of adj[]. */
+    int *offsets = calloc((size_t)n + 1, sizeof(int));
+    int *adj = ne > 0 ? malloc((size_t)ne * sizeof(int)) : NULL;
+    int *cursor = malloc((size_t)n * sizeof(int));
+    if (!offsets || (ne > 0 && !adj) || !cursor) {
+        /* No index available — every node reachable via the entry-point seed
+         * above already has depth 0; nothing further can be propagated. */
+        free(offsets);
+        free(adj);
+        free(cursor);
+        for (int i = 0; i < n; i++)
+            if (depth[i] == -1)
+                depth[i] = 0;
+        free(q);
+        return;
+    }
+    for (int e = 0; e < ne; e++) {
+        int s = es[e];
+        if (s >= 0 && s < n)
+            offsets[s + 1]++;
+    }
+    for (int i = 0; i < n; i++)
+        offsets[i + 1] += offsets[i];
+    memcpy(cursor, offsets, (size_t)n * sizeof(int));
+    for (int e = 0; e < ne; e++) {
+        int s = es[e];
+        if (s >= 0 && s < n)
+            adj[cursor[s]++] = ed[e];
+    }
+    free(cursor);
+
     while (head < tail) {
         int c = q[head++], cd = depth[c];
-        for (int e = 0; e < ne; e++)
-            if (es[e] == c) {
-                int t = ed[e];
-                if (t >= 0 && t < n && depth[t] == -1) {
-                    depth[t] = cd + SKIP_ONE;
-                    q[tail++] = t;
-                }
+        for (int k = offsets[c]; k < offsets[c + 1]; k++) {
+            int t = adj[k];
+            if (t >= 0 && t < n && depth[t] == -1) {
+                depth[t] = cd + SKIP_ONE;
+                q[tail++] = t;
             }
+        }
     }
+    free(offsets);
+    free(adj);
     for (int i = 0; i < n; i++)
         if (depth[i] == -1)
             depth[i] = 0;
@@ -620,7 +669,7 @@ cbm_layout_result_t *cbm_layout_compute(cbm_store_t *store, const char *project,
         for (int i = 0; i < n; i++)
             lbls[i] = search_out.results[i].node.label;
         if (cdepth)
-            compute_call_depth(n, es, ed, mapped, lbls, cdepth);
+            cbm_layout_compute_call_depth(n, es, ed, mapped, lbls, cdepth);
         free(lbls);
     }
 

--- a/src/ui/layout3d.c
+++ b/src/ui/layout3d.c
@@ -423,8 +423,8 @@ static void local_optimize(body_t *b, int n, const int *es, const int *ed, int n
  * Declared non-static in layout3d_internal.h so tests can drive the BFS
  * directly without a store-backed cbm_layout_compute() call.
  */
-void cbm_layout_compute_call_depth(int n, const int *es, const int *ed, int ne,
-                                   const char **labels, int *depth) {
+void cbm_layout_compute_call_depth(int n, const int *es, const int *ed, int ne, const char **labels,
+                                   int *depth) {
     for (int i = 0; i < n; i++)
         depth[i] = -1;
     if (n <= 0)
@@ -842,13 +842,15 @@ void cbm_layout_free(cbm_layout_result_t *r) {
     free(r);
 }
 
-char *cbm_layout_to_json(const cbm_layout_result_t *r) {
-    if (!r)
+yyjson_mut_val *cbm_layout_to_mut_json(const cbm_layout_result_t *r, yyjson_mut_doc *doc) {
+    if (!r || !doc)
         return NULL;
-    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
     yyjson_mut_val *root = yyjson_mut_obj(doc);
-    yyjson_mut_doc_set_root(doc, root);
 
+    /* Every string field is added via the _strcpy variant (copies into doc's
+     * own arena) rather than _str (borrows the pointer): callers that build
+     * straight into a long-lived document (handle_layout) free `r` right
+     * after this call returns, before the document is ever written. */
     yyjson_mut_val *na = yyjson_mut_arr(doc);
     for (int i = 0; i < r->node_count; i++) {
         yyjson_mut_val *nd = yyjson_mut_obj(doc);
@@ -860,13 +862,13 @@ char *cbm_layout_to_json(const cbm_layout_result_t *r) {
         yyjson_mut_obj_add_real(doc, nd, "y", ny);
         yyjson_mut_obj_add_real(doc, nd, "z", nz);
         if (r->nodes[i].label)
-            yyjson_mut_obj_add_str(doc, nd, "label", r->nodes[i].label);
+            yyjson_mut_obj_add_strcpy(doc, nd, "label", r->nodes[i].label);
         if (r->nodes[i].name)
-            yyjson_mut_obj_add_str(doc, nd, "name", r->nodes[i].name);
+            yyjson_mut_obj_add_strcpy(doc, nd, "name", r->nodes[i].name);
         if (r->nodes[i].file_path)
-            yyjson_mut_obj_add_str(doc, nd, "file_path", r->nodes[i].file_path);
+            yyjson_mut_obj_add_strcpy(doc, nd, "file_path", r->nodes[i].file_path);
         if (r->nodes[i].qualified_name)
-            yyjson_mut_obj_add_str(doc, nd, "qualified_name", r->nodes[i].qualified_name);
+            yyjson_mut_obj_add_strcpy(doc, nd, "qualified_name", r->nodes[i].qualified_name);
         if (r->nodes[i].start_line > 0)
             yyjson_mut_obj_add_int(doc, nd, "start_line", r->nodes[i].start_line);
         if (r->nodes[i].end_line > 0)
@@ -878,7 +880,7 @@ char *cbm_layout_to_json(const cbm_layout_result_t *r) {
         yyjson_mut_obj_add_strcpy(doc, nd, "color", hex);
         yyjson_mut_obj_add_int(doc, nd, "in_calls", r->nodes[i].in_calls);
         if (r->nodes[i].status)
-            yyjson_mut_obj_add_str(doc, nd, "status", r->nodes[i].status);
+            yyjson_mut_obj_add_strcpy(doc, nd, "status", r->nodes[i].status);
         yyjson_mut_arr_append(na, nd);
     }
     yyjson_mut_obj_add_val(doc, root, "nodes", na);
@@ -889,11 +891,25 @@ char *cbm_layout_to_json(const cbm_layout_result_t *r) {
         yyjson_mut_obj_add_int(doc, ed, "source", r->edges[i].source);
         yyjson_mut_obj_add_int(doc, ed, "target", r->edges[i].target);
         if (r->edges[i].type)
-            yyjson_mut_obj_add_str(doc, ed, "type", r->edges[i].type);
+            yyjson_mut_obj_add_strcpy(doc, ed, "type", r->edges[i].type);
         yyjson_mut_arr_append(ea, ed);
     }
     yyjson_mut_obj_add_val(doc, root, "edges", ea);
     yyjson_mut_obj_add_int(doc, root, "total_nodes", r->total_nodes);
+
+    return root;
+}
+
+char *cbm_layout_to_json(const cbm_layout_result_t *r) {
+    if (!r)
+        return NULL;
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *root = cbm_layout_to_mut_json(r, doc);
+    if (!root) {
+        yyjson_mut_doc_free(doc);
+        return NULL;
+    }
+    yyjson_mut_doc_set_root(doc, root);
 
     size_t len = 0;
     yyjson_write_err write_err = {0};

--- a/src/ui/layout3d.c
+++ b/src/ui/layout3d.c
@@ -563,17 +563,14 @@ cbm_layout_result_t *cbm_layout_compute(cbm_store_t *store, const char *project,
     (void)radius;
     (void)level;
 
-    /* 1. Query nodes */
-    cbm_search_params_t params;
-    memset(&params, 0, sizeof(params));
-    params.project = project;
-    params.limit = max_nodes;
-    params.min_degree = -1;
-    params.max_degree = -1;
-
+    /* 1. Query nodes — sampled by degree DESC (not cbm_store_search's default
+     * alphabetical order): an alphabetical slice of a large graph pulls
+     * nodes with almost no edges between them (see cbm_store_search_by_degree
+     * for why, and the commit message for measured numbers on a
+     * 435k-node/4.2M-edge project). */
     cbm_search_output_t search_out;
     memset(&search_out, 0, sizeof(search_out));
-    if (cbm_store_search(store, &params, &search_out) != CBM_STORE_OK)
+    if (cbm_store_search_by_degree(store, project, max_nodes, &search_out) != CBM_STORE_OK)
         return calloc(CBM_ALLOC_ONE, sizeof(cbm_layout_result_t));
 
     int n = search_out.count, total_count = search_out.total;
@@ -601,65 +598,60 @@ cbm_layout_result_t *cbm_layout_compute(cbm_store_t *store, const char *project,
     }
     qsort(id_map, (size_t)n, sizeof(node_id_entry_t), cmp_node_id_entry);
 
-    /* 3. Query edges — filter during fetch via binary search (O(e log n)) */
+    /* 3. Query edges scoped to the sampled node set in one call, then map
+     * source/target ids to local indices via binary search (O(e log n)).
+     * cbm_store_find_edges_among only returns edges whose BOTH endpoints are
+     * already in the sample — unlike the old per-edge-type
+     * cbm_store_find_edges_by_type loop, it never loads (and strdups
+     * project/properties for) the project's full edge set first, which was
+     * the bulk of this endpoint's memory (see the commit message). Since the
+     * fetch count is known upfront, the output arrays are sized exactly
+     * once instead of grown incrementally. */
     int *deg = calloc((size_t)n, sizeof(int));
+    int64_t *sample_ids = malloc((size_t)n * sizeof(int64_t));
     int mapped = 0;
-    int edge_cap = CBM_SZ_256;
-    cbm_edge_t *all_edges = malloc((size_t)edge_cap * sizeof(cbm_edge_t));
-    int *es = malloc((size_t)edge_cap * sizeof(int));
-    int *ed = malloc((size_t)edge_cap * sizeof(int));
-    cbm_schema_info_t schema;
-    memset(&schema, 0, sizeof(schema));
-    if (deg && all_edges && es && ed &&
-        cbm_store_get_schema(store, project, &schema) == CBM_STORE_OK) {
-        for (int t = 0; t < schema.edge_type_count; t++) {
-            cbm_edge_t *te = NULL;
-            int tc = 0;
-            if (cbm_store_find_edges_by_type(store, project, schema.edge_types[t].type, &te, &tc) ==
-                CBM_STORE_OK) {
-                for (int e = 0; e < tc; e++) {
-                    int si = find_node_index(id_map, n, te[e].source_id);
-                    int di = find_node_index(id_map, n, te[e].target_id);
+    cbm_edge_t *all_edges = NULL;
+    int *es = NULL;
+    int *ed = NULL;
+    if (deg && sample_ids) {
+        for (int i = 0; i < n; i++)
+            sample_ids[i] = search_out.results[i].node.id;
+
+        cbm_edge_t *fetched_edges = NULL;
+        int fetched = 0;
+        if (cbm_store_find_edges_among(store, project, sample_ids, n, &fetched_edges, &fetched) ==
+                CBM_STORE_OK &&
+            fetched > 0) {
+            all_edges = malloc((size_t)fetched * sizeof(cbm_edge_t));
+            es = malloc((size_t)fetched * sizeof(int));
+            ed = malloc((size_t)fetched * sizeof(int));
+            if (all_edges && es && ed) {
+                for (int e = 0; e < fetched; e++) {
+                    /* Both endpoints are guaranteed members of sample_ids by
+                     * cbm_store_find_edges_among's own query — the lookup
+                     * below only converts id -> local index, but the `else`
+                     * stays as a defensive net rather than an assumption. */
+                    int si = find_node_index(id_map, n, fetched_edges[e].source_id);
+                    int di = find_node_index(id_map, n, fetched_edges[e].target_id);
                     if (si >= 0 && di >= 0) {
-                        if (mapped >= edge_cap) {
-                            int nc = edge_cap * PAIR_LEN;
-                            cbm_edge_t *te2 = realloc(all_edges, (size_t)nc * sizeof(cbm_edge_t));
-                            int *ts = realloc(es, (size_t)nc * sizeof(int));
-                            int *td = realloc(ed, (size_t)nc * sizeof(int));
-                            if (!te2 || !ts || !td) {
-                                if (te2)
-                                    all_edges = te2;
-                                if (ts)
-                                    es = ts;
-                                if (td)
-                                    ed = td;
-                                free_edge_array(te + e, tc - e);
-                                goto edges_done;
-                            }
-                            all_edges = te2;
-                            es = ts;
-                            ed = td;
-                            edge_cap = nc;
-                        }
-                        all_edges[mapped] = te[e];
-                        memset(&te[e], 0, sizeof(cbm_edge_t));
+                        all_edges[mapped] = fetched_edges[e];
+                        memset(&fetched_edges[e], 0, sizeof(cbm_edge_t));
                         es[mapped] = si;
                         ed[mapped] = di;
                         deg[si]++;
                         deg[di]++;
                         mapped++;
                     } else {
-                        free((void *)te[e].project);
-                        free((void *)te[e].type);
-                        free((void *)te[e].properties_json);
+                        free((void *)fetched_edges[e].project);
+                        free((void *)fetched_edges[e].type);
+                        free((void *)fetched_edges[e].properties_json);
                     }
                 }
-                free(te);
             }
+            free_edge_array(fetched_edges, fetched);
         }
-    edges_done:
-        cbm_store_schema_free(&schema);
     }
+    free(sample_ids);
     free(id_map);
 
     /* 4. Call depth for z-axis */

--- a/src/ui/layout3d.h
+++ b/src/ui/layout3d.h
@@ -5,13 +5,24 @@
  *   - Overview: cluster centroids (packages/folders), ~1K-10K nodes
  *   - Detail: individual nodes within a region, up to max_nodes
  *
- * Layout positions are cached in the project's SQLite database.
+ * Layout positions are computed fresh on every request — there is no
+ * position cache. Each cbm_layout_compute() call re-samples the graph and
+ * re-runs the local optimization pass; see cbm_layout_compute's comment for
+ * how the node sample and edge set are scoped to keep that affordable on
+ * large projects.
  */
 #ifndef CBM_UI_LAYOUT3D_H
 #define CBM_UI_LAYOUT3D_H
 
 #include "store/store.h"
 #include <stdbool.h>
+
+/* Forward declarations of yyjson's mutable-document types, matched exactly
+ * against vendored/yyjson/yyjson.h's own typedefs (identical redeclaration
+ * of the same struct tag is legal in C11 — see 6.7p3) so callers that only
+ * need cbm_layout_to_mut_json don't have to pull in the full yyjson.h. */
+typedef struct yyjson_mut_doc yyjson_mut_doc;
+typedef struct yyjson_mut_val yyjson_mut_val;
 
 /* ── Layout node (output) ─────────────────────────────────────── */
 
@@ -70,5 +81,20 @@ void cbm_layout_free(cbm_layout_result_t *result);
 
 /* Serialize layout result to JSON string. Caller must free(). */
 char *cbm_layout_to_json(const cbm_layout_result_t *result);
+
+/* Build a layout result directly as an object — {"nodes":[...],
+ * "edges":[...], "total_nodes":N}, the same shape cbm_layout_to_json's
+ * string encodes — inside a caller-owned yyjson_mut_doc, instead of
+ * encoding to a standalone JSON string. All string fields are copied into
+ * `doc` (not borrowed from `result`), so `result` may be freed as soon as
+ * this call returns. Lets a caller that's assembling a larger document
+ * (e.g. handle_layout attaching missed_graph/linked_projects) skip the
+ * encode -> parse -> deep-copy round trip cbm_layout_to_json + yyjson_read +
+ * yyjson_doc_mut_copy would otherwise require to merge the result in.
+ * Returns the new object (not yet attached to any parent — the caller
+ * decides where it goes, typically yyjson_mut_doc_set_root or
+ * yyjson_mut_obj_add_val), or NULL on allocation failure or a NULL
+ * `result`/`doc`. */
+yyjson_mut_val *cbm_layout_to_mut_json(const cbm_layout_result_t *result, yyjson_mut_doc *doc);
 
 #endif /* CBM_UI_LAYOUT3D_H */

--- a/src/ui/layout3d_internal.h
+++ b/src/ui/layout3d_internal.h
@@ -21,7 +21,7 @@
  *
  * `depth` must have room for n ints; it is fully overwritten.
  */
-void cbm_layout_compute_call_depth(int n, const int *es, const int *ed, int ne,
-                                    const char **labels, int *depth);
+void cbm_layout_compute_call_depth(int n, const int *es, const int *ed, int ne, const char **labels,
+                                   int *depth);
 
 #endif /* CBM_UI_LAYOUT3D_INTERNAL_H */

--- a/src/ui/layout3d_internal.h
+++ b/src/ui/layout3d_internal.h
@@ -1,0 +1,27 @@
+/*
+ * layout3d_internal.h — Internal helpers exposed for testing.
+ *
+ * These functions are implementation details of layout3d.c; they are
+ * declared here only so that tests/test_ui.c can drive them directly
+ * without needing a store-backed cbm_layout_compute() call. Production
+ * code outside layout3d.c should use the public API in layout3d.h instead.
+ */
+#ifndef CBM_UI_LAYOUT3D_INTERNAL_H
+#define CBM_UI_LAYOUT3D_INTERNAL_H
+
+/*
+ * Call-depth BFS used to seed the z-axis of the layout.
+ *
+ * `n` nodes, edges given as parallel arrays es[0..ne)/ed[0..ne) of node
+ * indices (source/target, both in [0,n)). `labels` is indexed by node;
+ * Route/File/Module/Package nodes seed depth 0 (entry points). If none of
+ * those labels are present, nodes with zero in-degree seed depth 0 instead.
+ * BFS then propagates depth+1 along outgoing edges. Any node never reached
+ * (including one with no entry point can reach it) is left at depth 0.
+ *
+ * `depth` must have room for n ints; it is fully overwritten.
+ */
+void cbm_layout_compute_call_depth(int n, const int *es, const int *ed, int ne,
+                                    const char **labels, int *depth);
+
+#endif /* CBM_UI_LAYOUT3D_INTERNAL_H */

--- a/tests/test_httpd.c
+++ b/tests/test_httpd.c
@@ -1558,6 +1558,125 @@ TEST(ui_server_delete_project_unlink_failure_keeps_watch) {
     PASS();
 }
 
+/* ── /api/layout end-to-end (#2039) ──────────────────────────────
+ *
+ * handle_layout was refactored to build one yyjson_mut_doc directly (via
+ * cbm_layout_to_mut_json) instead of encoding cbm_layout_to_json's string,
+ * re-parsing it, and deep-copying it into a second mutable doc — then to
+ * send that doc's single write with cbm_http_reply_buf instead of
+ * cbm_http_replyf("%s", ...). These tests exercise the real handler over a
+ * live socket against a real on-disk project store, so a regression in that
+ * refactor (wrong doc, dangling string pointers into a freed
+ * cbm_layout_result_t, a bad content-length from switching reply
+ * functions) shows up as a real HTTP failure, not just a unit test of the
+ * JSON builder in isolation. */
+static int layout_seed_project(const ui_delete_fixture_t *fx, const char *project) {
+    char db_path[1024];
+    ui_delete_db_path(fx, project, db_path, sizeof(db_path));
+    cbm_store_t *store = cbm_store_open_path(db_path);
+    if (!store)
+        return CBM_STORE_ERR;
+    if (cbm_store_upsert_project(store, project, "/tmp/layout-e2e") != CBM_STORE_OK) {
+        cbm_store_close(store);
+        return CBM_STORE_ERR;
+    }
+    cbm_node_t caller = {.project = project,
+                         .label = "Function",
+                         .name = "caller",
+                         .qualified_name = "layout_e2e.caller",
+                         .file_path = "a.py",
+                         .start_line = 1,
+                         .end_line = 2};
+    cbm_node_t callee = {.project = project,
+                         .label = "Function",
+                         .name = "callee",
+                         .qualified_name = "layout_e2e.callee",
+                         .file_path = "b.py",
+                         .start_line = 1,
+                         .end_line = 2};
+    int64_t caller_id = cbm_store_upsert_node(store, &caller);
+    int64_t callee_id = cbm_store_upsert_node(store, &callee);
+    int rc = CBM_STORE_ERR;
+    if (caller_id > 0 && callee_id > 0) {
+        cbm_edge_t e = {
+            .project = project, .source_id = caller_id, .target_id = callee_id, .type = "CALLS"};
+        rc = cbm_store_insert_edge(store, &e) > 0 ? CBM_STORE_OK : CBM_STORE_ERR;
+    }
+    cbm_store_close(store);
+    return rc;
+}
+
+TEST(ui_server_layout_returns_nodes_and_edges) {
+    ui_delete_fixture_t fx;
+    ASSERT_EQ(ui_delete_fixture_init(&fx), 0);
+    ASSERT_EQ(layout_seed_project(&fx, "layout-e2e"), CBM_STORE_OK);
+
+    th_server_t ts;
+    ASSERT_EQ(th_server_start(&ts), 0);
+    char resp[16384];
+    int n = th_http(cbm_http_server_port(ts.srv),
+                    "GET /api/layout?project=layout-e2e HTTP/1.1\r\n\r\n", resp, sizeof(resp));
+    ASSERT_GT(n, 0);
+    ASSERT_EQ(th_status(resp), 200);
+    ASSERT_NOT_NULL(strstr(resp, "\"nodes\":["));
+    ASSERT_NOT_NULL(strstr(resp, "\"edges\":["));
+    ASSERT_NOT_NULL(strstr(resp, "\"total_nodes\":2"));
+    ASSERT_NOT_NULL(strstr(resp, "\"name\":\"caller\""));
+    ASSERT_NOT_NULL(strstr(resp, "\"name\":\"callee\""));
+    ASSERT_NOT_NULL(strstr(resp, "\"linked_projects\":["));
+    /* No missed_graph key: nothing indexed under the "<project>::missed"
+     * shadow project, so attach_missed_graph is a no-op — same as before
+     * this refactor. */
+    ASSERT_NULL(strstr(resp, "\"missed_graph\""));
+
+    /* Body byte count must match what the server actually declared — proof
+     * cbm_http_reply_buf (len from the single yyjson_mut_write) sent exactly
+     * the buffer it built, not a mismatched or truncated copy. */
+    const char *cl_hdr = strstr(resp, "Content-Length: ");
+    ASSERT_NOT_NULL(cl_hdr);
+    long declared_len = strtol(cl_hdr + strlen("Content-Length: "), NULL, 10);
+    const char *body = strstr(resp, "\r\n\r\n");
+    ASSERT_NOT_NULL(body);
+    body += 4;
+    ASSERT_EQ((long)strlen(body), declared_len);
+
+    th_server_stop(&ts);
+    ui_delete_fixture_cleanup(&fx);
+    PASS();
+}
+
+TEST(ui_server_layout_missing_project_param) {
+    th_server_t ts;
+    ASSERT_EQ(th_server_start(&ts), 0);
+    char resp[4096];
+    int n = th_http(cbm_http_server_port(ts.srv), "GET /api/layout HTTP/1.1\r\n\r\n", resp,
+                    sizeof(resp));
+    ASSERT_GT(n, 0);
+    ASSERT_EQ(th_status(resp), 400);
+    ASSERT_NOT_NULL(strstr(resp, "{\"error\":\"missing project parameter\"}"));
+    th_server_stop(&ts);
+    PASS();
+}
+
+TEST(ui_server_layout_unknown_project) {
+    ui_delete_fixture_t fx;
+    ASSERT_EQ(ui_delete_fixture_init(&fx), 0);
+
+    th_server_t ts;
+    ASSERT_EQ(th_server_start(&ts), 0);
+    char resp[4096];
+    int n =
+        th_http(cbm_http_server_port(ts.srv),
+                "GET /api/layout?project=layout-e2e-missing HTTP/1.1\r\n\r\n", resp, sizeof(resp));
+    ASSERT_GT(n, 0);
+    ASSERT_EQ(th_status(resp), 404);
+    ASSERT_NOT_NULL(strstr(resp, "{\"error\":\"project not found\"}"));
+
+    th_server_stop(&ts);
+    ui_delete_fixture_cleanup(&fx);
+    PASS();
+}
+
 TEST(ui_server_ui_config_detects_zh_accept_language) {
     th_server_t ts;
     ASSERT_EQ(th_server_start(&ts), 0);
@@ -2416,6 +2535,9 @@ SUITE(httpd) {
     RUN_TEST(ui_server_delete_project_missing_name_keeps_watch);
     RUN_TEST(ui_server_delete_project_invalid_name_keeps_watch);
     RUN_TEST(ui_server_delete_project_unlink_failure_keeps_watch);
+    RUN_TEST(ui_server_layout_returns_nodes_and_edges);
+    RUN_TEST(ui_server_layout_missing_project_param);
+    RUN_TEST(ui_server_layout_unknown_project);
     RUN_TEST(ui_server_ui_config_detects_zh_accept_language);
     RUN_TEST(ui_server_ui_config_includes_serving_version_issue1820);
     RUN_TEST(ui_server_ui_config_prefers_config_lang);

--- a/tests/test_store_edges.c
+++ b/tests/test_store_edges.c
@@ -4,11 +4,13 @@
  * Ported from internal/store/store_test.go (TestEdgeCRUD, TestInsertEdgeBatch,
  * TestFindEdgesByURLPath, etc.)
  */
+#include "../src/foundation/compat.h"
 #include "test_framework.h"
 #include <store/store.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <unistd.h>
 
 /* Helper: create a store with project + N nodes (A, B, C, ...) */
 static cbm_store_t *setup_store_with_nodes(int n, int64_t *ids) {
@@ -460,6 +462,185 @@ TEST(store_edge_find_type_nonexistent) {
     PASS();
 }
 
+/* ── find_edges_among (scoped edge fetch for #2039) ──────────────── */
+
+/* A-B-C-D-E path graph (CALLS chain) plus a B->D IMPORTS edge so more than
+ * one type is exercised. Sampling {A,B,C} should return only edges whose
+ * BOTH endpoints are in that set: A->B and (deliberately excluded) neither
+ * C->D nor B->D nor D->E, since D and E are outside the sample. */
+static cbm_store_t *setup_among_store(int64_t *ids) {
+    int64_t discard[5];
+    if (!ids)
+        ids = discard;
+    cbm_store_t *s = setup_store_with_nodes(5, ids); /* A B C D E */
+
+    cbm_edge_t ab = {.project = "test", .source_id = ids[0], .target_id = ids[1], .type = "CALLS"};
+    cbm_edge_t bc = {.project = "test", .source_id = ids[1], .target_id = ids[2], .type = "CALLS"};
+    cbm_edge_t cd = {.project = "test", .source_id = ids[2], .target_id = ids[3], .type = "CALLS"};
+    cbm_edge_t de = {.project = "test", .source_id = ids[3], .target_id = ids[4], .type = "CALLS"};
+    cbm_edge_t bd = {
+        .project = "test", .source_id = ids[1], .target_id = ids[3], .type = "IMPORTS"};
+    cbm_store_insert_edge(s, &ab);
+    cbm_store_insert_edge(s, &bc);
+    cbm_store_insert_edge(s, &cd);
+    cbm_store_insert_edge(s, &de);
+    cbm_store_insert_edge(s, &bd);
+    return s;
+}
+
+TEST(store_find_edges_among_scopes_to_sample) {
+    int64_t ids[5];
+    cbm_store_t *s = setup_among_store(ids);
+
+    int64_t sample[3] = {ids[0], ids[1], ids[2]}; /* A, B, C — excludes D, E */
+    cbm_edge_t *edges = NULL;
+    int count = 0;
+    int rc = cbm_store_find_edges_among(s, "test", sample, 3, &edges, &count);
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_EQ(count, 2); /* A->B, B->C only: C->D/B->D/D->E fall outside the sample */
+
+    bool saw_ab = false, saw_bc = false;
+    for (int i = 0; i < count; i++) {
+        ASSERT_NOT_NULL(edges[i].type);
+        /* No properties column fetched — must stay NULL, not garbage. */
+        ASSERT_NULL(edges[i].properties_json);
+        if (edges[i].source_id == ids[0] && edges[i].target_id == ids[1] &&
+            strcmp(edges[i].type, "CALLS") == 0)
+            saw_ab = true;
+        if (edges[i].source_id == ids[1] && edges[i].target_id == ids[2] &&
+            strcmp(edges[i].type, "CALLS") == 0)
+            saw_bc = true;
+    }
+    ASSERT_TRUE(saw_ab);
+    ASSERT_TRUE(saw_bc);
+
+    cbm_store_free_edges(edges, count);
+    cbm_store_close(s);
+    PASS();
+}
+
+TEST(store_find_edges_among_no_internal_edges) {
+    int64_t ids[5];
+    cbm_store_t *s = setup_among_store(ids);
+
+    /* A and E are both in the graph but never directly connected to each
+     * other, and no other sampled node bridges them. */
+    int64_t sample[2] = {ids[0], ids[4]};
+    cbm_edge_t *edges = NULL;
+    int count = 0;
+    int rc = cbm_store_find_edges_among(s, "test", sample, 2, &edges, &count);
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_EQ(count, 0);
+    cbm_store_free_edges(edges, count);
+
+    cbm_store_close(s);
+    PASS();
+}
+
+TEST(store_find_edges_among_invalid_args) {
+    int64_t ids[5];
+    cbm_store_t *s = setup_among_store(ids);
+    int64_t sample[1] = {ids[0]};
+    cbm_edge_t *edges = (cbm_edge_t *)0x1; /* poison — must be reset to NULL */
+    int count = -1;
+
+    ASSERT_EQ(cbm_store_find_edges_among(NULL, "test", sample, 1, &edges, &count), CBM_STORE_ERR);
+    ASSERT_NULL(edges);
+    ASSERT_EQ(count, 0);
+
+    edges = (cbm_edge_t *)0x1;
+    count = -1;
+    ASSERT_EQ(cbm_store_find_edges_among(s, "test", sample, 0, &edges, &count), CBM_STORE_ERR);
+    ASSERT_NULL(edges);
+    ASSERT_EQ(count, 0);
+
+    edges = (cbm_edge_t *)0x1;
+    count = -1;
+    ASSERT_EQ(cbm_store_find_edges_among(s, "test", NULL, 1, &edges, &count), CBM_STORE_ERR);
+    ASSERT_NULL(edges);
+    ASSERT_EQ(count, 0);
+
+    cbm_store_close(s);
+    PASS();
+}
+
+/* Repeated calls on the same handle must not leak/collide their private TEMP
+ * table — each call re-scopes it to a fresh id set. */
+TEST(store_find_edges_among_reusable_across_calls) {
+    int64_t ids[5];
+    cbm_store_t *s = setup_among_store(ids);
+
+    int64_t first[2] = {ids[0], ids[1]};
+    cbm_edge_t *e1 = NULL;
+    int c1 = 0;
+    ASSERT_EQ(cbm_store_find_edges_among(s, "test", first, 2, &e1, &c1), CBM_STORE_OK);
+    ASSERT_EQ(c1, 1); /* A->B */
+    cbm_store_free_edges(e1, c1);
+
+    int64_t second[2] = {ids[3], ids[4]};
+    cbm_edge_t *e2 = NULL;
+    int c2 = 0;
+    ASSERT_EQ(cbm_store_find_edges_among(s, "test", second, 2, &e2, &c2), CBM_STORE_OK);
+    ASSERT_EQ(c2, 1); /* D->E */
+    cbm_store_free_edges(e2, c2);
+
+    cbm_store_close(s);
+    PASS();
+}
+
+/* cbm_store_open_path_query hands out a read-only connection — layout
+ * requests go through it. cbm_store_find_edges_among must work there: it
+ * only ever writes to the private TEMP schema, never the main DB file. */
+static void tse_cleanup_db(const char *db_path) {
+    char sidecar[512];
+    unlink(db_path);
+    snprintf(sidecar, sizeof(sidecar), "%s-wal", db_path);
+    unlink(sidecar);
+    snprintf(sidecar, sizeof(sidecar), "%s-shm", db_path);
+    unlink(sidecar);
+}
+
+TEST(store_find_edges_among_readonly_connection) {
+    char db_path[512];
+    snprintf(db_path, sizeof(db_path), "%s/cbm_test_edges_among_ro_%d.db", cbm_tmpdir(),
+            (int)getpid());
+    tse_cleanup_db(db_path);
+
+    cbm_store_t *setup = cbm_store_open_path(db_path);
+    ASSERT_NOT_NULL(setup);
+    ASSERT_EQ(cbm_store_upsert_project(setup, "test", "/tmp/test"), CBM_STORE_OK);
+    int64_t ids[3];
+    char name[8], qn[32];
+    for (int i = 0; i < 3; i++) {
+        snprintf(name, sizeof(name), "%c", 'A' + i);
+        snprintf(qn, sizeof(qn), "test.%c", 'A' + i);
+        cbm_node_t node = {
+            .project = "test", .label = "Function", .name = name, .qualified_name = qn};
+        ids[i] = cbm_store_upsert_node(setup, &node);
+        ASSERT_GT(ids[i], 0);
+    }
+    cbm_edge_t ab = {.project = "test", .source_id = ids[0], .target_id = ids[1], .type = "CALLS"};
+    ASSERT_GT(cbm_store_insert_edge(setup, &ab), 0);
+    ASSERT_EQ(cbm_store_seal_for_atomic_publish(setup), CBM_STORE_OK);
+    cbm_store_close(setup);
+
+    cbm_store_t *reader = cbm_store_open_path_query(db_path);
+    ASSERT_NOT_NULL(reader);
+
+    cbm_edge_t *edges = NULL;
+    int count = 0;
+    int rc = cbm_store_find_edges_among(reader, "test", ids, 3, &edges, &count);
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_EQ(count, 1);
+    ASSERT_EQ(edges[0].source_id, ids[0]);
+    ASSERT_EQ(edges[0].target_id, ids[1]);
+    cbm_store_free_edges(edges, count);
+
+    cbm_store_close(reader);
+    tse_cleanup_db(db_path);
+    PASS();
+}
+
 /* ── count_edges on empty project ──────────────────────────────── */
 
 TEST(store_edge_count_empty_project) {
@@ -654,6 +835,11 @@ SUITE(store_edges) {
     RUN_TEST(store_edge_find_source_nonexistent);
     RUN_TEST(store_edge_find_target_nonexistent);
     RUN_TEST(store_edge_find_type_nonexistent);
+    RUN_TEST(store_find_edges_among_scopes_to_sample);
+    RUN_TEST(store_find_edges_among_no_internal_edges);
+    RUN_TEST(store_find_edges_among_invalid_args);
+    RUN_TEST(store_find_edges_among_reusable_across_calls);
+    RUN_TEST(store_find_edges_among_readonly_connection);
     RUN_TEST(store_edge_count_empty_project);
     RUN_TEST(store_edge_count_by_type_missing);
     RUN_TEST(store_edge_delete_by_type_preserves_others);

--- a/tests/test_store_edges.c
+++ b/tests/test_store_edges.c
@@ -603,7 +603,7 @@ static void tse_cleanup_db(const char *db_path) {
 TEST(store_find_edges_among_readonly_connection) {
     char db_path[512];
     snprintf(db_path, sizeof(db_path), "%s/cbm_test_edges_among_ro_%d.db", cbm_tmpdir(),
-            (int)getpid());
+             (int)getpid());
     tse_cleanup_db(db_path);
 
     cbm_store_t *setup = cbm_store_open_path(db_path);

--- a/tests/test_store_search.c
+++ b/tests/test_store_search.c
@@ -1339,6 +1339,122 @@ TEST(store_batch_count_degrees) {
     PASS();
 }
 
+/* ── search_by_degree (well-connected node sampling for #2039) ───── */
+
+/* Hub (degree 6: 3 in + 3 out), Mid (degree 2), three Leaf* nodes (degree 1
+ * each), and an Island node with no edges at all (degree 0). Hub must sort
+ * first, Island must sort last. */
+static cbm_store_t *setup_degree_store(int64_t *hub, int64_t *mid, int64_t leaves[3],
+                                       int64_t *island) {
+    cbm_store_t *s = cbm_store_open_memory();
+    cbm_store_upsert_project(s, "deg", "/tmp/deg");
+
+    cbm_node_t nhub = {
+        .project = "deg", .label = "Function", .name = "Hub", .qualified_name = "deg.Hub"};
+    cbm_node_t nmid = {
+        .project = "deg", .label = "Function", .name = "Mid", .qualified_name = "deg.Mid"};
+    cbm_node_t nisland = {.project = "deg",
+                          .label = "Function",
+                          .name = "Island",
+                          .qualified_name = "deg.Island"};
+    *hub = cbm_store_upsert_node(s, &nhub);
+    *mid = cbm_store_upsert_node(s, &nmid);
+    *island = cbm_store_upsert_node(s, &nisland);
+
+    for (int i = 0; i < 3; i++) {
+        char name[16], qn[32];
+        snprintf(name, sizeof(name), "Leaf%d", i);
+        snprintf(qn, sizeof(qn), "deg.Leaf%d", i);
+        cbm_node_t nl = {
+            .project = "deg", .label = "Function", .name = name, .qualified_name = qn};
+        leaves[i] = cbm_store_upsert_node(s, &nl);
+    }
+
+    /* Hub <-> each Leaf (Hub: 3 out to leaves), Mid <-> Hub + one Leaf. */
+    cbm_edge_t e1 = {.project = "deg", .source_id = *hub, .target_id = leaves[0], .type = "CALLS"};
+    cbm_edge_t e2 = {.project = "deg", .source_id = *hub, .target_id = leaves[1], .type = "CALLS"};
+    cbm_edge_t e3 = {.project = "deg", .source_id = *hub, .target_id = leaves[2], .type = "CALLS"};
+    cbm_edge_t e4 = {.project = "deg", .source_id = *mid, .target_id = *hub, .type = "CALLS"};
+    cbm_store_insert_edge(s, &e1);
+    cbm_store_insert_edge(s, &e2);
+    cbm_store_insert_edge(s, &e3);
+    cbm_store_insert_edge(s, &e4);
+    return s;
+}
+
+TEST(store_search_by_degree_orders_high_degree_first) {
+    int64_t hub, mid, leaves[3], island;
+    cbm_store_t *s = setup_degree_store(&hub, &mid, leaves, &island);
+
+    cbm_search_output_t out = {0};
+    int rc = cbm_store_search_by_degree(s, "deg", 100, &out);
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_EQ(out.count, 6); /* Hub, Mid, 3 Leaves, Island */
+    ASSERT_EQ(out.total, 6);
+
+    /* Hub (degree 4: 3 CALLS out + 1 in from Mid) sorts first. */
+    ASSERT_STR_EQ(out.results[0].node.name, "Hub");
+    /* Island (degree 0) sorts last. */
+    ASSERT_STR_EQ(out.results[out.count - 1].node.name, "Island");
+
+    cbm_store_search_free(&out);
+    cbm_store_close(s);
+    PASS();
+}
+
+TEST(store_search_by_degree_respects_limit) {
+    int64_t hub, mid, leaves[3], island;
+    cbm_store_t *s = setup_degree_store(&hub, &mid, leaves, &island);
+    (void)mid;
+    (void)leaves;
+    (void)island;
+
+    cbm_search_output_t out = {0};
+    int rc = cbm_store_search_by_degree(s, "deg", 1, &out);
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_EQ(out.count, 1);
+    ASSERT_EQ(out.total, 6); /* total is pre-LIMIT, matching cbm_store_search */
+    ASSERT_STR_EQ(out.results[0].node.name, "Hub");
+    ASSERT_EQ(out.results[0].node.id, hub);
+
+    cbm_store_search_free(&out);
+    cbm_store_close(s);
+    PASS();
+}
+
+TEST(store_search_by_degree_invalid_args) {
+    int64_t hub, mid, leaves[3], island;
+    cbm_store_t *s = setup_degree_store(&hub, &mid, leaves, &island);
+
+    cbm_search_output_t out = {0};
+    out.results = (cbm_search_result_t *)0x1; /* poison — must be reset */
+    out.count = -1;
+    ASSERT_EQ(cbm_store_search_by_degree(NULL, "deg", 10, &out), CBM_STORE_ERR);
+    ASSERT_NULL(out.results);
+    ASSERT_EQ(out.count, 0);
+
+    ASSERT_EQ(cbm_store_search_by_degree(s, NULL, 10, &out), CBM_STORE_ERR);
+
+    cbm_store_close(s);
+    PASS();
+}
+
+TEST(store_search_by_degree_empty_project) {
+    cbm_store_t *s = cbm_store_open_memory();
+    ASSERT_NOT_NULL(s);
+    cbm_store_upsert_project(s, "empty", "/tmp/empty");
+
+    cbm_search_output_t out = {0};
+    int rc = cbm_store_search_by_degree(s, "empty", 10, &out);
+    ASSERT_EQ(rc, CBM_STORE_OK);
+    ASSERT_EQ(out.count, 0);
+    ASSERT_EQ(out.total, 0);
+    cbm_store_search_free(&out);
+
+    cbm_store_close(s);
+    PASS();
+}
+
 /* ── GlobToLike edge cases ──────────────────────────────────────── */
 
 TEST(store_glob_to_like_empty) {
@@ -1835,6 +1951,10 @@ SUITE(store_search) {
     RUN_TEST(store_ensure_case_insensitive);
     RUN_TEST(store_strip_case_flag);
     RUN_TEST(store_batch_count_degrees);
+    RUN_TEST(store_search_by_degree_orders_high_degree_first);
+    RUN_TEST(store_search_by_degree_respects_limit);
+    RUN_TEST(store_search_by_degree_invalid_args);
+    RUN_TEST(store_search_by_degree_empty_project);
     /* Edge case tests */
     RUN_TEST(store_glob_to_like_empty);
     RUN_TEST(store_glob_to_like_only_star);

--- a/tests/test_store_search.c
+++ b/tests/test_store_search.c
@@ -1353,10 +1353,8 @@ static cbm_store_t *setup_degree_store(int64_t *hub, int64_t *mid, int64_t leave
         .project = "deg", .label = "Function", .name = "Hub", .qualified_name = "deg.Hub"};
     cbm_node_t nmid = {
         .project = "deg", .label = "Function", .name = "Mid", .qualified_name = "deg.Mid"};
-    cbm_node_t nisland = {.project = "deg",
-                          .label = "Function",
-                          .name = "Island",
-                          .qualified_name = "deg.Island"};
+    cbm_node_t nisland = {
+        .project = "deg", .label = "Function", .name = "Island", .qualified_name = "deg.Island"};
     *hub = cbm_store_upsert_node(s, &nhub);
     *mid = cbm_store_upsert_node(s, &nmid);
     *island = cbm_store_upsert_node(s, &nisland);
@@ -1365,8 +1363,7 @@ static cbm_store_t *setup_degree_store(int64_t *hub, int64_t *mid, int64_t leave
         char name[16], qn[32];
         snprintf(name, sizeof(name), "Leaf%d", i);
         snprintf(qn, sizeof(qn), "deg.Leaf%d", i);
-        cbm_node_t nl = {
-            .project = "deg", .label = "Function", .name = name, .qualified_name = qn};
+        cbm_node_t nl = {.project = "deg", .label = "Function", .name = name, .qualified_name = qn};
         leaves[i] = cbm_store_upsert_node(s, &nl);
     }
 

--- a/tests/test_ui.c
+++ b/tests/test_ui.c
@@ -749,8 +749,8 @@ TEST(compute_call_depth_csr_bfs) {
     for (int i = hub; i < n; i++)
         labels[i] = "Function";
 
-    const int ne = 1 /* entry->hub */ + N_CHILDREN /* hub->child[i] */ +
-                   1 /* child[0]->grandchild */;
+    const int ne =
+        1 /* entry->hub */ + N_CHILDREN /* hub->child[i] */ + 1 /* child[0]->grandchild */;
     int *es = malloc((size_t)ne * sizeof(int));
     int *ed = malloc((size_t)ne * sizeof(int));
     ASSERT_NOT_NULL(es);

--- a/tests/test_ui.c
+++ b/tests/test_ui.c
@@ -10,6 +10,7 @@
 #include "ui/config.h"
 #include "ui/embedded_assets.h"
 #include "ui/layout3d.h"
+#include "ui/layout3d_internal.h"
 #include "store/store.h"
 #ifdef _WIN32
 #include "foundation/win_utf8.h"
@@ -726,6 +727,68 @@ TEST(layout_dead_code_classification) {
     PASS();
 }
 
+/* ── Call-depth BFS (CSR adjacency) ──────────────────────────────
+ *
+ * Drives cbm_layout_compute_call_depth() directly (see layout3d_internal.h)
+ * rather than through the store-backed cbm_layout_compute(), so the CSR BFS
+ * itself is under test independent of node sampling / query plumbing.
+ */
+TEST(compute_call_depth_csr_bfs) {
+    /* Graph: File entry -> hub -> 20 children (many outgoing edges from one
+     * node) -> one grandchild two hops down, plus a node with no edges at
+     * all (never reached by the BFS). */
+    enum { N_CHILDREN = 20 };
+    const int entry = 0, hub = 1, first_child = 2;
+    const int grandchild = first_child + N_CHILDREN;
+    const int unreachable = grandchild + 1;
+    const int n = unreachable + 1;
+
+    const char **labels = calloc((size_t)n, sizeof(char *));
+    ASSERT_NOT_NULL(labels);
+    labels[entry] = "File"; /* seeds depth 0 as an entry point */
+    for (int i = hub; i < n; i++)
+        labels[i] = "Function";
+
+    const int ne = 1 /* entry->hub */ + N_CHILDREN /* hub->child[i] */ +
+                   1 /* child[0]->grandchild */;
+    int *es = malloc((size_t)ne * sizeof(int));
+    int *ed = malloc((size_t)ne * sizeof(int));
+    ASSERT_NOT_NULL(es);
+    ASSERT_NOT_NULL(ed);
+    int k = 0;
+    es[k] = entry;
+    ed[k] = hub;
+    k++;
+    for (int i = 0; i < N_CHILDREN; i++) {
+        es[k] = hub;
+        ed[k] = first_child + i;
+        k++;
+    }
+    es[k] = first_child;
+    ed[k] = grandchild;
+    k++;
+    ASSERT_EQ(k, ne);
+
+    int *depth = malloc((size_t)n * sizeof(int));
+    ASSERT_NOT_NULL(depth);
+    cbm_layout_compute_call_depth(n, es, ed, ne, labels, depth);
+
+    ASSERT_EQ(depth[entry], 0);
+    ASSERT_EQ(depth[hub], 1);
+    for (int i = 0; i < N_CHILDREN; i++)
+        ASSERT_EQ(depth[first_child + i], 2);
+    ASSERT_EQ(depth[grandchild], 3);
+    /* Never touched by any edge: must fall back to depth 0, not the -1
+     * sentinel and not some stale/garbage value from the CSR arrays. */
+    ASSERT_EQ(depth[unreachable], 0);
+
+    free(labels);
+    free(es);
+    free(ed);
+    free(depth);
+    PASS();
+}
+
 /* ── Octree recursion guard (distilled from PR #821; refs #498/#726/#402) ── */
 
 /* Bodies that share a position made octree_insert subdivide forever — the
@@ -885,5 +948,6 @@ SUITE(ui) {
     RUN_TEST(layout_to_json);
     RUN_TEST(layout_null_inputs);
     RUN_TEST(layout_dead_code_classification);
+    RUN_TEST(compute_call_depth_csr_bfs);
     RUN_TEST(layout_coincident_nodes_bounded);
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #2039.

Makes the graph UI usable on very large projects (tested on a 435k-node / 4.2M-edge index). The browser side stopped leaking GPU and JS memory on every display-setting change, and the server side no longer takes minutes and gigabytes to lay out the graph. One commit per fix so they can be reviewed or split independently:

**Client (graph-ui)**
1. `fix(graph-ui)`: edge and node geometry is allocated once, refilled in place, and disposed on cleanup; edge brightness is applied through the material instead of rewriting 4.2M vertex colors. This is the fix for the leak in #2039.
2. `feat(graph-ui)`: deterministic edge render budget with a "Rendering X of Y edges" notice, mirroring the existing node budget.
3. `perf(graph-ui)`: fewer copies of the layout payload, interned edge/node strings, one shared adjacency index instead of per-click rebuilds, partial top-k for labels.

**Server**
4. `perf(ui)`: call-depth BFS uses a CSR adjacency index (O(n+e) instead of O(n·e)). This was 100 % of the 490 s.
5. `perf(ui)`: edge query is scoped to the sampled node ids and no longer fetches `properties`; node sample is ordered by degree so small budgets produce a connected subgraph.
6. `perf(ui)`: layout JSON is built once and handed straight to the reply buffer, removing the parse → deep-copy → rewrite → printf round trip.

### Measurements

Same machine, same `c1.db`, before = `main` @ 5802ccdd, after = this branch.

`GET /api/layout?project=c1&max_nodes=N`

| N | before | after |
|---|---|---|
| 5 000 (default) | 7.3 s, 461 MB peak, 538 edges (1.8 MB) | 3.7 s, 145 MB peak, 386k edges (22 MB) |
| 150 000 | 20 s, 948 MB peak, 518k edges (84 MB) | 13.5 s, 1.18 GB peak, 2.96M edges (208 MB) |
| 435 000 (all) | 490 s, 3.3 GB peak, 4.2M edges (382 MB) | 31 s, 2.2 GB peak, 4.2M edges (382 MB) |

The degree-ordered sample returns far more edges for the same node budget (that is the point: the old alphabetical sample was almost edge-less), so payloads for small budgets grow. Peak server memory at the full budget is still dominated by the 4.2M-edge JSON document itself; a streaming writer would be the next step and is out of scope here.

Browser, full 435k budget, 14 edge-brightness slider changes:

| | before | after |
|---|---|---|
| Time to first render (incl. server) | ~9 min | 66 s |
| JS heap after render | 855 MB | 639 MB |
| JS heap after 14 changes | 3949 MB (limit 4192), no recovery after 25 s idle | 642 MB (flat) |
| Renderer footprint after 14 changes | 3.4 GB | 0.9 GB |
| GPU process footprint after 14 changes | 4.2 GB | 1.35 GB (browser-wide GPU helper; baseline 0.5 GB) |

The HUD now reads "Rendering 1,000,000 of 4,226,606 edges (render budget)"; node click, detail-panel connections, and edge-type filter toggles were smoke-tested at the 150k budget with no console errors.

### Notes for reviewers
- Two intentional response changes in `/api/layout`: `nodes[]` is now ordered by degree (desc, then name, id) for every request, not alphabetically; and `linked_projects` is always present (possibly `[]`) instead of being omitted when there are none. Edge `source`/`target` still index into the same response's `nodes[]`.
- The layout header comment claiming positions are cached in SQLite was stale; there is no cache. Adding one is a reasonable follow-up but out of scope here.
- `cbm_store_search` ordering is unchanged (it is a paginated public API); degree ordering is a separate opt-in query used only by the layout.
- Edge geometry capacity only grows within a mounted graph; buffers sized for the largest edge count seen stay allocated until the graph unmounts.
- `scripts/test.sh` (ASan+UBSan, 141 suites) passed except one pre-existing flaky test (`index_second_inprocess_run_survives_issue773`) that also fails intermittently on the merge base. `clang-format`, `cppcheck`, and diff-scoped `clang-tidy` are clean on the changed files; note `src/ui/*.c` is not in the Makefile's lint file list.
- This bundles six fixes for one issue because they are all needed for the large-project case to work; happy to split into per-commit PRs if preferred.

## Checklist

- [x] Every commit is signed off (`git commit -s`)
- [x] Tests pass locally (`make -f Makefile.cbm test`)
- [x] Lint passes (`make -f Makefile.cbm lint-ci`)
- [x] New behavior is covered by a test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
