### PR TITLE
fix(daemon): accept single-uid userns overflow-owned ancestors (#1830)

### DIFF
--- a/src/daemon/ipc.c
+++ b/src/daemon/ipc.c
@@ -1385,14 +1385,191 @@ static char *private_log_directory_path_copy(const char *directory_path) {
     return string_copy(directory_path);
 }
 
-static bool posix_directory_owner_trusted(uid_t owner) {
-    return owner == (uid_t)0 || owner == geteuid();
+/* #1830 — single-uid user-namespace ancestors.
+ *
+ * Inside a 1:1 user namespace (for example `podman --userns=keep-id` or
+ * `unshare -U --map-current-user`), ancestors whose real owner is unmapped —
+ * the root-owned /, /tmp and the like — appear owned by the kernel overflow
+ * uid (`/proc/sys/kernel/overflowuid`, conventionally 65534). Refusing every
+ * overflow-owned ancestor made the daemon unusable in that legitimate setup.
+ *
+ * The overflow owner is tolerated for ANCESTORS ONLY, and ONLY when
+ * /proc/self/uid_map is a single-uid map whose sole inside id is our euid. In
+ * that shape no in-namespace principal can be the overflow owner, so an
+ * overflow-owned ancestor is exactly as safe as a root-owned one on the host:
+ * nobody reachable can have created it or can mutate it. A multi-uid map
+ * (rootless podman with subuids) still shows host root as overflow and is
+ * refused — conservative scope, not the safety argument. There is deliberately
+ * no environment escape hatch.
+ *
+ * The private directory itself is never tolerated as overflow: it is created by
+ * us (euid-owned) and re-checked `== geteuid()` by the created/final/snapshot
+ * gates, which stay strict. A host-squatted /tmp/cbm-daemon-<uid> appears
+ * overflow-owned and is refused there. */
+#define POSIX_NO_OVERFLOW_UID ((uid_t) - 1)
+
+#ifdef CBM_ENABLE_TEST_SEAMS
+static bool g_posix_overflow_override_active;
+static uid_t g_posix_overflow_override_uid = POSIX_NO_OVERFLOW_UID;
+void cbm_daemon_ipc_posix_set_ancestor_overflow_uid_for_test(bool active,
+                                                             unsigned long overflow_uid) {
+    g_posix_overflow_override_active = active;
+    g_posix_overflow_override_uid = active ? (uid_t)overflow_uid : POSIX_NO_OVERFLOW_UID;
 }
+#endif
+
+#if defined(__linux__) || defined(CBM_ENABLE_TEST_SEAMS)
+/* Parse a /proc/self/uid_map image. True iff it is exactly one mapping line
+ * "<inside> <outside> <count>" with count == 1 and inside == euid. Extra lines,
+ * a count other than 1, a different inside id, or malformed input all yield
+ * false (no tolerance). */
+static bool posix_uid_map_is_single_uid(const char *uid_map, uid_t euid) {
+    if (!uid_map) {
+        return false;
+    }
+    unsigned long inside = 0;
+    unsigned long outside = 0;
+    unsigned long count = 0;
+    int consumed = 0;
+    if (sscanf(uid_map, " %lu %lu %lu %n", &inside, &outside, &count, &consumed) != 3) {
+        return false;
+    }
+    if (count != 1UL || (uid_t)inside != euid) {
+        return false;
+    }
+    (void)outside;
+    /* Reject a second mapping line: a single-uid map has exactly one. */
+    const char *rest = uid_map + consumed;
+    while (*rest == ' ' || *rest == '\t' || *rest == '\n' || *rest == '\r') {
+        rest++;
+    }
+    return *rest == '\0';
+}
+#endif
+
+#if defined(__linux__)
+static bool posix_read_small_proc_file(const char *path, char *buffer, size_t capacity) {
+    int fd = open(path, O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+        return false;
+    }
+    size_t total = 0;
+    bool ok = true;
+    while (total + 1 < capacity) {
+        ssize_t got = read(fd, buffer + total, capacity - 1 - total);
+        if (got < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            ok = false;
+            break;
+        }
+        if (got == 0) {
+            break;
+        }
+        total += (size_t)got;
+    }
+    (void)close(fd);
+    if (!ok) {
+        return false;
+    }
+    buffer[total] = '\0';
+    return true;
+}
+
+static uid_t posix_compute_ancestor_overflow_uid(void) {
+    char map[256];
+    if (!posix_read_small_proc_file("/proc/self/uid_map", map, sizeof(map)) ||
+        !posix_uid_map_is_single_uid(map, geteuid())) {
+        return POSIX_NO_OVERFLOW_UID;
+    }
+    char overflow_text[32];
+    /* Unreadable → no tolerance; never hardcode 65534. */
+    if (!posix_read_small_proc_file("/proc/sys/kernel/overflowuid", overflow_text,
+                                    sizeof(overflow_text))) {
+        return POSIX_NO_OVERFLOW_UID;
+    }
+    unsigned long overflow = 0;
+    if (sscanf(overflow_text, " %lu", &overflow) != 1) {
+        return POSIX_NO_OVERFLOW_UID;
+    }
+    return (uid_t)overflow;
+}
+
+static uid_t g_posix_overflow_cached = POSIX_NO_OVERFLOW_UID;
+static pthread_once_t g_posix_overflow_once = PTHREAD_ONCE_INIT;
+static void posix_overflow_init_once(void) {
+    g_posix_overflow_cached = posix_compute_ancestor_overflow_uid();
+}
+#endif /* __linux__ */
+
+/* The overflow uid tolerated for ancestors in this process, or
+ * POSIX_NO_OVERFLOW_UID when none. Derived once from immutable /proc state. */
+static uid_t posix_ancestor_overflow_uid(void) {
+#ifdef CBM_ENABLE_TEST_SEAMS
+    if (g_posix_overflow_override_active) {
+        return g_posix_overflow_override_uid;
+    }
+#endif
+#if defined(__linux__)
+    (void)pthread_once(&g_posix_overflow_once, posix_overflow_init_once);
+    return g_posix_overflow_cached;
+#else
+    return POSIX_NO_OVERFLOW_UID;
+#endif
+}
+
+/* Ancestor owner acceptance. euid and root are always trusted; the namespace
+ * overflow uid is trusted only when overflow_uid != POSIX_NO_OVERFLOW_UID. */
+static bool posix_ancestor_owner_ok(uid_t owner, uid_t euid, uid_t overflow_uid) {
+    return owner == (uid_t)0 || owner == euid ||
+           (overflow_uid != POSIX_NO_OVERFLOW_UID && owner == overflow_uid);
+}
+
+/* Pure ancestor accept/refuse over (owner, mode). Mirrors the owner + write-bit
+ * policy of posix_directory_parent_secure so the decision is unit-testable
+ * without a chown-able overflow-owned directory (unprivileged tests cannot
+ * create one). The ACL and fstat checks stay in the caller. */
+static bool posix_ancestor_stat_ok(uid_t owner, mode_t mode, uid_t euid, uid_t overflow_uid) {
+    if (!posix_ancestor_owner_ok(owner, euid, overflow_uid)) {
+        return false;
+    }
+    bool owner_is_overflow = overflow_uid != POSIX_NO_OVERFLOW_UID && owner == overflow_uid &&
+                             owner != euid && owner != (uid_t)0;
+    if ((mode & 0002) != 0) {
+        /* World-writable ancestor: only the root/overflow-owned sticky pattern
+         * (for example /tmp). A plain writable ancestor lets any local user swap
+         * a path component. */
+        return (owner == (uid_t)0 || owner_is_overflow) && (mode & S_ISVTX) != 0;
+    }
+    if ((mode & 0020) != 0 && owner_is_overflow) {
+        /* Group-writable is admitted with a warning for euid/root owners where
+         * the group is knowable (#1537); for an unmapped overflow owner the
+         * host-side group membership is unknown, so refuse. */
+        return false;
+    }
+    return true;
+}
+
+static bool posix_directory_ancestor_owner_trusted(uid_t owner) {
+    return posix_ancestor_owner_ok(owner, geteuid(), posix_ancestor_overflow_uid());
+}
+
+#ifdef CBM_ENABLE_TEST_SEAMS
+bool cbm_daemon_ipc_posix_uid_map_is_single_uid_for_test(const char *uid_map, unsigned long euid) {
+    return posix_uid_map_is_single_uid(uid_map, (uid_t)euid);
+}
+bool cbm_daemon_ipc_posix_ancestor_stat_ok_for_test(unsigned long owner, unsigned int mode,
+                                                    unsigned long euid, bool overflow_active,
+                                                    unsigned long overflow_uid) {
+    return posix_ancestor_stat_ok((uid_t)owner, (mode_t)mode, (uid_t)euid,
+                                  overflow_active ? (uid_t)overflow_uid : POSIX_NO_OVERFLOW_UID);
+}
+#endif
 
 static bool posix_directory_parent_secure(int directory_fd) {
     struct stat status;
     if (directory_fd < 0 || fstat(directory_fd, &status) != 0 || !S_ISDIR(status.st_mode) ||
-        !posix_directory_owner_trusted(status.st_uid) ||
         !cbm_macos_extended_acl_fd_is_deny_only(directory_fd)) {
         return false;
     }
@@ -1403,14 +1580,18 @@ static bool posix_directory_parent_secure(int directory_fd) {
      * with a shared primary group), and refusing it here made the daemon
      * unusable with no way for the reader to see why.
      *
-     * WORLD-writable is still refused: any local user could swap a path
-     * component. Group-writable is admitted for ancestors only — the private
-     * directory itself is chmod'd to 0700 and verified after this walk, so the
-     * thing that actually holds data stays owner-private either way. */
-    if ((status.st_mode & 0002) != 0) {
-        return status.st_uid == (uid_t)0 && (status.st_mode & S_ISVTX) != 0;
+     * WORLD-writable is still refused (apart from the root/overflow-owned sticky
+     * pattern such as /tmp): any local user could swap a path component.
+     * Group-writable is admitted for ancestors only — the private directory
+     * itself is chmod'd to 0700 and verified after this walk, so the thing that
+     * actually holds data stays owner-private either way. #1830 extends the
+     * accepted owner set to the single-uid user-namespace overflow uid; see
+     * posix_ancestor_stat_ok. */
+    if (!posix_ancestor_stat_ok(status.st_uid, status.st_mode, geteuid(),
+                                posix_ancestor_overflow_uid())) {
+        return false;
     }
-    if ((status.st_mode & 0020) != 0) {
+    if ((status.st_mode & 0020) != 0 && (status.st_mode & 0002) == 0) {
         char mode_text[16];
         (void)snprintf(mode_text, sizeof(mode_text), "%04o", (unsigned)(status.st_mode & 07777));
         cbm_log_warn("daemon.private_dir_group_writable_ancestor", "mode", mode_text);
@@ -1420,17 +1601,20 @@ static bool posix_directory_parent_secure(int directory_fd) {
 
 /* Validate a path transition only through the two already-open directory
  * handles.  A group/other-writable parent is unsafe unless it is the standard
- * root-owned sticky-directory pattern (for example /tmp) and the selected
- * child is itself root/current-user owned.  Existing ancestors are observed,
- * never chmod'd or ACL-rewritten. */
+ * root/overflow-owned sticky-directory pattern (for example /tmp) and both the
+ * parent and the selected child are trusted-owned (euid/root, or the single-uid
+ * user-namespace overflow uid for #1830).  Existing ancestors are observed,
+ * never chmod'd or ACL-rewritten.  The euid-only enforcement that stops a
+ * squatted private directory lives in the created/final/snapshot checks, not
+ * here — this only walks ancestors. */
 static bool posix_directory_transition_secure(int parent_fd, int child_fd) {
     struct stat parent;
     struct stat child;
     if (parent_fd < 0 || child_fd < 0 || !posix_directory_parent_secure(parent_fd) ||
         fstat(parent_fd, &parent) != 0 || fstat(child_fd, &child) != 0 ||
         !S_ISDIR(parent.st_mode) || !S_ISDIR(child.st_mode) ||
-        !posix_directory_owner_trusted(parent.st_uid) ||
-        !posix_directory_owner_trusted(child.st_uid)) {
+        !posix_directory_ancestor_owner_trusted(parent.st_uid) ||
+        !posix_directory_ancestor_owner_trusted(child.st_uid)) {
         return false;
     }
     return true;

--- a/src/daemon/ipc.h
+++ b/src/daemon/ipc.h
@@ -94,6 +94,18 @@ const char *cbm_daemon_ipc_validation_detail(void);
 #ifdef CBM_ENABLE_TEST_SEAMS
 /* #1537: seed the detail so a test can prove the CLI refusal surfaces it. */
 void cbm_daemon_ipc_set_validation_detail_for_testing(const char *detail);
+#ifndef _WIN32
+/* #1830 seams (POSIX). Override the single-uid user-namespace overflow uid that
+ * ancestors may be owned by (active=false restores the real /proc-derived
+ * value); and expose the pure uid_map-parse and ancestor accept/refuse decision
+ * so they can be tested without a chown-able overflow-owned directory. */
+void cbm_daemon_ipc_posix_set_ancestor_overflow_uid_for_test(bool active,
+                                                             unsigned long overflow_uid);
+bool cbm_daemon_ipc_posix_uid_map_is_single_uid_for_test(const char *uid_map, unsigned long euid);
+bool cbm_daemon_ipc_posix_ancestor_stat_ok_for_test(unsigned long owner, unsigned int mode,
+                                                    unsigned long euid, bool overflow_active,
+                                                    unsigned long overflow_uid);
+#endif
 #endif
 
 /* Create/validate an owner-only directory and securely open one regular

--- a/tests/test_daemon_ipc.c
+++ b/tests/test_daemon_ipc.c
@@ -49,6 +49,9 @@
 #include <sys/un.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#ifdef __linux__
+#include <sched.h> /* #1830 userns real smoke: unshare(CLONE_NEWUSER). */
+#endif
 #ifdef __APPLE__
 #include <membership.h>
 #include <sys/acl.h>
@@ -4950,6 +4953,124 @@ TEST(daemon_ipc_posix_world_writable_ancestor_still_refused_issue1537) {
     ASSERT_TRUE(refused);
     PASS();
 }
+
+#ifdef CBM_ENABLE_TEST_SEAMS
+/* #1830: /proc/self/uid_map single-uid detection. A single-uid map is exactly
+ * one line "<inside> <outside> 1" whose inside id is our euid; anything else —
+ * the init map, a count other than 1, a foreign inside id, extra lines, or junk
+ * — must read as "not single-uid" so the overflow tolerance never engages. */
+TEST(daemon_ipc_posix_uid_map_single_uid_parse_issue1830) {
+    const unsigned long me = 1000;
+    ASSERT_TRUE(cbm_daemon_ipc_posix_uid_map_is_single_uid_for_test("1000 1000 1\n", me));
+    ASSERT_TRUE(cbm_daemon_ipc_posix_uid_map_is_single_uid_for_test("1000 0 1", me));
+    ASSERT_TRUE(!cbm_daemon_ipc_posix_uid_map_is_single_uid_for_test("0 0 4294967295\n", me));
+    ASSERT_TRUE(!cbm_daemon_ipc_posix_uid_map_is_single_uid_for_test("1000 1000 2\n", me));
+    ASSERT_TRUE(!cbm_daemon_ipc_posix_uid_map_is_single_uid_for_test("42 1000 1\n", me));
+    ASSERT_TRUE(!cbm_daemon_ipc_posix_uid_map_is_single_uid_for_test("1000 1000 1\n0 0 1\n", me));
+    ASSERT_TRUE(!cbm_daemon_ipc_posix_uid_map_is_single_uid_for_test("", me));
+    ASSERT_TRUE(!cbm_daemon_ipc_posix_uid_map_is_single_uid_for_test("not a map", me));
+    PASS();
+}
+
+/* #1830: the ancestor accept/refuse decision. The overflow uid is tolerable for
+ * an ancestor ONLY when the single-uid tolerance is engaged, and even then only
+ * where a root owner would be: not world-writable unless sticky, and never
+ * group-writable (the unmapped owner's host group is unknown). With tolerance
+ * OFF (init/multi-uid/unreadable map) an overflow-owned ancestor is refused
+ * exactly as before #1830 — that OFF row is what a revert of the tolerance
+ * would collapse the ON rows to, so it pins the fix. euid/root/foreign owners
+ * behave identically with tolerance on or off. */
+TEST(daemon_ipc_posix_overflow_ancestor_tolerated_only_in_single_uid_ns_issue1830) {
+    const unsigned long euid = 1000;
+    const unsigned long ovf = 65534;
+    const unsigned long foreign = 4242;
+#define ANCESTOR_OK(owner, mode, on, ovfuid) \
+    cbm_daemon_ipc_posix_ancestor_stat_ok_for_test((owner), (mode), euid, (on), (ovfuid))
+
+    /* Overflow-owned ancestors, single-uid tolerance ENGAGED. */
+    ASSERT_TRUE(ANCESTOR_OK(ovf, 0755, true, ovf));
+    ASSERT_TRUE(ANCESTOR_OK(ovf, 0700, true, ovf));
+    ASSERT_TRUE(ANCESTOR_OK(ovf, 01777, true, ovf)); /* sticky /tmp shape */
+    ASSERT_TRUE(!ANCESTOR_OK(ovf, 0777, true, ovf)); /* world-writable, no sticky */
+    ASSERT_TRUE(!ANCESTOR_OK(ovf, 0775, true, ovf)); /* group-writable overflow owner */
+
+    /* Same ancestors, tolerance OFF — the pre-#1830 refusal (and the multi-uid /
+     * unreadable-map path). A revert of the fix makes the ON rows read like these. */
+    ASSERT_TRUE(!ANCESTOR_OK(ovf, 0755, false, 0));
+    ASSERT_TRUE(!ANCESTOR_OK(ovf, 01777, false, 0));
+
+    /* Controls unaffected by the tolerance. */
+    ASSERT_TRUE(ANCESTOR_OK(euid, 0755, true, ovf));
+    ASSERT_TRUE(ANCESTOR_OK(euid, 0700, false, 0));
+    ASSERT_TRUE(ANCESTOR_OK(0, 01777, true, ovf));       /* root-owned sticky /tmp */
+    ASSERT_TRUE(!ANCESTOR_OK(0, 0777, true, ovf));       /* root world-writable, no sticky */
+    ASSERT_TRUE(!ANCESTOR_OK(foreign, 0755, true, ovf)); /* a mapped-out foreign uid */
+#undef ANCESTOR_OK
+    PASS();
+}
+
+/* #1830 real end-to-end smoke: inside a single-uid user namespace the
+ * root-owned ancestors (/, /tmp) are overflow-owned, and the daemon must still
+ * create its private directory there. An overflow-owned ancestor cannot be
+ * fabricated unprivileged, so this runs the real path only when a user
+ * namespace is actually available. O10 whitelisted-skip everywhere it is not:
+ * macOS has no user namespaces (compile-gated out); Docker's default seccomp
+ * blocks unshare(CLONE_NEWUSER) on the Colima container leg; some kernels ship
+ * user namespaces disabled. WHAT WAS TRIED when it skips: fork + unshare
+ * CLONE_NEWUSER + a 1:1 uid_map write, which the sandbox denied (EPERM). The
+ * deterministic decision coverage above is what binds the fix. */
+TEST(daemon_ipc_posix_single_uid_userns_real_smoke_issue1830) {
+#if defined(__linux__)
+    uid_t host_uid = geteuid();
+    char probe[TEST_PATH_CAP];
+    (void)snprintf(probe, sizeof(probe), "/tmp/cbm-userns-smoke-%ld/x", (long)getpid());
+    char probe_dir[TEST_PATH_CAP];
+    (void)snprintf(probe_dir, sizeof(probe_dir), "/tmp/cbm-userns-smoke-%ld", (long)getpid());
+
+    pid_t child = fork();
+    if (child == 0) {
+        /* Child: enter a single-uid user namespace mapping host_uid 1:1. */
+        if (unshare(CLONE_NEWUSER) != 0) {
+            _exit(2); /* userns unavailable → signal skip to the parent. */
+        }
+        int sg = open("/proc/self/setgroups", O_WRONLY | O_CLOEXEC);
+        if (sg >= 0) {
+            (void)!write(sg, "deny", 4);
+            (void)close(sg);
+        }
+        int mf = open("/proc/self/uid_map", O_WRONLY | O_CLOEXEC);
+        char line[64];
+        int n = snprintf(line, sizeof(line), "%ld %ld 1", (long)host_uid, (long)host_uid);
+        bool mapped = mf >= 0 && n > 0 && write(mf, line, (size_t)n) == n;
+        if (mf >= 0) {
+            (void)close(mf);
+        }
+        if (!mapped) {
+            _exit(2);
+        }
+        /* Inside the ns / and /tmp now show the overflow uid. With #1830 the
+         * daemon can still build its private tree there; without it, refused. */
+        bool secured = cbm_daemon_ipc_private_directory_secure(probe);
+        _exit(secured ? 0 : 1);
+    }
+    if (child < 0) {
+        FAIL("fork failed for userns smoke");
+    }
+    int status = 0;
+    while (waitpid(child, &status, 0) < 0 && errno == EINTR) {}
+    (void)rmdir(probe);
+    (void)rmdir(probe_dir);
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 2) {
+        SKIP_PLATFORM("user namespaces unavailable (no CLONE_NEWUSER / seccomp-blocked)");
+    }
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(0, WEXITSTATUS(status));
+    PASS();
+#else
+    SKIP_PLATFORM("user namespaces are Linux-only");
+#endif
+}
+#endif /* CBM_ENABLE_TEST_SEAMS */
 #endif /* !_WIN32 */
 
 SUITE(daemon_ipc) {
@@ -4992,6 +5113,11 @@ SUITE(daemon_ipc) {
 #ifndef _WIN32
     RUN_TEST(daemon_ipc_posix_group_writable_ancestor_is_admitted_issue1537);
     RUN_TEST(daemon_ipc_posix_world_writable_ancestor_still_refused_issue1537);
+#ifdef CBM_ENABLE_TEST_SEAMS
+    RUN_TEST(daemon_ipc_posix_uid_map_single_uid_parse_issue1830);
+    RUN_TEST(daemon_ipc_posix_overflow_ancestor_tolerated_only_in_single_uid_ns_issue1830);
+    RUN_TEST(daemon_ipc_posix_single_uid_userns_real_smoke_issue1830);
+#endif
     RUN_TEST(daemon_ipc_posix_startup_lock_is_cross_process);
     RUN_TEST(daemon_ipc_posix_lifetime_reservation_rejects_fork_inheritance);
     RUN_TEST(daemon_ipc_posix_child_participant_handoff_retains_legacy_bridge);


### PR DESCRIPTION
### Problem

Inside a single-uid user namespace (`unshare -U --map-current-user`, `podman --userns=keep-id`), the root-owned top-level ancestors (`/`, `/tmp`) appear owned by the kernel **overflow uid** (nobody). The daemon's directory-security walk refused every overflow-owned ancestor, so it could not create its private runtime directory and refused to start in that legitimate setup.

### Fix (#1830)

Accept an overflow-owned **ancestor** only when `/proc/self/uid_map` is a **single-uid map** (exactly one line, `count == 1`, `inside == euid`) **and** `/proc/sys/kernel/overflowuid` is readable (the value is read from `/proc`, never hardcoded; unreadable ⇒ no tolerance). No environment escape hatch. Group-writable-overflow ancestors are refused (an unmapped owner's host group is unknowable); world-writable-overflow is tolerated only with the sticky bit (the `/tmp` shape).

### Why it's safe

The tolerance is confined to the **ancestor walk** (`posix_directory_parent_secure`, `posix_directory_transition_secure`). The directories that actually hold data stay strict `== geteuid()`: the created-dir recheck (`ipc.c:1687`) and the final-dir gate (`ipc.c:1714`). **These two euid gates are the security-critical backstop** — a host-squatted, overflow-owned private directory is still refused there, so the overflow tolerance only widens which *ancestors* the walk may traverse, never the destination. In a single-uid namespace `uid_map` is write-once/immutable and no in-namespace principal can own or mutate an overflow-owned file, so an overflow-owned ancestor is exactly as safe as a root-owned one on the host.

### Verification

- The single-uid gate refuses a multi-uid map, `count != 1`, `inside != euid`, and any second mapping line; a mapped-out **foreign** uid is refused even with tolerance ON.
- macOS 52 / 1-skip; Linux (Colima arm64, gcc) 47 / 1-skip — exercises the `__linux__` /proc path, plus a real `unshare(CLONE_NEWUSER)` end-to-end smoke (whitelisted-skip where userns is unavailable).
- RED-on-revert: neutering the overflow clause fails the ancestor-decision test; restoring is byte-identical and green.
- clang-format + cppcheck clean; localized to `src/daemon/ipc.c` (+ test seams).

Adversarially reviewed as a security-boundary change: no privilege-boundary fail-open found; the safety rests on the two `== geteuid()` gates above staying strict.
