### PR TITLE
ci: repin the apt.llvm.org ASan + analyzer lanes to clang-21

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -68,12 +68,12 @@ jobs:
       - name: Install build deps
         run: sudo apt-get update && sudo apt-get install -y zlib1g-dev
 
-      - name: Install LLVM 22 (pinned analyzer toolchain)
+      - name: Install LLVM 21 (pinned analyzer toolchain)
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" | sudo tee /etc/apt/sources.list.d/llvm-22.list
+          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
           sudo apt-get update
-          sudo apt-get install -y clang-tidy-22
+          sudo apt-get install -y clang-tidy-21
 
       - name: Memory-analyzer gate
-        run: scripts/ci/lint-mem.sh clang-tidy-22
+        run: scripts/ci/lint-mem.sh clang-tidy-21

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -227,12 +227,12 @@ jobs:
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install -y zlib1g-dev ccache
 
-      - name: Install LLVM 22 (pinned diagnostic toolchain)
+      - name: Install LLVM 21 (pinned diagnostic toolchain)
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" | sudo tee /etc/apt/sources.list.d/llvm-22.list
+          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
           sudo apt-get update
-          sudo apt-get install -y clang-22
+          sudo apt-get install -y clang-21
 
       - name: Compiler cache (content-verified, restore)
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -247,11 +247,11 @@ jobs:
       # lane: stack-use-after-return, stack-use-after-scope, and strict string
       # checks. Mirrors `make -f Makefile.cbm diag`, including its reasoning
       # for leaving detect_invalid_pointer_pairs out.
-      - name: Test (clang-22, ASan+UBSan + off-by-default ASan checks)
+      - name: Test (clang-21, ASan+UBSan + off-by-default ASan checks)
         env:
           ASAN_OPTIONS: "detect_stack_use_after_return=1:strict_string_checks=1:detect_stack_use_after_scope=1"
         run: |
-          scripts/test.sh CC=clang-22 CXX=clang++-22 \
+          scripts/test.sh CC=clang-21 CXX=clang++-21 \
             SANITIZE="-fsanitize=address,undefined -fno-omit-frame-pointer -fno-optimize-sibling-calls"
 
       - name: Compiler cache (save)


### PR DESCRIPTION
apt.llvm.org rotates its per-major `noble` snapshot channels; the `llvm-toolchain-noble-22` channel transiently emptied, which broke the msan lane (fixed in #2124 by moving `Dockerfile.msan` clang-22 → clang-21).

The two **GitHub-hosted** workflows that install clang from the same host were still pinned to 22 and would break the same way on the next rotation:

- `_test.yml` — `test-diag` lane (ASan + UBSan), `clang-22` / `clang++-22`
- `_lint.yml` — `lint-mem` lane (clang-analyzer), `clang-tidy-22`

This aligns both to **clang-21** (`llvm-toolchain-noble-21`, `clang-21`, `clang-tidy-21`), mirroring the exact repin #2124 used for the msan image. apt.llvm.org's `noble-21` channel is confirmed to serve `clang-21`, `clang-tidy-21`, `libclang-rt-21-dev` and `llvm-21` on amd64 + arm64 (`clang-21` = `1:21.1.8`).

**Deliberately not touched** (out of scope of the apt churn):
- macOS LSan lane's Homebrew `llvm@22` pin — a Homebrew formula, not an apt.llvm.org channel; the pin is intentional.
- `_lint.yml` clang-format lane — pinned to `clang-format-20` (v20, not 22).

Version-string swap only; no structural workflow changes.
