### PR TITLE
fix(watcher): exclude the indexer's own artifact dir from the git dirty signature (#1953)

### DIFF
--- a/src/watcher/watcher.c
+++ b/src/watcher/watcher.c
@@ -31,6 +31,7 @@
 #include "foundation/platform.h"
 #include "foundation/str_util.h"
 #include "foundation/subprocess.h"
+#include "pipeline/artifact.h" /* CBM_ARTIFACT_DIR: the indexer's own output directory */
 #ifdef _WIN32
 #include "foundation/win_utf8.h"
 #define WIN32_LEAN_AND_MEAN
@@ -631,12 +632,31 @@ static watcher_git_status_t git_dirty_signature(cbm_watcher_t *w, project_state_
      * watched at a sub-package of a monorepo reindexes whenever any SIBLING
      * package changes, because git reports the whole repository's dirty state
      * regardless of -C. Paths stay repository-relative either way, which is
-     * what repo_cdup is for. */
-    const char *status_argv[] = {"git",    "--no-optional-locks",
-                                 "-C",     state->root_path,
-                                 "status", "--porcelain",
-                                 "-uall",  "-z",
-                                 "--",     ".",
+     * what repo_cdup is for.
+     *
+     * `:(exclude).codebase-memory` drops the indexer's OWN output. After every
+     * publish the pipeline re-exports <root>/.codebase-memory/ whenever an
+     * artifact already lives there (once persisted, or committed by the team
+     * and checked out into every worktree). Folding that write into the
+     * signature made each successful reindex look like a NEW dirty state on
+     * the next poll, and the daemon re-triggered itself forever (#1953: reap
+     * clean -> watcher.changed, 100+ times in 15 minutes, index workers
+     * pinned). Nothing under that directory is ever an index input (discovery
+     * skips it), so a change there can never require a reindex. The pathspec
+     * is CWD-relative, so a project watched at a monorepo sub-package excludes
+     * its own artifact directory; it is the same pathspec the exporter's
+     * clean-tree probe uses, for the same reason. */
+    const char *status_argv[] = {"git",
+                                 "--no-optional-locks",
+                                 "-C",
+                                 state->root_path,
+                                 "status",
+                                 "--porcelain",
+                                 "-uall",
+                                 "-z",
+                                 "--",
+                                 ".",
+                                 ":(exclude)" CBM_ARTIFACT_DIR,
                                  NULL};
     watcher_git_output_t output;
     watcher_git_status_t status =

--- a/tests/test_watcher.c
+++ b/tests/test_watcher.c
@@ -12,6 +12,7 @@
 #include "test_helpers.h"
 #include <daemon/application.h>
 #include <watcher/watcher.h>
+#include <pipeline/artifact.h>
 #include <store/store.h>
 #include <errno.h>
 #include <stdatomic.h>
@@ -1570,6 +1571,133 @@ TEST(watcher_no_change_no_reindex) {
     /* Cleanup */
     cbm_watcher_free(w);
     cbm_store_close(store);
+    th_rmtree(tmpdir);
+    PASS();
+}
+
+/* #1953: the reindex's OWN OUTPUT must never count as a change. After every
+ * publish the pipeline re-exports <root>/.codebase-memory/graph.db.zst (plus
+ * artifact.json) whenever an artifact already lives there — a `persistence:
+ * true` index leaves one behind, and a linked worktree checks the team's
+ * committed one out. The dirty signature folded that file's (size, mtime)
+ * in, so each successful reindex rewrote it, the next poll saw a "new" dirty
+ * state, and the daemon re-triggered itself forever: `index.supervisor.reap
+ * outcome=clean` immediately followed by `watcher.changed strategy=git`, 100+
+ * times in 15 minutes with two index workers pinned. Nothing under .git moved
+ * and no source changed, which is why the reporters blamed their long
+ * hyphenated worktree branch names (#1254's retracted theory). The scenario is
+ * built exactly that way to show the branch is irrelevant: the artifact write
+ * is the trigger. Untracked (`??`) and committed (` M`) artifacts both looped. */
+static const char *exporting_index_db_path = NULL;
+static int exporting_index_export_rc = 0;
+static int exporting_index_callback(const char *name, const char *path, void *ud) {
+    (void)ud;
+    index_call_count++;
+    /* What the daemon's index worker does after publish: export_after_publish
+     * re-exports FAST because cbm_artifact_exists(root). */
+    int rc = cbm_artifact_export(exporting_index_db_path, path, name, CBM_ARTIFACT_FAST);
+    if (rc != 0) {
+        exporting_index_export_rc = rc;
+    }
+    return 0;
+}
+
+TEST(watcher_own_artifact_export_does_not_retrigger_issue1953) {
+    char tmpdir[256];
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/cbm_watcher_1953_XXXXXX");
+    if (!cbm_mkdtemp(tmpdir))
+        FAIL("cbm_mkdtemp failed");
+
+    char main_repo[400];
+    char worktree[400];
+    char db_path[400];
+    snprintf(main_repo, sizeof(main_repo), "%s/main", tmpdir);
+    snprintf(worktree, sizeof(worktree), "%s/4385-auditable-patreon-manual-grants", tmpdir);
+    snprintf(db_path, sizeof(db_path), "%s/graph.db", tmpdir);
+    if (!cbm_mkdir_p(main_repo, 0755) || wt_git(main_repo, "init -q") != 0) {
+        th_rmtree(tmpdir);
+        FAIL("git init failed");
+    }
+    {
+        char p[500];
+        th_write_file(wt_path(p, sizeof(p), main_repo, "file.txt"), "hello\n");
+    }
+    wt_git(main_repo, "add file.txt");
+    wt_git(main_repo, "commit -q -m init");
+
+    /* Linked worktree on the reporters' branch profile (>= 25 chars, hyphens). */
+    {
+        char args[600];
+        snprintf(args, sizeof(args),
+                 "worktree add -q -b 4385-auditable-patreon-manual-grants \"%s\"", worktree);
+        if (wt_git(main_repo, args) != 0) {
+            th_rmtree(tmpdir);
+            FAIL("git worktree add failed");
+        }
+    }
+
+    /* A minimal but valid store standing in for the project's cache DB. */
+    {
+        cbm_store_t *db = cbm_store_open_path(db_path);
+        if (!db) {
+            th_rmtree(tmpdir);
+            FAIL("cbm_store_open_path failed");
+        }
+        cbm_store_exec(db, "INSERT OR IGNORE INTO projects(name, indexed_at, root_path) "
+                           "VALUES('wt-1953', '2026-01-01', '/tmp/wt-1953');");
+        cbm_store_close(db);
+    }
+
+    /* The artifact is already there — as after any persisted index. */
+    ASSERT_EQ(cbm_artifact_export(db_path, worktree, "wt-1953", CBM_ARTIFACT_FAST), 0);
+    ASSERT_TRUE(cbm_artifact_exists(worktree));
+
+    cbm_store_t *store = cbm_store_open_memory();
+    exporting_index_db_path = db_path;
+    exporting_index_export_rc = 0;
+    cbm_watcher_t *w = cbm_watcher_new(store, exporting_index_callback, NULL);
+    cbm_watcher_watch(w, "wt-1953", worktree);
+    index_call_count = 0;
+
+    cbm_watcher_poll_once(w); /* baseline */
+    ASSERT_EQ(index_call_count, 0);
+
+    /* Idle worktree: nothing but the tool's own artifact directory differs
+     * from HEAD. Every poll used to reindex — and re-export, feeding the next. */
+    for (int i = 0; i < 4; i++) {
+        cbm_watcher_touch(w, "wt-1953");
+        cbm_watcher_poll_once(w);
+    }
+    ASSERT_EQ(exporting_index_export_rc, 0);
+    ASSERT_EQ(index_call_count, 0);
+
+    /* Committed artifact (team sharing): the export now MODIFIES tracked files
+     * instead of leaving untracked ones. The commit is a real HEAD change and
+     * reindexes once; the re-export that reindex performs must not. */
+    wt_git(worktree, "add -A");
+    wt_git(worktree, "commit -q -m share-artifact");
+    cbm_watcher_touch(w, "wt-1953");
+    cbm_watcher_poll_once(w);
+    ASSERT_EQ(index_call_count, 1);
+    for (int i = 0; i < 4; i++) {
+        cbm_watcher_touch(w, "wt-1953");
+        cbm_watcher_poll_once(w);
+    }
+    ASSERT_EQ(exporting_index_export_rc, 0);
+    ASSERT_EQ(index_call_count, 1);
+
+    /* A real edit in the worktree is still seen. */
+    {
+        char p[500];
+        th_append_file(wt_path(p, sizeof(p), worktree, "file.txt"), "edit\n");
+    }
+    cbm_watcher_touch(w, "wt-1953");
+    cbm_watcher_poll_once(w);
+    ASSERT_EQ(index_call_count, 2);
+
+    cbm_watcher_free(w);
+    cbm_store_close(store);
+    exporting_index_db_path = NULL;
     th_rmtree(tmpdir);
     PASS();
 }
@@ -3176,6 +3304,7 @@ SUITE(watcher) {
     RUN_TEST(watcher_identical_watch_preserves_dirty_baseline);
     RUN_TEST(watcher_detects_new_file);
     RUN_TEST(watcher_no_change_no_reindex);
+    RUN_TEST(watcher_own_artifact_export_does_not_retrigger_issue1953);
     RUN_TEST(watcher_dirty_state_reindexes_once_issue937);
     RUN_TEST(watcher_failed_reindex_retries_issue937);
     RUN_TEST(watcher_multiple_projects);


### PR DESCRIPTION
Fixes #1953.

With `auto_watch` on, `index.supervisor.reap outcome=clean` was followed immediately by `watcher.changed … strategy=git` on the same project, forever (100+ events in 15 minutes, two worker children pinned at 100% CPU). Not the branch name: the dirty signature is built from `git status --porcelain -uall`, and after every successful reindex the export step rewrites `.codebase-memory/artifact.json` and `graph.db.zst` (`export_after_publish` re-exports whenever an artifact exists, persisted once or committed by the team and checked out into every worktree). Those entries hash differently on every poll, so the signature never matched the committed baseline and each reindex manufactured the next "change". (#1254's overflow theory was retracted by its own reporter; that loop was the #937 level-vs-edge bug.)

Fix (`src/watcher/watcher.c`): the signature's `git status` now runs with `-- . ":(exclude).codebase-memory"`, the same pathspec `artifact.c`'s own clean-tree probe already uses for the same reason. Argv-spawned, CWD-relative (a monorepo sub-package excludes its own artifact dir); discovery already skips that directory, so nothing there is ever an index input.

Test (`tests/test_watcher.c`): temp repo plus a linked worktree on branch `4385-auditable-patreon-manual-grants`, watched at the worktree; the index callback runs the real `cbm_artifact_export`. Four idle polls → 0 reindexes (untracked artifact); commit the artifact → 1 (a real HEAD move); four more idle polls → still 1; a real edit → 2. RED on unmodified production (`index_call_count == 4, expected 0`, with the reported reap→changed interleaving in the log), GREEN with the fix, RED again on revert.

Local verification (macOS host): watcher 73/0, index_supervisor + daemon + daemon_application 74/0, daemon_runtime + frontend + bootstrap + ipc + version 144/0, `tests/test_watcher_disabled.sh` PASS, `make lint-ci` clean.

Recorded, not in this change: the submodule leg of the signature has no exclude (only matters if a submodule is itself indexed with its own artifact).
