### PR TITLE
fix(lang): track Solidity modifier invocations as decorators

### DIFF
--- a/internal/cbm/lang_specs.c
+++ b/internal/cbm/lang_specs.c
@@ -1038,6 +1038,7 @@ static const char *solidity_field_types[] = {"state_variable_declaration", "stru
 static const char *solidity_call_types[] = {"call_expression", "call", "new_expression", NULL};
 static const char *solidity_import_types[] = {"import_directive", "import", "using_directive",
                                               NULL};
+static const char *solidity_decorator_types[] = {"modifier_invocation", NULL};
 static const char *solidity_branch_types[] = {"if_statement",    "for_statement",
                                               "while_statement", "do_while_statement",
                                               "try_statement",   NULL};
@@ -2115,7 +2116,7 @@ static const CBMLangSpec lang_specs[CBM_LANG_COUNT] = {
                            solidity_field_types, solidity_module_types, solidity_call_types,
                            solidity_import_types, empty_types, solidity_branch_types,
                            solidity_var_types, solidity_assign_types, solidity_throw_types, NULL,
-                           empty_types, NULL, NULL, tree_sitter_solidity, NULL},
+                           solidity_decorator_types, NULL, NULL, tree_sitter_solidity, NULL},
 
     // CBM_LANG_TYPST
     [CBM_LANG_TYPST] = {CBM_LANG_TYPST, typst_func_types, empty_types, empty_types,


### PR DESCRIPTION
## Summary

Adds Solidity `modifier_invocation` support to the existing Solidity language specification so modifier usages such as `onlyOwner` are tracked as decorators in the code graph.

## Changes

* Added `solidity_decorator_types` with `modifier_invocation`
* Wired it into `CBM_LANG_SOLIDITY`
* Enables modifier definitions and invocations such as `onlyOwner` to be tracked correctly

## Verification

Verified locally with `search_code` using `onlyOwner`:

* Found the modifier definition
* Found the `onlyOwner` invocation on `withdraw`

 Relation to #1754

The issue proposes adding Solidity parser support. Since Solidity grammar is already vendored through Tree-sitter, this change extends the existing parsing path without introducing a Node.js runtime or JavaScript dependency.

This PR specifically fixes the missing modifier/decorator tracking in the current Solidity support.
