### PR TITLE
fix(registry): recognize C# lower-case type keywords in receiver_chain_admits

### DIFF
--- a/src/pipeline/registry.c
+++ b/src/pipeline/registry.c
@@ -925,6 +925,22 @@ static const char *qualified_suffix_match(const qn_array_t *arr, const char *cal
     return match;
 }
 
+/* C#'s built-in type aliases (int, string, bool, ...) are lower-case
+ * KEYWORDS naming a type, not an ordinary lower-case value root; closed list,
+ * no caller-language read, matching the guard below's own design. */
+static bool receiver_root_is_type_keyword(const char *root, size_t len) {
+    static const char *const keywords[] = {
+        "bool",   "byte",  "char",  "decimal", "double", "dynamic", "float",  "int",  "long",
+        "object", "sbyte", "short", "string",  "uint",   "ulong",   "ushort", "void",
+    };
+    for (size_t i = 0; i < sizeof(keywords) / sizeof(keywords[0]); i++) {
+        if (strlen(keywords[i]) == len && strncmp(root, keywords[i], len) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /* A dotted callee whose FIRST segment starts upper-case names a type — URLSession,
  * Calendar, JSONEncoder. That receiver chain is evidence the bare-name scorers
  * throw away, and throwing it away binds Foundation's URLSession.shared.data to
@@ -933,7 +949,8 @@ static const char *qualified_suffix_match(const qn_array_t *arr, const char *cal
  * appears somewhere in the chain. Calendar.utcGregorian.startOfDayUTC resolving
  * to AuthDTOs.Calendar.startOfDayUTC passes, because Calendar is in the chain.
  *
- * Only an upper-case first segment is guarded. A lower-case root names a value
+ * Only an upper-case first segment is guarded, plus the closed set of
+ * lower-case type keywords above. Any other lower-case root names a value
  * (vm.load, http.Get, os.path.join) whose declared type the chain does not
  * show, so the chain proves nothing there and the call passes through
  * unchanged. A callee with no separator passes through as well.
@@ -960,7 +977,14 @@ static bool receiver_chain_admits(const char *callee_name, const char *candidate
         return true; /* bare name — no receiver chain to judge */
     }
     if (dotted[0] < 'A' || dotted[0] > 'Z') {
-        return true; /* lower-case root names a value, not a type */
+        const char *first_dot = strchr(dotted, '.');
+        size_t root_len = (size_t)((first_dot ? first_dot : last_dot) - dotted);
+        if (!receiver_root_is_type_keyword(dotted, root_len)) {
+            return true; /* lower-case root names a value, not a type */
+        }
+        /* A reserved type keyword IS a type in receiver position
+         * (int.TryParse), so it falls through to the same chain-consistency
+         * check an upper-case root gets. */
     }
     /* A name written in capitals with underscores is a constant holding a
      * value, not a type: ISO_4217_URL.lower is a string's own method. JSON and

--- a/tests/test_pipeline.c
+++ b/tests/test_pipeline.c
@@ -9814,6 +9814,34 @@ TEST(registry_receiver_chain_ignores_lowercase_root_issue1893) {
     PASS();
 }
 
+/* Issue #2121: unlike vm.load's lower-case value root above, C#'s built-in
+ * type keywords (int, string, bool, ...) DO name a type and must get the
+ * same chain-consistency check an upper-case root gets. */
+TEST(registry_receiver_chain_refuses_lowercase_type_keyword_issue2121) {
+    cbm_registry_t *reg = cbm_registry_new();
+    cbm_registry_add(reg, "TryParse", "tmp.Decoys.TsidNode.TryParse", "Method");
+
+    cbm_resolution_t r = cbm_registry_resolve(reg, "int.TryParse", "tmp.Demo", NULL, NULL, 0);
+    ASSERT_NULL(r.qualified_name);
+
+    cbm_registry_free(reg);
+    PASS();
+}
+
+/* The true positive the new keyword check must not eat: the project really
+ * does define a type literally named "int" (or similar) and the chain shows
+ * it, so the match must still go through. */
+TEST(registry_receiver_chain_keeps_type_keyword_when_chain_matches_issue2121) {
+    cbm_registry_t *reg = cbm_registry_new();
+    cbm_registry_add(reg, "TryParse", "tmp.int.TryParse", "Method");
+
+    cbm_resolution_t r = cbm_registry_resolve(reg, "int.TryParse", "tmp.Demo", NULL, NULL, 0);
+    ASSERT_STR_EQ(r.qualified_name, "tmp.int.TryParse");
+
+    cbm_registry_free(reg);
+    PASS();
+}
+
 /* An unqualified callee has no chain at all and must pass through unchanged. */
 TEST(registry_receiver_chain_ignores_bare_name_issue1893) {
     cbm_registry_t *reg = cbm_registry_new();
@@ -14155,6 +14183,8 @@ SUITE(pipeline) {
     RUN_TEST(registry_receiver_chain_refuses_library_suffix_match_issue1893);
     RUN_TEST(registry_receiver_chain_keeps_project_extension_issue1893);
     RUN_TEST(registry_receiver_chain_ignores_lowercase_root_issue1893);
+    RUN_TEST(registry_receiver_chain_refuses_lowercase_type_keyword_issue2121);
+    RUN_TEST(registry_receiver_chain_keeps_type_keyword_when_chain_matches_issue2121);
     RUN_TEST(registry_receiver_chain_ignores_bare_name_issue1893);
     RUN_TEST(registry_fuzzy_confidence_single);
     RUN_TEST(registry_fuzzy_confidence_distance);


### PR DESCRIPTION
## What does this PR do?

`receiver_chain_admits()` (`src/pipeline/registry.c`) fast-admits a lower-case-rooted receiver chain as a value rather than a type. That's correct for Go, Python and Swift (`vm.load`, `http.Get`, `os.path.join`), but C# spells its built-in types as lower-case keywords (`int`, `string`, `bool`, ...), so a static call like `int.TryParse(...)` skips the chain-consistency check entirely and can fabricate a `CALLS` edge to any unrelated method sharing the same name (#2121).

Fix: a closed set of C# type keywords is checked only when the receiver root is lower-case; anything not in that set still fast-admits exactly as before, so other languages' lower-case value roots are unaffected.

Fixes #2121

## What does this PR do NOT fix?

The issue's second example, `Options.Create(new object())`, no longer reproduces at HEAD: PR #1897 (merged 2026-09-04) already added the chain-consistency guard this PR extends, and it happens to cover that upper-case-rooted shape already.

## How was this verified?

- Added `registry_receiver_chain_refuses_lowercase_type_keyword_issue2121`. Without the fix, `ASSERT_NULL` in that test trips because the fabricated edge still resolves; with the fix it's clean. Ran both ways in the same Docker image (`ubuntu:24.04`, ASan+UBSan test build).
- Reproduced the issue's own two-file C# example end to end with the built CLI (`index_repository` + `trace_path`): `int.TryParse` fabricates an edge to an unrelated `TryParse` on main; zero edges on this branch.
- Added a second test, `registry_receiver_chain_keeps_type_keyword_when_chain_matches_issue2121`, confirming the guard still resolves a real project type whose chain matches, so it isn't just refusing everything lower-case.
- Full `pipeline` suite (279 tests) green on this branch; `cppcheck` and `clang-format --dry-run` clean on the changed file. Not checked against the exact CI toolchain: local cppcheck was 2.13.0 and clang-format 18.1.3, CI pins 2.20.0 and clang-format-20.
