### PR TITLE
feat(cli): opt-in exit contract for index_repository

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -157,6 +157,81 @@ int cbm_cli_exit_status_after_maintenance(int exit_status, bool maintenance_canc
     return maintenance_cancelled && exit_status == EXIT_SUCCESS ? EXIT_FAILURE : exit_status;
 }
 
+/* One override, parsed strictly: a typo must not silently disable a gate, so
+ * anything that is not a whole number falls back to the documented default. */
+static long cli_gate_threshold(const char *name, long fallback) {
+    const char *raw = getenv(name);
+    if (!raw || !raw[0]) {
+        return fallback;
+    }
+    char *end = NULL;
+    errno = 0;
+    long value = strtol(raw, &end, 10);
+    /* Overflow clamps to LONG_MAX with the whole string consumed, which would
+     * read as a ceiling no run can exceed: the one typo that disables a gate. */
+    if (errno == ERANGE || end == raw || *end != '\0') {
+        return fallback;
+    }
+    return value;
+}
+
+/* The contract is opt-in. Unset, empty, or "0" leaves the historical 0/1
+ * status untouched, so no existing caller sees a new code until it asks. */
+static bool cli_gate_enabled(void) {
+    const char *raw = getenv("CBM_GATE");
+    return raw && raw[0] && strcmp(raw, "0") != 0;
+}
+
+int cbm_cli_index_exit_status(const char *result, int base_status) {
+    if (!result || !cli_gate_enabled()) {
+        return base_status;
+    }
+    yyjson_doc *envelope = yyjson_read(result, strlen(result), 0);
+    if (!envelope) {
+        return base_status;
+    }
+    yyjson_val *root = yyjson_doc_get_root(envelope);
+    yyjson_val *content = yyjson_is_obj(root) ? yyjson_obj_get(root, "content") : NULL;
+    yyjson_val *first = yyjson_is_arr(content) ? yyjson_arr_get_first(content) : NULL;
+    const char *text = first ? yyjson_get_str(yyjson_obj_get(first, "text")) : NULL;
+
+    int status = base_status;
+    yyjson_doc *payload = text ? yyjson_read(text, strlen(text), 0) : NULL;
+    yyjson_val *proot = payload ? yyjson_doc_get_root(payload) : NULL;
+    if (yyjson_is_obj(proot)) {
+        const char *state = yyjson_get_str(yyjson_obj_get(proot, "status"));
+        const char *reason = yyjson_get_str(yyjson_obj_get(proot, "reason"));
+        if (state && strcmp(state, "error") == 0) {
+            status = (reason && strcmp(reason, "target_unavailable") == 0)
+                         ? CBM_CLI_EXIT_TARGET
+                         : (base_status != CBM_CLI_EXIT_OK ? base_status : CBM_CLI_EXIT_FAILURE);
+        } else if (base_status == CBM_CLI_EXIT_OK) {
+            long unusable = (long)yyjson_get_int(yyjson_obj_get(proot, "parse_unusable_count"));
+            long partial = (long)yyjson_get_int(yyjson_obj_get(proot, "parse_partial_count"));
+            long files = (long)yyjson_get_int(yyjson_obj_get(proot, "files_indexed"));
+            long max_unusable = cli_gate_threshold("CBM_GATE_MAX_UNUSABLE", 0);
+            long max_partial_pct = cli_gate_threshold("CBM_GATE_MAX_PARTIAL_PCT", 10);
+            /* "degraded" is the pipeline's own verdict that the graph came out
+             * far smaller than the run expected — a quality failure by any
+             * reading, so it joins the two parse thresholds. */
+            bool degraded = strcmp(state ? state : "", "degraded") == 0;
+            bool too_many_unusable = max_unusable >= 0 && unusable > max_unusable;
+            /* Integer arithmetic on purpose: a percentage compared through a
+             * double would make the threshold depend on rounding. */
+            bool too_many_partial =
+                max_partial_pct >= 0 && files > 0 && partial * 100 > max_partial_pct * files;
+            if (degraded || too_many_unusable || too_many_partial) {
+                status = CBM_CLI_EXIT_QUALITY;
+            }
+        }
+    }
+    if (payload) {
+        yyjson_doc_free(payload);
+    }
+    yyjson_doc_free(envelope);
+    return status;
+}
+
 /* #1537. Two very different failures reached this one message: the cohort was
  * BUSY (real sessions are running — the reader can close them), or the
  * reservation failed outright (lock I/O, stale coordination state, permissions

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -57,6 +57,48 @@ bool cbm_cli_mcp_result_is_error(const char *result);
  * accepted cancellation into EXIT_FAILURE. */
 int cbm_cli_exit_status_after_maintenance(int exit_status, bool maintenance_cancelled);
 
+/* ── Index exit contract ──────────────────────────────────────────
+ *
+ * A freshness gate must not have to read anyone's account of itself: it reads
+ * the process status. `index_repository` therefore grades its own outcome.
+ *
+ *   0  indexed, quality at or above the thresholds
+ *   1  hard failure (pipeline fell over inside a reachable repository)
+ *   2  indexed, but below a quality threshold — a graph that exists and lies
+ *      about how much of the tree it covers is worse than no graph
+ *   3  target unavailable: repo_path is absent, unreadable, or not a directory
+ *
+ * 1 keeps its historical meaning so existing `|| fail` scripts are unaffected;
+ * 2 and 3 are new and carve out cases that used to return 0 and 1.
+ *
+ * The contract is opt-in: it applies only when CBM_GATE is set to a non-empty
+ * value other than "0". Without it the CLI exits exactly as before, so a
+ * caller that never asked for grading never sees a new code.
+ *
+ * Thresholds, both overridable by environment:
+ *   CBM_GATE_MAX_UNUSABLE     (default 0)   absolute count of unparsable files
+ *   CBM_GATE_MAX_PARTIAL_PCT  (default 10)  parse_partial_count / files_indexed
+ * A threshold set to a negative value disables that check.
+ *
+ * The two numbers differ on purpose and must not be collapsed into one: a file
+ * that did not parse at all is a defect and gets no tolerance, while partial
+ * parsing marks constructs this grammar does not cover — a property of language
+ * support, not of index quality, and normal at a few percent in a large tree.
+ * A gate its own repository cannot pass gets switched off, which protects
+ * nothing. */
+enum {
+    CBM_CLI_EXIT_OK = 0,
+    CBM_CLI_EXIT_FAILURE = 1,
+    CBM_CLI_EXIT_QUALITY = 2,
+    CBM_CLI_EXIT_TARGET = 3,
+};
+
+/* Grade an index_repository result envelope. `base_status` is what the
+ * ordinary isError mapping already produced; it is preserved unless the
+ * payload justifies a more specific code. Unparsable payloads change
+ * nothing — silence is never upgraded into a verdict. */
+int cbm_cli_index_exit_status(const char *result, int base_status);
+
 /* ── Self-update: version comparison ──────────────────────────── */
 
 /* Compare two semver strings (e.g. "0.2.1" vs "0.2.0").

--- a/src/main.c
+++ b/src/main.c
@@ -1000,6 +1000,11 @@ static int run_cli(int argc, char **argv, cbm_project_lock_manager_t *project_lo
         } else {
             exit_code = cli_print_mcp_result(result);
         }
+        /* One place for both presentations: a gate reading the status must get
+         * the same verdict whether or not the caller asked for --json. */
+        if (tool_name && strcmp(tool_name, "index_repository") == 0) {
+            exit_code = cbm_cli_index_exit_status(result, exit_code);
+        }
         exit_code = cbm_cli_exit_status_after_maintenance(exit_code, maintenance_cancelled);
         if (cbm_index_worker_active()) {
             /* The supervisor protocol classifies the PROCESS, not the tool

--- a/src/mcp/mcp.c
+++ b/src/mcp/mcp.c
@@ -10316,6 +10316,28 @@ static bool build_index_success_response(cbm_mcp_server_t *srv, yyjson_mut_doc *
         add_parse_partial_summary(doc, root, file_errors, file_error_count);
         add_parse_unusable_summary(doc, root, file_errors, file_error_count);
     }
+    /* Denominator for quality gates. parse_partial_count on its own cannot
+     * say whether sixty flagged files are a rounding error or half the
+     * repository; file_hashes holds exactly one row per indexed file. */
+    if (store) {
+        cbm_file_hash_t *hashes = NULL;
+        int hash_count = 0;
+        if (cbm_store_get_file_hashes(store, project_name, &hashes, &hash_count) == CBM_STORE_OK) {
+            yyjson_mut_obj_add_int(doc, root, "files_indexed", hash_count);
+            /* The share, stated outright. A gate that only passes or fails
+             * cannot tell anyone HOW partial the parse was, and "the graph is
+             * fresh, but 6.2% of files parsed partially" is a usable hint
+             * where a bare verdict is not. Tenths of a percent are derived by
+             * integer division so the number never depends on rounding. */
+            yyjson_mut_val *partial_val = yyjson_mut_obj_get(root, "parse_partial_count");
+            if (partial_val && hash_count > 0) {
+                int partial = yyjson_mut_get_int(partial_val);
+                long tenths = (long)partial * 1000 / hash_count;
+                yyjson_mut_obj_add_real(doc, root, "parse_partial_pct", (double)tenths / 10.0);
+            }
+            cbm_store_free_file_hashes(hashes, hash_count);
+        }
+    }
     int nodes = 0;
     int edges = 0;
     bool degraded = false;
@@ -11254,6 +11276,16 @@ static char *handle_index_repository(cbm_mcp_server_t *srv, const char *args) {
                                "previous index may have been rolled back.");
     } else {
         yyjson_mut_obj_add_str(doc, root, "status", "error");
+        /* A repository that is not there at all is a different failure from a
+         * pipeline that fell over inside one that is — the hint below reads
+         * identically for both, so callers could not tell them apart. The
+         * split is deliberately about the ROOT: an unreadable subtree is a
+         * pipeline failure, not a missing target. */
+        cbm_path_info_t target = {0};
+        bool target_reachable =
+            cbm_path_info_utf8(repo_path, &target) == CBM_PATH_INFO_OK && target.is_directory;
+        yyjson_mut_obj_add_str(doc, root, "reason",
+                               target_reachable ? "pipeline_failed" : "target_unavailable");
         yyjson_mut_obj_add_str(doc, root, "hint",
                                "Pipeline failed. Check repo_path exists and contains source files. "
                                "Try mode='fast' for a quicker diagnostic run.");

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -14886,6 +14886,319 @@ TEST(cli_update_only_names_an_installer_that_exists_issue1632) {
     PASS();
 }
 
+/* ── index_repository exit contract ──────────────────────────────
+ *
+ * cbm_cli_index_exit_status grades a result envelope into a process exit
+ * code, because a freshness gate reads process status rather than a tool's
+ * account of itself. The six outcomes were measured by hand against the
+ * built binary when the contract landed; measured once is not pinned, and
+ * a code that moves silently is exactly what the contract exists to stop. */
+
+/* Build the envelope the CLI actually receives: the payload travels as a
+ * JSON string inside content[0].text. Escaping it by hand in every test
+ * would put the test's own escaping on trial instead of the grader. */
+static char *cli_index_envelope(const char *payload) {
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    if (!doc) {
+        return NULL;
+    }
+    yyjson_mut_val *root = yyjson_mut_obj(doc);
+    yyjson_mut_doc_set_root(doc, root);
+    yyjson_mut_val *content = yyjson_mut_arr(doc);
+    yyjson_mut_val *item = yyjson_mut_obj(doc);
+    yyjson_mut_obj_add_str(doc, item, "text", payload);
+    yyjson_mut_arr_append(content, item);
+    yyjson_mut_obj_add_val(doc, root, "content", content);
+    char *json = yyjson_mut_write(doc, 0, NULL);
+    yyjson_mut_doc_free(doc);
+    return json;
+}
+
+/* Grade one payload. Returns -1 only if the envelope could not be built, a
+ * value no exit code uses, so a setup failure cannot pass for a verdict. */
+static int cli_index_grade(const char *payload, int base_status) {
+    char *envelope = cli_index_envelope(payload);
+    if (!envelope) {
+        return -1;
+    }
+    int status = cbm_cli_index_exit_status(envelope, base_status);
+    free(envelope);
+    return status;
+}
+
+typedef struct {
+    char *gate;
+    char *unusable;
+    char *partial_pct;
+} cli_gate_env_t;
+
+/* A test that means to exercise the documented defaults must not inherit
+ * whatever the developer happens to have exported. The contract is opt-in,
+ * so the gate is switched on here; the one test about it being off unsets
+ * CBM_GATE itself. */
+static cli_gate_env_t cli_gate_env_clear(void) {
+    cli_gate_env_t saved = {save_test_env("CBM_GATE"), save_test_env("CBM_GATE_MAX_UNUSABLE"),
+                            save_test_env("CBM_GATE_MAX_PARTIAL_PCT")};
+    cbm_setenv("CBM_GATE", "1", 1);
+    cbm_unsetenv("CBM_GATE_MAX_UNUSABLE");
+    cbm_unsetenv("CBM_GATE_MAX_PARTIAL_PCT");
+    return saved;
+}
+
+static void cli_gate_env_restore(cli_gate_env_t saved) {
+    restore_test_env("CBM_GATE", saved.gate);
+    restore_test_env("CBM_GATE_MAX_UNUSABLE", saved.unusable);
+    restore_test_env("CBM_GATE_MAX_PARTIAL_PCT", saved.partial_pct);
+}
+
+/* Without CBM_GATE the CLI exits exactly as it always did: a payload that
+ * would grade 2 or 3 with the gate on keeps the base status. "0" and the
+ * empty string count as off, so an exported CBM_GATE=0 is not a surprise. */
+TEST(cli_index_exit_gate_off_keeps_base_status) {
+    cli_gate_env_t saved = cli_gate_env_clear();
+    const char *below_quality = "{\"status\":\"ok\",\"files_indexed\":10,"
+                                "\"parse_partial_count\":5,\"parse_unusable_count\":1}";
+    const char *missing_target = "{\"status\":\"error\",\"reason\":\"target_unavailable\"}";
+
+    /* Positive control: with the gate on both payloads DO change the status,
+     * so the unchanged codes below are the switch working, not a dead check. */
+    int quality_on = cli_index_grade(below_quality, CBM_CLI_EXIT_OK);
+    int target_on = cli_index_grade(missing_target, CBM_CLI_EXIT_FAILURE);
+
+    cbm_unsetenv("CBM_GATE");
+    int quality_unset = cli_index_grade(below_quality, CBM_CLI_EXIT_OK);
+    int target_unset = cli_index_grade(missing_target, CBM_CLI_EXIT_FAILURE);
+
+    cbm_setenv("CBM_GATE", "0", 1);
+    int quality_zero = cli_index_grade(below_quality, CBM_CLI_EXIT_OK);
+
+    cbm_setenv("CBM_GATE", "", 1);
+    int quality_empty = cli_index_grade(below_quality, CBM_CLI_EXIT_OK);
+    cli_gate_env_restore(saved);
+
+    ASSERT_EQ(quality_on, CBM_CLI_EXIT_QUALITY);
+    ASSERT_EQ(target_on, CBM_CLI_EXIT_TARGET);
+    ASSERT_EQ(quality_unset, CBM_CLI_EXIT_OK);
+    ASSERT_EQ(target_unset, CBM_CLI_EXIT_FAILURE);
+    ASSERT_EQ(quality_zero, CBM_CLI_EXIT_OK);
+    ASSERT_EQ(quality_empty, CBM_CLI_EXIT_OK);
+    PASS();
+}
+
+/* A clean index keeps the code it always had: the contract adds verdicts,
+ * it does not make previously good runs start failing. */
+TEST(cli_index_exit_clean_run_stays_zero) {
+    cli_gate_env_t saved = cli_gate_env_clear();
+    int status = cli_index_grade("{\"status\":\"ok\",\"files_indexed\":4,"
+                                 "\"parse_partial_count\":0,\"parse_unusable_count\":0}",
+                                 CBM_CLI_EXIT_OK);
+    cli_gate_env_restore(saved);
+    ASSERT_EQ(status, CBM_CLI_EXIT_OK);
+    PASS();
+}
+
+/* A file that did not parse at all gets no tolerance — the default is zero,
+ * so one such file is already a quality failure. */
+TEST(cli_index_exit_unusable_file_is_a_quality_failure) {
+    cli_gate_env_t saved = cli_gate_env_clear();
+    int status = cli_index_grade("{\"status\":\"ok\",\"files_indexed\":5,"
+                                 "\"parse_partial_count\":0,\"parse_unusable_count\":1}",
+                                 CBM_CLI_EXIT_OK);
+    cli_gate_env_restore(saved);
+    ASSERT_EQ(status, CBM_CLI_EXIT_QUALITY);
+    PASS();
+}
+
+/* Partial parsing is graded as a share, not a count: 20 of 100 files is
+ * twice the default ceiling. */
+TEST(cli_index_exit_partial_above_threshold_is_a_quality_failure) {
+    cli_gate_env_t saved = cli_gate_env_clear();
+    int status = cli_index_grade("{\"status\":\"ok\",\"files_indexed\":100,"
+                                 "\"parse_partial_count\":20,\"parse_unusable_count\":0}",
+                                 CBM_CLI_EXIT_OK);
+    cli_gate_env_restore(saved);
+    ASSERT_EQ(status, CBM_CLI_EXIT_QUALITY);
+    PASS();
+}
+
+/* The boundary itself passes. The comparison is strict and integral on
+ * purpose: at exactly the documented ceiling a double could round either
+ * way, and a threshold whose verdict depends on rounding is not a
+ * threshold. 10 of 100 is the ceiling, and the ceiling is allowed. */
+TEST(cli_index_exit_partial_exactly_at_threshold_passes) {
+    cli_gate_env_t saved = cli_gate_env_clear();
+    int at_ceiling = cli_index_grade("{\"status\":\"ok\",\"files_indexed\":100,"
+                                     "\"parse_partial_count\":10,\"parse_unusable_count\":0}",
+                                     CBM_CLI_EXIT_OK);
+    /* One file more is over it, which proves the case above is the boundary
+     * and not simply a check that never fires. */
+    int over_ceiling = cli_index_grade("{\"status\":\"ok\",\"files_indexed\":100,"
+                                       "\"parse_partial_count\":11,\"parse_unusable_count\":0}",
+                                       CBM_CLI_EXIT_OK);
+    cli_gate_env_restore(saved);
+    ASSERT_EQ(at_ceiling, CBM_CLI_EXIT_OK);
+    ASSERT_EQ(over_ceiling, CBM_CLI_EXIT_QUALITY);
+    PASS();
+}
+
+/* "degraded" is the pipeline's own verdict that the graph came out far
+ * smaller than the run expected. It carries no parse counts, so it has to
+ * be graded on the status alone. */
+TEST(cli_index_exit_degraded_status_is_a_quality_failure) {
+    cli_gate_env_t saved = cli_gate_env_clear();
+    int status = cli_index_grade("{\"status\":\"degraded\",\"files_indexed\":40,"
+                                 "\"parse_partial_count\":0,\"parse_unusable_count\":0}",
+                                 CBM_CLI_EXIT_OK);
+    cli_gate_env_restore(saved);
+    ASSERT_EQ(status, CBM_CLI_EXIT_QUALITY);
+    PASS();
+}
+
+/* An absent target and a pipeline that fell over inside a reachable
+ * repository used to share code 1, which is the whole reason the contract
+ * was written: the caller could not tell "wrong path" from "broken run". */
+TEST(cli_index_exit_separates_missing_target_from_broken_run) {
+    cli_gate_env_t saved = cli_gate_env_clear();
+    int target = cli_index_grade("{\"status\":\"error\",\"reason\":\"target_unavailable\"}",
+                                 CBM_CLI_EXIT_FAILURE);
+    int pipeline = cli_index_grade("{\"status\":\"error\",\"reason\":\"pipeline_failed\"}",
+                                   CBM_CLI_EXIT_FAILURE);
+    /* An error the mapping had not already flagged still has to land on a
+     * failure code rather than fall through as success. */
+    int unflagged = cli_index_grade("{\"status\":\"error\",\"reason\":\"pipeline_failed\"}",
+                                    CBM_CLI_EXIT_OK);
+    cli_gate_env_restore(saved);
+    ASSERT_EQ(target, CBM_CLI_EXIT_TARGET);
+    ASSERT_EQ(pipeline, CBM_CLI_EXIT_FAILURE);
+    ASSERT_EQ(unflagged, CBM_CLI_EXIT_FAILURE);
+    PASS();
+}
+
+/* Silence is never upgraded into a verdict. A payload the grader cannot
+ * read says nothing about index quality, and inventing a 2 from it would
+ * fail runs for the crime of an unexpected response shape. */
+TEST(cli_index_exit_never_upgrades_silence) {
+    cli_gate_env_t saved = cli_gate_env_clear();
+    ASSERT_EQ(cbm_cli_index_exit_status(NULL, CBM_CLI_EXIT_OK), CBM_CLI_EXIT_OK);
+    ASSERT_EQ(cbm_cli_index_exit_status("", CBM_CLI_EXIT_OK), CBM_CLI_EXIT_OK);
+    ASSERT_EQ(cbm_cli_index_exit_status("not json at all", CBM_CLI_EXIT_OK), CBM_CLI_EXIT_OK);
+    /* A well-formed envelope carrying no content, and one whose text is not
+     * itself JSON — both are shapes a future response could take. */
+    ASSERT_EQ(cbm_cli_index_exit_status("{\"content\":[]}", CBM_CLI_EXIT_OK), CBM_CLI_EXIT_OK);
+    ASSERT_EQ(cli_index_grade("plain text, not a payload", CBM_CLI_EXIT_OK), CBM_CLI_EXIT_OK);
+    /* And the same shapes must not erase a failure already established. */
+    ASSERT_EQ(cbm_cli_index_exit_status(NULL, CBM_CLI_EXIT_FAILURE), CBM_CLI_EXIT_FAILURE);
+    cli_gate_env_restore(saved);
+    PASS();
+}
+
+/* Grading only ever makes a code more specific. A base failure survives a
+ * payload that looks perfectly healthy, because the transport already knew
+ * something the payload does not say. */
+TEST(cli_index_exit_does_not_downgrade_a_failing_base) {
+    cli_gate_env_t saved = cli_gate_env_clear();
+    int status = cli_index_grade("{\"status\":\"ok\",\"files_indexed\":9,"
+                                 "\"parse_partial_count\":0,\"parse_unusable_count\":0}",
+                                 CBM_CLI_EXIT_FAILURE);
+    cli_gate_env_restore(saved);
+    ASSERT_EQ(status, CBM_CLI_EXIT_FAILURE);
+    PASS();
+}
+
+/* Both thresholds are overridable, and both are read at grading time. */
+TEST(cli_index_exit_thresholds_read_the_environment) {
+    cli_gate_env_t saved = cli_gate_env_clear();
+    const char *twenty_percent = "{\"status\":\"ok\",\"files_indexed\":100,"
+                                 "\"parse_partial_count\":20,\"parse_unusable_count\":0}";
+    const char *three_unusable = "{\"status\":\"ok\",\"files_indexed\":50,"
+                                 "\"parse_partial_count\":0,\"parse_unusable_count\":3}";
+
+    /* Positive control: at the defaults both payloads fail, so a pass below
+     * is the override working and not the check being absent. */
+    int partial_default = cli_index_grade(twenty_percent, CBM_CLI_EXIT_OK);
+    int unusable_default = cli_index_grade(three_unusable, CBM_CLI_EXIT_OK);
+
+    cbm_setenv("CBM_GATE_MAX_PARTIAL_PCT", "50", 1);
+    cbm_setenv("CBM_GATE_MAX_UNUSABLE", "5", 1);
+    int partial_raised = cli_index_grade(twenty_percent, CBM_CLI_EXIT_OK);
+    int unusable_raised = cli_index_grade(three_unusable, CBM_CLI_EXIT_OK);
+    cli_gate_env_restore(saved);
+
+    ASSERT_EQ(partial_default, CBM_CLI_EXIT_QUALITY);
+    ASSERT_EQ(unusable_default, CBM_CLI_EXIT_QUALITY);
+    ASSERT_EQ(partial_raised, CBM_CLI_EXIT_OK);
+    ASSERT_EQ(unusable_raised, CBM_CLI_EXIT_OK);
+    PASS();
+}
+
+/* A negative ceiling switches its own check off. This is the documented
+ * escape hatch for a repository whose grammars are known to be thin. */
+TEST(cli_index_exit_negative_threshold_disables_the_check) {
+    cli_gate_env_t saved = cli_gate_env_clear();
+    cbm_setenv("CBM_GATE_MAX_PARTIAL_PCT", "-1", 1);
+    cbm_setenv("CBM_GATE_MAX_UNUSABLE", "-1", 1);
+    int status = cli_index_grade("{\"status\":\"ok\",\"files_indexed\":100,"
+                                 "\"parse_partial_count\":99,\"parse_unusable_count\":7}",
+                                 CBM_CLI_EXIT_OK);
+    /* Disabling the parse checks must not disable the pipeline's own
+     * verdict: "degraded" is not a threshold and has no off switch. */
+    int degraded = cli_index_grade("{\"status\":\"degraded\",\"files_indexed\":10,"
+                                   "\"parse_partial_count\":0,\"parse_unusable_count\":0}",
+                                   CBM_CLI_EXIT_OK);
+    cli_gate_env_restore(saved);
+    ASSERT_EQ(status, CBM_CLI_EXIT_OK);
+    ASSERT_EQ(degraded, CBM_CLI_EXIT_QUALITY);
+    PASS();
+}
+
+/* A typo must not silently disable a gate. Anything that is not a whole
+ * number falls back to the documented default, so "1O" (letter O) fails the
+ * run it would have failed anyway instead of quietly waving it through. */
+TEST(cli_index_exit_unreadable_threshold_falls_back_to_default) {
+    cli_gate_env_t saved = cli_gate_env_clear();
+    const char *twenty_percent = "{\"status\":\"ok\",\"files_indexed\":100,"
+                                 "\"parse_partial_count\":20,\"parse_unusable_count\":0}";
+    /* The last one overflows long: strtol clamps it to LONG_MAX with the
+     * whole string consumed, a ceiling no run could exceed. */
+    const char *unreadable[] = {
+        "abc", "1O", "10pct", " 10", "10 ", "", "1e1", "10.0", "99999999999999999999999"};
+    for (size_t i = 0; i < sizeof(unreadable) / sizeof(unreadable[0]); i++) {
+        cbm_setenv("CBM_GATE_MAX_PARTIAL_PCT", unreadable[i], 1);
+        int status = cli_index_grade(twenty_percent, CBM_CLI_EXIT_OK);
+        if (status != CBM_CLI_EXIT_QUALITY) {
+            printf("  unreadable threshold \"%s\" gave exit %d\n", unreadable[i], status);
+        }
+        ASSERT_EQ(status, CBM_CLI_EXIT_QUALITY);
+    }
+    /* A value that DOES read still takes effect, so the loop above is about
+     * unreadable text and not about the override being ignored outright. */
+    cbm_setenv("CBM_GATE_MAX_PARTIAL_PCT", "50", 1);
+    int readable = cli_index_grade(twenty_percent, CBM_CLI_EXIT_OK);
+    cli_gate_env_restore(saved);
+    ASSERT_EQ(readable, CBM_CLI_EXIT_OK);
+    PASS();
+}
+
+/* A share needs a denominator. Without files_indexed the percentage cannot
+ * be computed at all, and a run must not be failed on a number nobody
+ * could work out. */
+TEST(cli_index_exit_partial_without_denominator_is_not_graded) {
+    cli_gate_env_t saved = cli_gate_env_clear();
+    int no_denominator = cli_index_grade("{\"status\":\"ok\",\"parse_partial_count\":20}",
+                                         CBM_CLI_EXIT_OK);
+    int zero_denominator = cli_index_grade("{\"status\":\"ok\",\"files_indexed\":0,"
+                                           "\"parse_partial_count\":20}",
+                                           CBM_CLI_EXIT_OK);
+    /* An unusable file is an absolute count and still grades without one. */
+    int unusable_still_graded = cli_index_grade("{\"status\":\"ok\",\"parse_unusable_count\":1}",
+                                                CBM_CLI_EXIT_OK);
+    cli_gate_env_restore(saved);
+    ASSERT_EQ(no_denominator, CBM_CLI_EXIT_OK);
+    ASSERT_EQ(zero_denominator, CBM_CLI_EXIT_OK);
+    ASSERT_EQ(unusable_still_graded, CBM_CLI_EXIT_QUALITY);
+    PASS();
+}
+
 SUITE(cli) {
     if (!th_secure_runtime_parent_new(g_cli_suite_runtime_parent,
                                       sizeof(g_cli_suite_runtime_parent), "cli-suite")) {
@@ -15304,6 +15617,21 @@ SUITE(cli) {
     /* Stdin argument gate (#1359) */
     RUN_TEST(cli_zero_argument_tool_never_reads_stdin_issue1359);
     RUN_TEST(cli_stdin_args_gate_tracks_tool_schema_issue1359);
+
+    /* index_repository exit contract */
+    RUN_TEST(cli_index_exit_gate_off_keeps_base_status);
+    RUN_TEST(cli_index_exit_clean_run_stays_zero);
+    RUN_TEST(cli_index_exit_unusable_file_is_a_quality_failure);
+    RUN_TEST(cli_index_exit_partial_above_threshold_is_a_quality_failure);
+    RUN_TEST(cli_index_exit_partial_exactly_at_threshold_passes);
+    RUN_TEST(cli_index_exit_degraded_status_is_a_quality_failure);
+    RUN_TEST(cli_index_exit_separates_missing_target_from_broken_run);
+    RUN_TEST(cli_index_exit_never_upgrades_silence);
+    RUN_TEST(cli_index_exit_does_not_downgrade_a_failing_base);
+    RUN_TEST(cli_index_exit_thresholds_read_the_environment);
+    RUN_TEST(cli_index_exit_negative_threshold_disables_the_check);
+    RUN_TEST(cli_index_exit_unreadable_threshold_falls_back_to_default);
+    RUN_TEST(cli_index_exit_partial_without_denominator_is_not_graded);
     cbm_cli_set_activation_runtime_parent_for_test(NULL);
     test_rmdir_r(g_cli_suite_runtime_parent);
     g_cli_suite_runtime_parent[0] = '\0';


### PR DESCRIPTION
Refs #2168

## Opt-in exit contract for `cli index_repository`

A freshness gate cannot read a tool's account of itself, it reads the process
status. Today `index_repository` returns `0` for an index that parsed part of
the tree, and the same `1` whether the repository is missing or a pipeline fell
over inside one that exists. Callers cannot tell those apart.

**Nothing changes unless `CBM_GATE=1` is set.** Without it the CLI exits
exactly as before. With it, grading happens in the CLI only; MCP responses are
untouched, so agents and `scripts/soak-test.sh`, which judge by JSON-RPC and
tool-level `isError`, see exactly what they saw before.

| outcome | today | with `CBM_GATE=1` |
|---|---|---|
| indexed, clean | 0 | 0 |
| indexed, files parsed partially above threshold | 0 | **2** |
| indexed, a file did not parse at all | 0 | **2** |
| indexed, node count far below expectation (`status: degraded`) | 0 | **2** |
| pipeline failed inside a reachable repository | 1 | 1 |
| `repo_path` absent, unreadable, or not a directory | 1 | **3** |

Thresholds, both optional, negative disables the check:

- `CBM_GATE_MAX_UNUSABLE`, default `0`, absolute count of unparsable files
- `CBM_GATE_MAX_PARTIAL_PCT`, default `10`, share of partially parsed files

The two defaults differ deliberately. A file that did not parse at all is a
defect and gets no tolerance. Partial parsing marks constructs a grammar does
not cover, a property of language support rather than of index quality: this
repository itself sits at 5.8% with a fully working graph. A gate its own
project cannot pass gets switched off, which protects nothing.

## Additive fields

- `files_indexed` and `parse_partial_pct` on the index response. The ratio had
  no denominator, and a gate that can only pass or fail cannot say *how*
  partial a parse was.
- `reason` on failures, `target_unavailable` or `pipeline_failed`. The hint
  text read identically for both.

## Verification

Full suite on this branch: 8001 passed, 1 failed, 7 skipped. The one failure is
`daemon_ipc_posix_single_uid_userns_real_smoke_issue1830`, which fails the same
way on a clean build of `main` at 055fbb7d on this machine (user-namespace
setup), so it is unrelated to this change.

13 tests in the `cli` suite pin the contract, including that an unset, empty
or `0` `CBM_GATE` leaves the historical status untouched.

End to end on this repository (clean git worktree of this branch, isolated
`CBM_CACHE_DIR` and `CBM_RUNTIME_DIR`), exit status read without a pipeline so
`$?` is the command's own:

```
gate unset:
  missing path                                   exit 1   (unchanged)
  this repository                                exit 0   (unchanged)
CBM_GATE=1:
  missing path                                   exit 3   reason target_unavailable
  this repository                                exit 0   files_indexed 1065, parse_partial_pct 5.8, under the default 10
CBM_GATE=1 CBM_GATE_MAX_PARTIAL_PCT=5:
  this repository                                exit 2
```

The same sequence against a binary built from `main` at 055fbb7d gives
`1 / 0 / 1 / 0 / 0`: today's status, unchanged by the variable.
