### PR TITLE
test(cli): point PATH at the fixture so uninstall isolation holds on any machine

### DIFF
--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -2033,6 +2033,15 @@ TEST(cli_uninstall_quiesces_active_cohort_before_removing_binary_and_index) {
     char *old_cache = NULL;
     cli_activation_save_env(&old_home, &old_cache);
     cbm_setenv("HOME", tmpdir, 1);
+    /* PATH has to move with HOME. Agent detection asks cbm_find_cli, which
+     * reads PATH before anything else, so a real agent binary on the developer's
+     * PATH is found even though HOME points at this fixture. Uninstall then
+     * tries to edit that agent's config file here, fails because the fixture
+     * never created one, and stops before removing the binary and the index —
+     * which is exactly what this test measures. Redirecting PATH makes the
+     * result the same on every machine. */
+    char *old_path = save_test_env("PATH");
+    cbm_setenv("PATH", tmpdir, 1);
 
     char cache_dir[512];
     char index_path[640];
@@ -2070,6 +2079,7 @@ TEST(cli_uninstall_quiesces_active_cohort_before_removing_binary_and_index) {
     bool binary_preserved =
         installed && strcmp(installed, "binary must survive active-daemon refusal") == 0;
     cli_activation_restore_env(old_home, old_cache);
+    restore_test_env("PATH", old_path);
     test_rmdir_r(tmpdir);
 
     ASSERT_EQ(rc, 0);


### PR DESCRIPTION
## What this changes

One test moved `HOME` and `CBM_CACHE_DIR` into a temporary directory but left `PATH` alone.
This points `PATH` at the same fixture and restores it afterwards, using the
`save_test_env` / `restore_test_env` pair that the Copilot and VS Code tests in this file
already use. Ten added lines, one test, no production code.

## Why the test failed

Agent detection reads `PATH` before anything else, so a real agent binary on the
developer's machine is found even though `HOME` points at an empty fixture. `uninstall`
then tries to edit that agent's config file inside the fixture, fails because the fixture
never created one, and stops before removing the binary and the index — which is the thing
`cli_uninstall_quiesces_active_cohort_before_removing_binary_and_index` measures.

On my machine the agent is Goose, at `/Users/<me>/go/bin/goose`:

```
error: agent_config agent=Goose op=mcp_uninstall path=/tmp/cli-daemon-uninstall-7gY0EY/.config/goose/config.yaml (target: does not exist or cannot be inspected)
error: one or more agent cleanup operations failed; executable and index removal were not started
```

The test then fails on `ASSERT_EQ(rc, 0)` with `rc == 1`.

## Evidence

Same tree, same built `test-runner`, only `PATH` differs:

| Run | Result |
|:--|:--|
| `goose` on `PATH`, before this change | `291 passed, 1 failed` |
| `goose` removed from `PATH`, before this change | `292 passed, 0 failed` |
| `goose` on `PATH`, after this change | `292 passed, 0 failed` |

The third row is the one that matters: the suite is green while `goose` is still installed
and still on `PATH`, so the fix is the redirect rather than a quieter environment.

## This does not fix the underlying defect

The abort it exposed is real, and I reported it on #1954, which already tracks the same
abort reached through a symlinked Cursor config. One agent config that cannot be edited
stops teardown for every other agent and for the executable and indexes. That wants a
product decision I did not want to make for you — treat "nothing to remove" as success at
the two call sites, or keep it an error that no longer gates the executable and index
removal — so this PR only stops the test suite from depending on what the developer has
installed.

## Scope I deliberately left alone

Fourteen tests call `cli_activation_save_env`. Twelve leave `PATH` open the same way; only
`cli_install_config_failure_keeps_published_binary` and
`cli_update_already_current_does_not_quiesce_sessions` redirect it today.

I changed only the one that demonstrably fails. The other eleven pass on this machine, and
redirecting `PATH` in a passing test changes what it exercises, so I did not want to do that
without a failure to point at. Happy to send that as a follow-up if you would rather have
the whole class covered at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERsNp8UNLaixL4uUz7hRTX
