### PR TITLE
test(daemon): bound idle frontend maintenance probes

### DIFF
--- a/tests/test_daemon_frontend.c
+++ b/tests/test_daemon_frontend.c
@@ -1359,6 +1359,26 @@ TEST(daemon_frontend_idle_uses_one_maintenance_observer) {
     ASSERT_TRUE(fixture_closed);
     PASS();
 }
+
+/* An idle monitor must not repeatedly perform the expensive presence probe
+ * while no maintenance request exists. The short window is below the
+ * production idle cadence, so a second observation indicates a hot poll loop. */
+TEST(daemon_frontend_idle_maintenance_probe_is_bounded) {
+    frontend_maintenance_fixture_t fixture;
+    ASSERT_TRUE(frontend_maintenance_fixture_start(&fixture, "idle-cadence"));
+
+    cbm_daemon_frontend_test_observer_reset(false);
+    cbm_daemon_maintenance_monitor_t *monitor = cbm_daemon_maintenance_monitor_start(
+        fixture.manager, NULL, NULL, EXIT_SUCCESS, "idle cadence test");
+    ASSERT_TRUE(monitor != NULL);
+    cbm_usleep(100 * 1000U);
+    uint64_t observations = cbm_daemon_frontend_test_monitor_observations();
+    ASSERT_TRUE(cbm_daemon_maintenance_monitor_stop(&monitor));
+    frontend_maintenance_fixture_finish(&fixture);
+
+    ASSERT_EQ(observations, 1);
+    PASS();
+}
 #endif
 
 #ifndef _WIN32
@@ -1663,6 +1683,7 @@ SUITE(daemon_frontend) {
     RUN_TEST(daemon_frontend_rejects_non_notification_cancellation_shapes);
 #if defined(CBM_ENABLE_TEST_SEAMS) && CBM_ENABLE_TEST_SEAMS
     RUN_TEST(daemon_frontend_idle_uses_one_maintenance_observer);
+    RUN_TEST(daemon_frontend_idle_maintenance_probe_is_bounded);
 #endif
 #ifndef _WIN32
     RUN_TEST(daemon_frontend_maintenance_exits_while_stdio_reader_is_blocked);


### PR DESCRIPTION
## Summary

Add focused regression coverage for the idle frontend maintenance probe cadence, preventing the old hot polling loop from returning during quiet sessions.

## Reviewers

@DeusData, @CaptainMittens, @LazyXuan

Fixes #2093