### PR TITLE
test(windows): guard clean MCP stdio startup

### DIFF
--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -166,6 +166,7 @@ $guards = @(
     "tests\windows\test_hook_augment.py",
     "tests\windows\test_ui_drive_listing.py",
     "tests\windows\test_cli_non_ascii_arg.py",
+    "tests\windows\test_mcp_stdio.py",
     "tests\windows\test_windows_update_handoff.py"
 )
 

--- a/tests/windows/test_mcp_stdio.py
+++ b/tests/windows/test_mcp_stdio.py
@@ -1,6 +1,7 @@
 """Regression guard for clean Windows MCP stdio startup."""
 
 import os
+import subprocess
 import sys
 import tempfile
 
@@ -18,11 +19,26 @@ def main():
         return 2
 
     with tempfile.TemporaryDirectory(prefix="cbm-mcp-stdio-") as cache:
-        with McpServer(binary, cache_dir=cache) as server:
-            server.initialize(timeout=30)
-            server.tools_list(timeout=30)
-            server.close()
+        runtime = os.path.join(os.path.dirname(cache), "cbm-mcp-stdio-runtime")
+        os.makedirs(runtime)
+        server = McpServer(binary, cache_dir=cache,
+                           extra_env={"CBM_RUNTIME_DIR": runtime})
+        try:
+            with server:
+                server.initialize(timeout=30)
+                server.tools_list(timeout=30)
             stderr = server.stderr_text()
+        finally:
+            stop = subprocess.run(
+                [binary, "daemon", "stop"],
+                env=server.env,
+                capture_output=True,
+                timeout=30,
+            )
+            if stop.returncode != 0:
+                detail = (stop.stdout + stop.stderr).decode("utf-8", "replace")
+                raise RuntimeError("daemon cleanup failed (%d): %s" %
+                                   (stop.returncode, detail.strip()))
 
     forbidden = (
         "The system cannot find the path specified.",

--- a/tests/windows/test_mcp_stdio.py
+++ b/tests/windows/test_mcp_stdio.py
@@ -1,0 +1,41 @@
+"""Regression guard for clean Windows MCP stdio startup."""
+
+import os
+import sys
+import tempfile
+
+from mcp_stdio import McpServer
+
+
+def main():
+    if os.name != "nt":
+        print("SKIP: Windows-only MCP stdio guard")
+        return 2
+
+    binary = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("CBM_TEST_BINARY")
+    if not binary:
+        print("SETUP FAIL: CBM_TEST_BINARY is required", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory(prefix="cbm-mcp-stdio-") as cache:
+        with McpServer(binary, cache_dir=cache) as server:
+            server.initialize(timeout=30)
+            server.tools_list(timeout=30)
+            server.close()
+            stderr = server.stderr_text()
+
+    forbidden = (
+        "The system cannot find the path specified.",
+        "El sistema no puede encontrar la ruta especificada.",
+    )
+    leaked = [message for message in forbidden if message in stderr]
+    if leaked:
+        print("FAIL: startup leaked an OS path error to stderr: " + ", ".join(leaked),
+              file=sys.stderr)
+        return 1
+    print("PASS: successful MCP startup emitted no OS path error")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What does this PR do?

Adds a native Windows MCP stdio regression guard for #654. The guard isolates daemon runtime cleanup and rejects the reported path-not-found diagnostics after a successful initialize/tools/list exchange.

## Checklist

- [ ] Every commit is signed off (`git commit -s`) — required, CI rejects
      unsigned commits ([DCO](../DCO), see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Tests pass locally (`make -f Makefile.cbm test`)
- [ ] Lint passes (`make -f Makefile.cbm lint-ci`)
- [ ] New behavior is covered by a test (reproduce-first for bug fixes)

Fixes #654