### PR TITLE
fix(discover): keep VB6 .frm/.cls files out of the FORM and Apex grammars

### DIFF
--- a/src/discover/discover.c
+++ b/src/discover/discover.c
@@ -700,7 +700,7 @@ static CBMLanguage detect_file_language(const char *entry_name, const char *abs_
     if (dot && strcmp(dot, ".m") == 0) {
         lang = cbm_disambiguate_m(abs_path);
     }
-    /* Special: .cls is shared by ObjectScript UDL and Apex */
+    /* Special: .cls is shared by ObjectScript UDL, Apex and VB6 class modules */
     if (dot && strcmp(dot, ".cls") == 0) {
         lang = cbm_disambiguate_cls(abs_path);
     }
@@ -711,6 +711,10 @@ static CBMLanguage detect_file_language(const char *entry_name, const char *abs_
     /* Special: .cfc components may be script-dialect or tag-dialect (<cfcomponent>) */
     if (dot && strcmp(dot, ".cfc") == 0) {
         lang = cbm_disambiguate_cfc(abs_path);
+    }
+    /* Special: .frm is shared by FORM and VB6 forms (#721) */
+    if (dot && strcmp(dot, ".frm") == 0) {
+        lang = cbm_disambiguate_frm(abs_path);
     }
     /* Special: ObjectScript Studio Export XML (<Export generator="...">) is
      * detected by content; otherwise .xml stays XML. */

--- a/src/discover/discover.h
+++ b/src/discover/discover.h
@@ -41,8 +41,14 @@ CBMLanguage cbm_disambiguate_m(const char *path);
 
 /* Disambiguate .cls files by reading first 4KB of content.
  * Returns CBM_LANG_OBJECTSCRIPT_UDL if a line starts with "Class <Uppercase>",
+ * CBM_LANG_COUNT (unsupported) for a Visual Basic 6 class module (#721),
  * otherwise CBM_LANG_APEX. On read failure, defaults to CBM_LANG_APEX. */
 CBMLanguage cbm_disambiguate_cls(const char *path);
+
+/* Disambiguate .frm files by reading first 4KB of content (#721).
+ * Returns CBM_LANG_COUNT (unsupported) for a Visual Basic 6 form, otherwise
+ * CBM_LANG_FORM. On read failure, defaults to CBM_LANG_FORM. */
+CBMLanguage cbm_disambiguate_frm(const char *path);
 
 /* Disambiguate .inc files by reading first 4KB of content.
  * Returns CBM_LANG_OBJECTSCRIPT_ROUTINE if it looks like an ObjectScript

--- a/src/discover/language.c
+++ b/src/discover/language.c
@@ -1249,9 +1249,49 @@ CBMLanguage cbm_disambiguate_m(const char *path) {
     return CBM_LANG_MATLAB;
 }
 
-/* Disambiguate .cls files: shared by InterSystems ObjectScript UDL and
- * Salesforce Apex. ObjectScript class files begin with a line of the form
- * "Class <UppercasePackage>...". Defaults to Apex on any doubt. */
+/* Visual Basic 6 / VBA source exports are recognisable from their header (#721):
+ * every module carries `Attribute VB_Name = "..."`, class modules open with
+ * `VERSION 1.0 CLASS`, forms/controls with `VERSION 5.00` + `Begin VB.Form` /
+ * `Begin VB.UserControl`. None of these occur in Apex or ObjectScript classes
+ * or in FORM programs, whose .cls / .frm extensions VB6 happens to share. */
+static bool has_vb6_markers(const char *buf) {
+    return str_contains(buf, "Attribute VB_Name") || str_contains(buf, "VERSION 1.0 CLASS") ||
+           str_contains(buf, "Begin VB.") || str_contains(buf, "\nOption Explicit");
+}
+
+/* Disambiguate .frm files: shared by the FORM symbolic-manipulation language
+ * and Visual Basic 6 forms (#721). There is no Visual Basic language yet, so a
+ * VB6 form is reported as unsupported (CBM_LANG_COUNT) rather than handed to
+ * the FORM grammar, which yields no defs and stray junk nodes. Defaults to
+ * FORM on any doubt (preserves existing behaviour). */
+CBMLanguage cbm_disambiguate_frm(const char *path) {
+    if (!path) {
+        return CBM_LANG_FORM;
+    }
+
+    FILE *f = cbm_fopen(path, "r");
+    if (!f) {
+        return CBM_LANG_FORM;
+    }
+
+    char buf[CBM_SZ_4K + SKIP_ONE];
+    size_t n = fread(buf, SKIP_ONE, CBM_SZ_4K, f);
+    buf[n] = '\0';
+    (void)fclose(f);
+
+    /* VB6 form files open with "VERSION x.yy" on line 1. */
+    if (strncmp(buf, "VERSION ", SLEN("VERSION ")) == 0 &&
+        isdigit((unsigned char)buf[SLEN("VERSION ")])) {
+        return CBM_LANG_COUNT;
+    }
+    return has_vb6_markers(buf) ? CBM_LANG_COUNT : CBM_LANG_FORM;
+}
+
+/* Disambiguate .cls files: shared by InterSystems ObjectScript UDL, Salesforce
+ * Apex and Visual Basic 6 class modules (#721). ObjectScript class files begin
+ * with a line of the form "Class <UppercasePackage>..."; VB6 class modules
+ * carry the VB6 header markers and are reported as unsupported (CBM_LANG_COUNT)
+ * until a Visual Basic grammar exists. Defaults to Apex on any doubt. */
 CBMLanguage cbm_disambiguate_cls(const char *path) {
     if (!path) {
         return CBM_LANG_APEX;
@@ -1266,6 +1306,10 @@ CBMLanguage cbm_disambiguate_cls(const char *path) {
     size_t n = fread(buf, SKIP_ONE, CBM_SZ_4K, f);
     buf[n] = '\0';
     (void)fclose(f);
+
+    if (has_vb6_markers(buf)) {
+        return CBM_LANG_COUNT;
+    }
 
     const char *line = buf;
     while (*line) {

--- a/tests/test_language.c
+++ b/tests/test_language.c
@@ -640,6 +640,72 @@ static CBMLanguage disambiguate_cfc_content(const char *name, const char *conten
     return lang;
 }
 
+/* ── .cls / .frm: VB6 vs Apex / ObjectScript / FORM (#721) ────────── */
+
+static bool write_probe_file(const char *path, const char *content) {
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        return false;
+    }
+    fputs(content, f);
+    fclose(f);
+    return true;
+}
+
+TEST(lang_cls_vb6_class_module_unsupported) {
+    char path[256];
+    snprintf(path, sizeof(path), "%s/test_lang_vb6.cls", cbm_tmpdir());
+    ASSERT_TRUE(write_probe_file(path, "VERSION 1.0 CLASS\r\nBEGIN\r\n  MultiUse = -1  'True\r\n"
+                                       "END\r\nAttribute VB_Name = \"Widget\"\r\n"
+                                       "Option Explicit\r\n\r\nPublic Sub Go()\r\nEnd Sub\r\n"));
+    ASSERT_EQ(cbm_disambiguate_cls(path), CBM_LANG_COUNT);
+    remove(path);
+    PASS();
+}
+
+TEST(lang_cls_apex_stays_apex) {
+    char path[256];
+    snprintf(path, sizeof(path), "%s/test_lang_apex.cls", cbm_tmpdir());
+    ASSERT_TRUE(write_probe_file(path, "public with sharing class Widget {\n"
+                                       "  public void go() {}\n}\n"));
+    ASSERT_EQ(cbm_disambiguate_cls(path), CBM_LANG_APEX);
+    remove(path);
+    /* Unreadable file keeps the pre-existing owner. */
+    ASSERT_EQ(cbm_disambiguate_cls("/tmp/nonexistent_file_12345.cls"), CBM_LANG_APEX);
+    PASS();
+}
+
+TEST(lang_cls_objectscript_stays_objectscript) {
+    char path[256];
+    snprintf(path, sizeof(path), "%s/test_lang_udl.cls", cbm_tmpdir());
+    ASSERT_TRUE(write_probe_file(path, "Class MyPkg.Widget Extends %RegisteredObject\n{\n\n"
+                                       "Method Go()\n{\n}\n\n}\n"));
+    ASSERT_EQ(cbm_disambiguate_cls(path), CBM_LANG_OBJECTSCRIPT_UDL);
+    remove(path);
+    PASS();
+}
+
+TEST(lang_frm_vb6_form_unsupported) {
+    char path[256];
+    snprintf(path, sizeof(path), "%s/test_lang_vb6.frm", cbm_tmpdir());
+    ASSERT_TRUE(write_probe_file(path, "VERSION 5.00\r\nBegin VB.Form Form1 \r\n"
+                                       "   Caption         =   \"Hi\"\r\nEnd\r\n"
+                                       "Attribute VB_Name = \"Form1\"\r\nOption Explicit\r\n"));
+    ASSERT_EQ(cbm_disambiguate_frm(path), CBM_LANG_COUNT);
+    remove(path);
+    PASS();
+}
+
+TEST(lang_frm_form_stays_form) {
+    char path[256];
+    snprintf(path, sizeof(path), "%s/test_lang_form.frm", cbm_tmpdir());
+    ASSERT_TRUE(write_probe_file(path, "Symbols x, y;\nLocal F = x + y;\nPrint;\n.end\n"));
+    ASSERT_EQ(cbm_disambiguate_frm(path), CBM_LANG_FORM);
+    remove(path);
+    ASSERT_EQ(cbm_disambiguate_frm("/tmp/nonexistent_file_12345.frm"), CBM_LANG_FORM);
+    PASS();
+}
+
 TEST(lang_cfc_tag_component) {
     /* <cfcomponent> wrapper ⇒ tag dialect. */
     ASSERT_EQ(disambiguate_cfc_content("test_cfc_tag.cfc",
@@ -1351,6 +1417,11 @@ SUITE(language) {
     RUN_TEST(lang_cfc_tag_after_license_comment);
     RUN_TEST(lang_cfc_script_after_license_comment);
     RUN_TEST(lang_cfc_default_on_read_fail);
+    RUN_TEST(lang_cls_vb6_class_module_unsupported);
+    RUN_TEST(lang_cls_apex_stays_apex);
+    RUN_TEST(lang_cls_objectscript_stays_objectscript);
+    RUN_TEST(lang_frm_vb6_form_unsupported);
+    RUN_TEST(lang_frm_form_stays_form);
 
     /* Go test ports */
     /* New languages */


### PR DESCRIPTION
## What does this PR do?

Stops Visual Basic 6 `.frm` / `.cls` files from being parsed with the wrong grammar — the short-term fix agreed in #721 (maintainer comment: "Short-term disambiguation looks like the right first PR").

Refs #721 (part 1 of 2; the Visual Basic grammar itself follows once the grammar choice is settled on the issue).

**Before:** VB6 forms went to the FORM grammar (0 defs), VB6 class modules to the Apex grammar (junk nodes; several timed out in `extract`).
**After:** both are recognised by their export header and reported as unsupported (`CBM_LANG_COUNT`, i.e. skipped), so the graph no longer contains misparsed nodes for them.

- `src/discover/language.c`: `has_vb6_markers()` (`Attribute VB_Name`, `VERSION 1.0 CLASS`, `Begin VB.`, `Option Explicit`); new `cbm_disambiguate_frm()` (line-1 `VERSION x.yy` or markers → unsupported, else FORM); the existing `cbm_disambiguate_cls()` (ObjectScript UDL vs Apex) gains the VB6 check before its ObjectScript line scan.
- `src/discover/discover.c`: `.frm` hook next to the `.m`/`.cls`/`.inc`/`.cfc` ones.
- `src/discover/discover.h`: docs for both.
- `tests/test_language.c`: VB6 `.cls` → unsupported, Apex stays Apex, **ObjectScript stays ObjectScript** (regression), VB6 `.frm` → unsupported, FORM stays FORM; read-failure defaults preserved.

No language table changes; defaults on any doubt are unchanged (Apex / FORM), so non-VB6 users see no difference.

## Checklist

- [x] Every commit is signed off (`git commit -s`)
- [x] Tests pass locally — note: run on Windows with a zig/clang toolchain **without** ASan/UBSan (no sanitiser runtime on this host); the `language`, `discover`, `grammar_regression`, `grammar_labels` and `lang_contract` suites pass on today's `main` (745794df); CI's sanitised runs are the authoritative check
- [x] Lint: `clang-format-20 --dry-run --Werror` clean on the touched `src/` files; cppcheck not run locally (not installed) — relying on CI
- [x] New behaviour is covered by a test (five new cases in `tests/test_language.c`)
