### PR TITLE
test(mcp): over-long grep records never invent matches (#2011)

### DIFF
--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -10118,6 +10118,73 @@ TEST(search_code_path_filter_prefilter_keeps_matches) {
     PASS();
 }
 
+/* #2011: a grep record longer than the read buffer used to be split across two
+ * fgets calls, and the continuation was parsed as a fresh file:line:content
+ * record — inventing a file path out of matched content and a line number of 0.
+ * A single >2 KiB line containing colons reproduces it: the repository holds
+ * two matches, and the split used to report three. */
+TEST(search_code_long_line_does_not_invent_matches) {
+    char tmp[512];
+    snprintf(tmp, sizeof(tmp), "/tmp/cbm_srch_longline_XXXXXX");
+    ASSERT_TRUE(cbm_mkdtemp(tmp) != NULL);
+
+    char big_path[768], normal_path[768];
+    snprintf(big_path, sizeof(big_path), "%s/big.js", tmp);
+    snprintf(normal_path, sizeof(normal_path), "%s/normal.js", tmp);
+
+    /* One line well over the 2 KiB read buffer, full of colons, with the
+     * needle at the very end so the match lands past the split point. */
+    FILE *fp = fopen(big_path, "w");
+    ASSERT_NOT_NULL(fp);
+    fprintf(fp, "var CFG=({");
+    for (int i = 0; i < 260; i++) {
+        fprintf(fp, "k%d:\"v%d\",", i, i);
+    }
+    fprintf(fp, "NEEDLEmarker:1});\n");
+    fclose(fp);
+
+    fp = fopen(normal_path, "w");
+    ASSERT_NOT_NULL(fp);
+    fprintf(fp, "const NEEDLEmarker = 42;\n");
+    fclose(fp);
+
+    cbm_mcp_server_t *srv = cbm_mcp_server_new(NULL);
+    ASSERT_NOT_NULL(srv);
+    const char *proj = "longline-search";
+    cbm_mcp_server_set_project(srv, proj);
+    cbm_store_upsert_project(cbm_mcp_server_store(srv), proj, tmp);
+
+    char *resp = cbm_mcp_server_handle(
+        srv, "{\"jsonrpc\":\"2.0\",\"id\":96,\"method\":\"tools/call\","
+             "\"params\":{\"name\":\"search_code\","
+             "\"arguments\":{\"pattern\":\"NEEDLEmarker\",\"project\":\"longline-search\"}}}");
+    ASSERT_NOT_NULL(resp);
+    char *inner = extract_text_content(resp);
+    ASSERT_NOT_NULL(inner);
+
+    /* Exactly the two real matches — the split must not produce a third. */
+    int grep_matches = -1;
+    const char *g = strstr(inner, "\"total_grep_matches\":");
+    if (g) {
+        sscanf(g, "\"total_grep_matches\":%d", &grep_matches);
+    } else if ((g = strstr(inner, "total_grep_matches: ")) != NULL) {
+        sscanf(g, "total_grep_matches: %d", &grep_matches);
+    }
+    ASSERT_EQ(grep_matches, 2);
+
+    /* Every reported line number belongs to a real line: the fabricated row
+     * carried line 0, which no grep -n record can produce. */
+    ASSERT_TRUE(strstr(inner, "\"line\":0") == NULL);
+
+    free(inner);
+    free(resp);
+    cbm_mcp_server_free(srv);
+    unlink(big_path);
+    unlink(normal_path);
+    rmdir(tmp);
+    PASS();
+}
+
 /* PR #756 (distilled): path_filter matching ZERO indexed files. With the
  * prefilter the scoped filelist has 0 records, and handle_search_code now
  * skips the grep subprocess entirely (xargs on an empty filelist is
@@ -19923,6 +19990,7 @@ SUITE(mcp) {
     RUN_TEST(search_code_scoped_path_with_cjk_root_issue903);
 #endif
     RUN_TEST(search_code_path_filter_prefilter_keeps_matches);
+    RUN_TEST(search_code_long_line_does_not_invent_matches);
     RUN_TEST(search_code_path_filter_matches_nothing);
     RUN_TEST(search_code_file_pattern_prefilter_boundaries);
     RUN_TEST(search_code_windows_scope_prefilter_removes_pipeline_filter);


### PR DESCRIPTION
Regression test for #2011. **The production fix already landed via #1597 (`3c7427e`)** — this PR is now the test only.

## What #2011 was

A grep record longer than the read buffer was split across two reads, and the continuation was parsed as a fresh `file:line:content` record: a fragment of matched content became the **file**, and the text after the next delimiter became the **line number**. An agent reading that result called `get_code_snippet` on a path that was never in the repository. The same split could also *lose* a real match, when the tail held fewer than two delimiters and the record was dropped by a `continue` instead.

## Why this is test-only now

`search_code` no longer reads into a fixed buffer. On current `main`, `scan_and_classify_grep_matches` reads each record with `cbm_getline` into a growable buffer:

```c
ssize_t line_length = cbm_getline(&line, &line_capacity, fp);
```

so a record cannot split, and `collect_grep_matches` is gone. I confirmed that before rebasing — the only remaining mention of the old function on `main` is a word in a comment.

That closed #2011 as a side effect of the lean-output work rather than as a targeted fix, so **nothing on `main` guards the shape today**. A future rewrite of the read loop that reintroduced a fixed buffer would restore the bug silently. Hence the test.

## The test

`tests/test_mcp.c` → `search_code_long_line_does_not_invent_matches`, beside the existing `search_code_path_filter_*` tests and registered in the suite. It writes a >2 KiB colon-laden line plus a normal one, calls `search_code` through `cbm_mcp_server_handle`, and asserts:

- `total_grep_matches == 2` — the repository's two real matches, not the three the split produced
- no row carries `line: 0`, the value the fabricated record used to yield

Against the original buffered implementation it failed exactly as #2011 describes (`grep_matches == 3, expected 2`); against `main`'s `cbm_getline` version it passes, as you confirmed on your side.

## Changes from the first version of this PR

- Rebased onto current `main`; the `src/mcp/mcp.c` drain hunk is dropped entirely — `main`'s file taken as-is, per your resolution.
- Retitled from `fix(mcp): …` to `test(mcp): …`, since there is no production change left.
- Commit re-authored under `kavish-19 <63698788+kavish-19@users.noreply.github.com>`; the earlier push used the wrong email of mine, which I have corrected on #2065 too. Sign-off matches the author on both.

Diff against `main` is `tests/test_mcp.c` only.
