### PR TITLE
fix(pipeline): skip the function sort when the graph has no functions

### DIFF
--- a/src/pipeline/pass_semantic_edges.c
+++ b/src/pipeline/pass_semantic_edges.c
@@ -992,8 +992,12 @@ static int phase1_scan_functions(cbm_gbuf_t *gbuf, cbm_sem_func_t **out_funcs,
      * sequence — so an unstable order changes WHICH semantic edges are
      * emitted. Sort the cheap pointer array by qualified name (unique) and
      * re-derive the three fields set so far; the heavy per-func payloads are
-     * filled in later phases, so no 12.7 KB structs are moved. */
-    qsort(node_ptrs, (size_t)func_count, sizeof(node_ptrs[0]), cmp_node_ptr_by_qn);
+     * filled in later phases, so no 12.7 KB structs are moved.
+     * A graph with no Function/Method nodes never allocates node_ptrs, and
+     * qsort's base is declared nonnull (glibc), so skip the sort outright. */
+    if (func_count > 0) {
+        qsort(node_ptrs, (size_t)func_count, sizeof(node_ptrs[0]), cmp_node_ptr_by_qn);
+    }
     for (int k = 0; k < func_count; k++) {
         funcs[k].node_id = node_ptrs[k]->id;
         funcs[k].file_path = node_ptrs[k]->file_path;

--- a/tests/test_pipeline.c
+++ b/tests/test_pipeline.c
@@ -13409,6 +13409,54 @@ TEST(pipeline_markdown_and_config_prose_reaches_fts_body) {
     PASS();
 }
 
+/* A graph with no Function or Method nodes at all -- a struct-only or
+ * config-only project -- must run pass_semantic_edges cleanly. Its phase-1
+ * scan used to hand qsort() a NULL base with count 0, before the func_count
+ * early-out in phase 1b could run. glibc declares qsort's base nonnull, so
+ * UBSan on the Linux leg reports that call; the macOS SDK carries no such
+ * attribute, so the sanitizer is silent there. The label counts pin the
+ * fixture to what it claims: at least one Struct and zero Function/Method,
+ * i.e. the scan genuinely finds nothing to sort. */
+TEST(pipeline_semantic_edges_no_functions) {
+    char tmp[256];
+    snprintf(tmp, sizeof(tmp), "/tmp/cbm_nofunc_XXXXXX");
+    ASSERT_NOT_NULL(cbm_mkdtemp(tmp));
+    char path[512];
+    char dbpath[512];
+    snprintf(dbpath, sizeof(dbpath), "%s/nofunc.db", tmp);
+
+    snprintf(path, sizeof(path), "%s/main.go", tmp);
+    ASSERT_EQ(th_write_file(path, "package main\n\ntype Widget struct{}\n"), 0);
+
+    cbm_pipeline_t *p = cbm_pipeline_new(tmp, dbpath, CBM_MODE_FULL);
+    ASSERT_NOT_NULL(p);
+    ASSERT_EQ(cbm_pipeline_run(p), 0);
+    cbm_pipeline_free(p);
+
+    cbm_store_t *s = cbm_store_open_path(dbpath);
+    ASSERT_NOT_NULL(s);
+    sqlite3_stmt *st = NULL;
+    ASSERT_EQ(sqlite3_prepare_v2(cbm_store_get_db(s), "SELECT COUNT(*) FROM nodes WHERE label = ?1",
+                                 -1, &st, NULL),
+              SQLITE_OK);
+    const char *labels[] = {"Struct", "Function", "Method"};
+    int counts[3] = {0, 0, 0};
+    for (size_t i = 0; i < sizeof(labels) / sizeof(labels[0]); i++) {
+        sqlite3_reset(st);
+        sqlite3_bind_text(st, 1, labels[i], -1, SQLITE_TRANSIENT);
+        ASSERT_EQ(sqlite3_step(st), SQLITE_ROW);
+        counts[i] = sqlite3_column_int(st, 0);
+    }
+    sqlite3_finalize(st);
+    cbm_store_close(s);
+    ASSERT_GT(counts[0], 0);
+    ASSERT_EQ(counts[1], 0);
+    ASSERT_EQ(counts[2], 0);
+
+    th_rmtree(tmp);
+    PASS();
+}
+
 #if defined(CBM_COVERAGE_MARKER_TEST_API) && CBM_COVERAGE_MARKER_TEST_API
 /* Join two Studio Export range strings and hand back the result. The caller
  * owns nothing: the string lives in the aggregate's arena, so copy it out
@@ -13827,6 +13875,7 @@ SUITE(pipeline) {
     RUN_TEST(pipeline_ensemble_routing_unterminated_item_is_safe);
     RUN_TEST(pipeline_delta_patch_indexes_docstring_into_fts_body);
     RUN_TEST(pipeline_markdown_and_config_prose_reaches_fts_body);
+    RUN_TEST(pipeline_semantic_edges_no_functions);
 }
 
 /* Focused semantic-manifest and publication contracts. Kept separate from the


### PR DESCRIPTION
## Defect

`phase1_scan_functions()` in `src/pipeline/pass_semantic_edges.c` sorts the collected Function/Method node pointers (`qsort(node_ptrs, (size_t)func_count, ...)`) so the func order is deterministic. When the graph has **no Function or Method node at all**, `node_ptrs` is never allocated and the call is `qsort(NULL, 0, ...)`. The `func_count <= 0` early-out sits in phase 1b (`phase1b_decode_and_build`), which runs only after phase 1 has returned, so it never guards this call. A NULL `qsort` base is undefined behaviour; glibc declares the parameter `nonnull`, so UBSan reports it.

## Reachability

Any struct/class-only or config-only project indexed in full/moderate mode. The existing `pipeline_docstring_go_class` test (a Go struct-only fixture) already reaches the call on the Linux leg today.

## Which lane flags it

- **Linux is the binding lane**: the arm64 test container (gcc 13.3 + glibc; `scripts/test.sh --suites pipeline CC=gcc CXX=g++ BUILD_DIR=build/linux-arm64`) reports `src/pipeline/pass_semantic_edges.c:996:5: runtime error: null pointer passed as argument 1, which is declared to never be null` with the stack `phase1_scan_functions` <- `cbm_pipeline_pass_semantic_edges` <- `predump_sem` <- `cbm_pipeline_run`.
- **macOS cannot flag it**: the SDK's `qsort` (`usr/include/_stdlib.h`) carries `_Nonnull` only on the comparator, so both the default ASan/UBSan build and the Homebrew LLVM diag lane are silent. Verified with a stand-alone `qsort(NULL, 0, ...)` probe under Apple clang 21 and Homebrew clang 22.1.8: no report from either.
- The harness has no UBSan gating (no `UBSAN_OPTIONS`, no `-fno-sanitize-recover`, no report scan), so a recoverable report prints and the suite still passes -- which is why this went unnoticed. That is being recorded separately as a test-infra finding.

## Fix

Guard the sort on `func_count > 0` (three lines, main's style). The re-derivation loop after it is already a no-op for an empty scan.

## Regression test

`pipeline_semantic_edges_no_functions` (suite `pipeline`) indexes a Go struct-only fixture (`type Widget struct{}`) through the full pipeline so `pass_semantic_edges` runs, and pins the fixture to what it claims: `Struct >= 1`, `Function = 0`, `Method = 0`.

## Verification

- **RED on `origin/main` (aa44c28e)**, Linux container, `UBSAN_OPTIONS=halt_on_error=1` with the one unrelated pre-existing report site suppressed (the vendored objectscript_udl external scanner passing a NULL source to `memcpy`, which surfaces as `scanner.c:122` and `bits/string_fortified.h:29`): the `pipeline` suite aborts at `pass_semantic_edges.c:996`, exit 1. UBSan reports each site once per process and `pipeline_docstring_go_class` reaches it first in suite order; with the new test registered first for one diagnostic run, the abort is owned by `pipeline_semantic_edges_no_functions`.
- **GREEN with the fix**, same lane: recoverable run 275 passed with zero `:996` reports (only the two objectscript_udl reports remain); `halt_on_error=1` run completes, 275 passed, exit 0.
- macOS default lane: `build/c/test-runner pipeline extraction` 617 passed, zero UBSan output (before and after, as expected on this SDK).
- `make -f Makefile.cbm lint-ci` clean; `bash scripts/check-no-test-skips.sh` OK; no raw `fopen(`, no SKIP/NOLINT, ASCII-only additions.

Distilled from #1810 with co-author credit to @ysfsmet.

Refs #1810
