### PR TITLE
fix(daemon): keep an ephemeral generation for a mid-HELLO cold-storm racer

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -47,6 +47,11 @@ struct cbm_daemon_coordinator {
     size_t client_count;
     /* See cbm_daemon_coordinator_set_permanent. */
     bool permanent;
+    /* See cbm_daemon_coordinator_set_linger. Distinct from `permanent`: a
+     * transient, runtime-driven hold that keeps an ephemeral coordinator
+     * admitting while cohort participants are still mid-bootstrap (cold-storm
+     * race, 2026-09). Clearing it while idle retires the coordinator at once. */
+    bool linger;
     size_t job_count;
     size_t watch_count;
     size_t callback_count;
@@ -291,7 +296,7 @@ static void release_client_locked(cbm_daemon_coordinator_t *coordinator,
     release_client_resources_locked(coordinator, client->id, batch);
     free(client);
     coordinator->client_count--;
-    if (coordinator->client_count == 0 && !coordinator->permanent) {
+    if (coordinator->client_count == 0 && !coordinator->permanent && !coordinator->linger) {
         coordinator->state = CBM_DAEMON_COORDINATOR_STOPPING;
     }
 }
@@ -326,6 +331,23 @@ void cbm_daemon_coordinator_set_permanent(cbm_daemon_coordinator_t *coordinator,
     }
     cbm_mutex_lock(&coordinator->mutex);
     coordinator->permanent = permanent;
+    cbm_mutex_unlock(&coordinator->mutex);
+}
+
+void cbm_daemon_coordinator_set_linger(cbm_daemon_coordinator_t *coordinator, bool linger) {
+    if (!coordinator) {
+        return;
+    }
+    cbm_mutex_lock(&coordinator->mutex);
+    coordinator->linger = linger;
+    /* Clearing the hold while the coordinator is already idle is the retirement
+     * signal: an ephemeral generation whose cohort participants have all
+     * connected and left (or whose linger window elapsed) transitions to
+     * STOPPING now, exactly as the last-client disconnect would have. */
+    if (!linger && !coordinator->permanent && coordinator->client_count == 0 &&
+        coordinator->state == CBM_DAEMON_COORDINATOR_RUNNING) {
+        coordinator->state = CBM_DAEMON_COORDINATOR_STOPPING;
+    }
     cbm_mutex_unlock(&coordinator->mutex);
 }
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -74,6 +74,14 @@ cbm_daemon_coordinator_t *cbm_daemon_coordinator_new(uint64_t lease_timeout_ms);
  * self-transitions to STOPPING when its client count reaches zero; only the
  * explicit stop/drain paths end it. */
 void cbm_daemon_coordinator_set_permanent(cbm_daemon_coordinator_t *coordinator, bool permanent);
+/* Transient, runtime-driven hold (distinct from `permanent`) that keeps an
+ * ephemeral coordinator RUNNING — still admitting new clients — after its last
+ * client disconnects, while cohort participants are still mid-bootstrap racing
+ * connect() (cold-storm race, 2026-09). Setting it before the last disconnect
+ * suppresses the self-transition to STOPPING; clearing it while the coordinator
+ * is already idle transitions to STOPPING at once, so retirement stays prompt
+ * and bounded. Has no effect on a permanent coordinator. */
+void cbm_daemon_coordinator_set_linger(cbm_daemon_coordinator_t *coordinator, bool linger);
 /* The caller must first quiesce coordinator calls and hook invocations. */
 void cbm_daemon_coordinator_free(cbm_daemon_coordinator_t *coordinator);
 

--- a/src/daemon/host.c
+++ b/src/daemon/host.c
@@ -891,6 +891,10 @@ static bool host_wait_for_lifetime(cbm_daemon_runtime_service_t *service,
             return cbm_daemon_runtime_service_stop(service, HOST_RUNTIME_SHUTDOWN_MS);
         }
         host_http_reconcile_at(host, cbm_now_ms(), false);
+        /* Retire an ephemeral generation that lingered for cold-storm cohort
+         * participants once they drain, or once its bounded linger elapses.
+         * A no-op unless a cohort-participant hook armed a linger. */
+        cbm_daemon_runtime_service_reconcile_lifetime(service);
         (void)cbm_daemon_runtime_service_wait_exited(service, HOST_WAIT_TICK_MS);
     }
 }

--- a/src/daemon/runtime.c
+++ b/src/daemon/runtime.c
@@ -49,6 +49,16 @@ void cbm_daemon_runtime_set_containment_hook_for_testing(
     cbm_daemon_runtime_containment_hook_t hook) {
     atomic_store(&runtime_containment_hook_seam, hook);
 }
+
+/* Cold-storm ephemeral-linger seam (2026-09). Overrides the bounded linger
+ * window that ephemeral last-committed-client retirement grants while cohort
+ * participants are still mid-bootstrap, so a test can drive both the linger and
+ * its expiry backstop in test time. UINT32_MAX leaves the production constant;
+ * any other value (0 = expire immediately) overrides. */
+static _Atomic uint32_t runtime_ephemeral_linger_timeout_seam = UINT32_MAX;
+void cbm_daemon_runtime_service_set_ephemeral_linger_timeout_for_testing(uint32_t timeout_ms) {
+    atomic_store(&runtime_ephemeral_linger_timeout_seam, timeout_ms);
+}
 #endif
 
 #ifdef _WIN32
@@ -95,6 +105,14 @@ enum {
      * wedged behind it, and the dead generation held the endpoint pipes and
      * the UI port for nine hours with nothing logged. */
     RUNTIME_ABANDONED_REQUEST_JOIN_TIMEOUT_MS = 30000,
+    /* Cold-storm race (2026-09): when the final committed client of an
+     * ephemeral generation disconnects while cohort participants are still
+     * admitted but mid-bootstrap (racing connect()), the generation lingers
+     * this long for them to connect instead of retiring out from under them.
+     * Mirrors the host initial-client window; the linger is always bounded so
+     * a participant that never connects cannot wedge the generation (the
+     * 900s host_serving hang). */
+    RUNTIME_EPHEMERAL_LINGER_MS = 10000,
     RUNTIME_PATH_CAP = 4096,
 
     RENDEZVOUS_REQUEST_ABI_OFFSET = 0,
@@ -231,6 +249,12 @@ struct cbm_daemon_runtime_service {
     /* Owned only by the convenience start() path. start_reserved() callers
      * retain their externally managed participant guard. */
     cbm_daemon_ipc_participant_guard_t *owned_participant_guard;
+    /* Cold-storm ephemeral-retirement gate (2026-09). When the final committed
+     * client disconnects while cohort participants are still admitted but not
+     * yet committed, the generation lingers until this bounded deadline instead
+     * of retiring; reconcile_lifetime retires it once that window elapses with
+     * no new client committing. Zero means no linger is armed. */
+    uint64_t ephemeral_linger_deadline_ms;
 };
 
 struct cbm_daemon_runtime_worker {
@@ -287,6 +311,16 @@ static uint64_t runtime_deadline_after(uint32_t timeout_ms) {
         return UINT64_MAX;
     }
     return now_ms + (uint64_t)timeout_ms;
+}
+
+static uint32_t runtime_ephemeral_linger_timeout_ms(void) {
+#ifdef CBM_ENABLE_TEST_SEAMS
+    uint32_t seam = atomic_load(&runtime_ephemeral_linger_timeout_seam);
+    if (seam != UINT32_MAX) {
+        return seam;
+    }
+#endif
+    return RUNTIME_EPHEMERAL_LINGER_MS;
 }
 
 static void runtime_wait_tick(uint64_t deadline_ms) {
@@ -1174,10 +1208,32 @@ static void runtime_service_interrupt_connections(cbm_daemon_runtime_service_t *
     runtime_service_interrupt_connections_except(service, NULL, false);
 }
 
+/* A cold-storm racer is a connection that has been ACCEPTED but has not yet
+ * passed HELLO admission (in_use with a live connection, not yet admitted, not
+ * tearing down) -- a one-shot client still mid-bootstrap. This deliberately
+ * does NOT count an already-admitted provisional session (HELLO done, app
+ * session opening): a provisional coordinator client must not keep a retiring
+ * generation alive (see runtime_worker_disconnect below and the
+ * daemon_runtime_final_disconnect_rejects_blocked_provisional_session guard).
+ * Caller holds service->mutex. `except` excludes the departing worker. */
+static bool runtime_has_pending_hello_peer_locked(const cbm_daemon_runtime_service_t *service,
+                                                  const cbm_daemon_runtime_worker_t *except) {
+    for (size_t i = 0; i < service->worker_capacity; i++) {
+        const cbm_daemon_runtime_worker_t *worker = &service->workers[i];
+        if (worker != except && worker->in_use && worker->connection && !worker->admitted &&
+            !atomic_load_explicit(&worker->disconnecting, memory_order_acquire)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static void runtime_worker_disconnect(cbm_daemon_runtime_worker_t *worker) {
     cbm_daemon_runtime_service_t *service = worker->service;
     cbm_daemon_client_id_t client_id = CBM_DAEMON_CLIENT_ID_INVALID;
     uint64_t shutdown_deadline = runtime_deadline_after(service->shutdown_timeout_ms);
+    bool last_committed_left = false;
+    bool linger_armed = false;
     atomic_store_explicit(&worker->disconnecting, true, memory_order_release);
     cbm_mutex_lock(&service->mutex);
     if (worker->admitted) {
@@ -1195,13 +1251,46 @@ static void runtime_worker_disconnect(cbm_daemon_runtime_worker_t *worker) {
              * alive after the final fully committed frontend disconnects.
              * A permanent generation (`daemon start`) deliberately survives
              * this: only the stop/drain ops or a process kill end it. */
-            runtime_service_begin_stopping_locked(service, shutdown_deadline, false,
-                                                  "last_committed_client_disconnected");
+            last_committed_left = true;
+            /* Cold-storm race (2026-09): if another connection is already
+             * accepted and still mid-HELLO (not yet admitted) when the last
+             * committed client leaves, it is a one-shot peer racing to commit —
+             * retiring now strands it on a STOPPING daemon and forces a full
+             * cold respawn ("cold-storm client failed (racing daemon spawn)").
+             * Linger a bounded window for it; the accept loop retires the
+             * generation once that racer drains without committing or the window
+             * elapses, and a racer that does commit clears the linger
+             * (runtime_worker_commit_admission). This deliberately lingers ONLY
+             * for a pre-HELLO racer, never for an already-admitted provisional
+             * session (HELLO done, app session opening): the contract that a
+             * provisional coordinator client cannot keep a retiring generation
+             * alive is preserved (the reject-blocked-provisional-session guard).
+             * With no such racer — the common single-client case — retire
+             * immediately, unchanged. (A cross-process cohort peer count is
+             * unavailable: advisory locks expose presence, not a holder count,
+             * and Windows LockFileEx has no non-owning probe.) */
+            if (runtime_has_pending_hello_peer_locked(service, worker)) {
+                service->ephemeral_linger_deadline_ms =
+                    runtime_deadline_after(runtime_ephemeral_linger_timeout_ms());
+                linger_armed = true;
+            } else {
+                service->ephemeral_linger_deadline_ms = 0;
+                runtime_service_begin_stopping_locked(service, shutdown_deadline, false,
+                                                      "last_committed_client_disconnected");
+            }
         }
     }
     cbm_mutex_unlock(&service->mutex);
     if (client_id == CBM_DAEMON_CLIENT_ID_INVALID) {
         return;
+    }
+    /* Set the coordinator hold BEFORE releasing this client so its last-client
+     * self-transition to STOPPING is suppressed while a racing peer is still
+     * mid-HELLO; when no peer is present the hold stays clear so the release
+     * retires the coordinator normally. last_committed_left implies a committed (hence
+     * admitted) client, so client_id is always valid here. */
+    if (last_committed_left) {
+        cbm_daemon_coordinator_set_linger(service->coordinator, linger_armed);
     }
     (void)cbm_daemon_client_disconnected(service->coordinator, client_id, cbm_now_ms());
     if (worker->application_session_opened && !worker->application_cancelled) {
@@ -1250,8 +1339,18 @@ static bool runtime_worker_commit_admission(cbm_daemon_runtime_worker_t *worker)
     if (committed) {
         worker->admission_committed = true;
         service->committed_clients++;
+        /* A freshly committed client ends any last-client linger window; the
+         * next drop to zero re-arms it against the participants outstanding
+         * then. */
+        service->ephemeral_linger_deadline_ms = 0;
     }
     cbm_mutex_unlock(&service->mutex);
+    if (committed) {
+        /* Mirror the cleared linger onto the coordinator. client_count is
+         * already nonzero (admission incremented it), so this only resets the
+         * hold for the next idle window — it never retires a live coordinator. */
+        cbm_daemon_coordinator_set_linger(service->coordinator, false);
+    }
     return committed;
 }
 
@@ -2183,6 +2282,11 @@ static void *runtime_accept_loop(void *opaque) {
             continue;
         }
 
+        /* Self-retire a generation lingering for a cold-storm peer once the peer
+         * drains or the bounded window elapses, without an external driver. A
+         * no-op unless a last-committed-client linger is armed. */
+        cbm_daemon_runtime_service_reconcile_lifetime(service);
+
         cbm_daemon_ipc_connection_t *connection = NULL;
         int accepted =
             cbm_daemon_ipc_accept(service->listener, RUNTIME_ACCEPT_POLL_MS, &connection);
@@ -2472,6 +2576,36 @@ size_t cbm_daemon_runtime_service_active_connections(cbm_daemon_runtime_service_
     size_t count = service->active_connections;
     cbm_mutex_unlock(&service->mutex);
     return count;
+}
+
+void cbm_daemon_runtime_service_reconcile_lifetime(cbm_daemon_runtime_service_t *service) {
+    if (!service) {
+        return;
+    }
+    bool retired = false;
+    cbm_mutex_lock(&service->mutex);
+    if (service->state == CBM_DAEMON_RUNTIME_SERVICE_RUNNING && !service->permanent &&
+        service->committed_clients == 0 && service->ephemeral_linger_deadline_ms != 0) {
+        bool peers_drained = !runtime_has_pending_hello_peer_locked(service, NULL);
+        bool window_elapsed = cbm_now_ms() >= service->ephemeral_linger_deadline_ms;
+        if (peers_drained || window_elapsed) {
+            /* The racing peer drained without committing (retire now), or never
+             * committed within the bounded window (the backstop that rules out
+             * an unbounded idle hang — the host_serving 900s mode). */
+            service->ephemeral_linger_deadline_ms = 0;
+            runtime_service_begin_stopping_locked(
+                service, runtime_deadline_after(service->shutdown_timeout_ms), false,
+                peers_drained ? "ephemeral_peer_drained" : "ephemeral_linger_expired");
+            retired = true;
+        }
+    }
+    cbm_mutex_unlock(&service->mutex);
+    if (retired) {
+        /* Release the coordinator hold now that the linger has resolved. With
+         * no client left this transitions the coordinator to STOPPING, so the
+         * service drains and exits cleanly rather than only on the deadline. */
+        cbm_daemon_coordinator_set_linger(service->coordinator, false);
+    }
 }
 
 size_t cbm_daemon_runtime_service_job_subscribers(cbm_daemon_runtime_service_t *service,

--- a/src/daemon/runtime.h
+++ b/src/daemon/runtime.h
@@ -329,6 +329,13 @@ uint64_t cbm_daemon_runtime_service_clients_admitted_total(cbm_daemon_runtime_se
 /* Includes accepted connections still waiting for HELLO. Never exceeds the
  * configured max_clients; over-cap peers receive REJECTED before close. */
 size_t cbm_daemon_runtime_service_active_connections(cbm_daemon_runtime_service_t *service);
+
+/* Re-evaluate an ephemeral generation that is lingering after its last committed
+ * client disconnected (the bounded cold-storm debounce). Retires it once the
+ * linger window elapses with no new client committing; the bound also rules out
+ * an unbounded idle hang. The host lifetime loop calls this every tick; it is a
+ * no-op unless a last-committed-client linger is armed. */
+void cbm_daemon_runtime_service_reconcile_lifetime(cbm_daemon_runtime_service_t *service);
 size_t cbm_daemon_runtime_service_job_subscribers(cbm_daemon_runtime_service_t *service,
                                                   const char *project_key);
 uint64_t cbm_daemon_runtime_service_client_process_id(cbm_daemon_runtime_service_t *service,
@@ -441,6 +448,12 @@ typedef void (*cbm_daemon_runtime_containment_hook_t)(const char *component);
 void cbm_daemon_runtime_set_abandoned_request_join_timeout_for_testing(uint32_t timeout_ms);
 void cbm_daemon_runtime_set_containment_hook_for_testing(
     cbm_daemon_runtime_containment_hook_t hook);
+/* Cold-storm ephemeral-linger seam (2026-09). Overrides the bounded linger
+ * window the last-committed-client retirement grants while cohort participants
+ * are mid-bootstrap, so a test drives both the linger and its expiry backstop
+ * in test time. UINT32_MAX restores the production constant; any other value
+ * (0 = expire immediately) overrides. Process-global; reset it after use. */
+void cbm_daemon_runtime_service_set_ephemeral_linger_timeout_for_testing(uint32_t timeout_ms);
 #endif
 
 #endif /* CBM_DAEMON_RUNTIME_H */

--- a/tests/test_daemon_runtime.c
+++ b/tests/test_daemon_runtime.c
@@ -2617,6 +2617,126 @@ TEST(daemon_runtime_final_disconnect_automatically_exits_within_bound) {
     PASS();
 }
 
+/* Cold-storm ephemeral-retirement gate (2026-09). A one-shot client sharing an
+ * ephemeral generation and racing connect() must not be stranded when another
+ * one-shot's connection just left. The generation lingers while a peer is still
+ * accepted (mid-HELLO) at the moment the last committed client disconnects; the
+ * accept loop retires it once the peer drains or a bounded window elapses. A raw
+ * connection (accepted, no HELLO sent) is exactly that racing peer. */
+#if defined(CBM_ENABLE_TEST_SEAMS)
+/* Direction 1 (the fix): with a peer accepted mid-HELLO, closing the last
+ * committed client leaves the generation RUNNING (lingering), not STOPPING, so
+ * the peer is not stranded. Reverting the active_connections gate flips
+ * `lingered` RED. A window far longer than the test keeps expiry from deciding
+ * the verdict. */
+TEST(daemon_runtime_ephemeral_lingers_while_peer_mid_hello) {
+    cbm_daemon_build_identity_t identity =
+        runtime_test_identity("2.4.0", runtime_test_self_build());
+    cbm_daemon_runtime_service_set_ephemeral_linger_timeout_for_testing(600000);
+    runtime_test_fixture_t fixture;
+    bool started = runtime_test_fixture_start(&fixture, "storm-peer", &identity);
+    cbm_daemon_runtime_client_t *client = NULL;
+    cbm_daemon_ipc_connection_t *peer = NULL;
+    cbm_daemon_runtime_connect_result_t result = {0};
+    bool peer_accepted = false;
+    bool lingered = false;
+    bool held_through_reconcile = false;
+
+    if (started) {
+        client = cbm_daemon_runtime_client_connect(fixture.endpoint, &identity,
+                                                   RUNTIME_TEST_TIMEOUT_MS, &result);
+    }
+    if (client) {
+        /* A racing peer: accepted (active_connections++), still mid-HELLO (no
+         * HELLO frame), so not a committed client. */
+        peer = cbm_daemon_ipc_connect(fixture.endpoint, RUNTIME_TEST_TIMEOUT_MS);
+        for (int i = 0; i < 1000 && !peer_accepted; i++) {
+            if (cbm_daemon_runtime_service_active_connections(fixture.service) >= 2) {
+                peer_accepted = true;
+                break;
+            }
+            cbm_usleep(2000);
+        }
+    }
+    if (peer_accepted) {
+        (void)cbm_daemon_runtime_client_close(client, RUNTIME_TEST_TIMEOUT_MS);
+        client = NULL;
+        lingered =
+            cbm_daemon_runtime_service_state(fixture.service) == CBM_DAEMON_RUNTIME_SERVICE_RUNNING;
+        cbm_daemon_runtime_service_reconcile_lifetime(fixture.service);
+        held_through_reconcile =
+            cbm_daemon_runtime_service_state(fixture.service) == CBM_DAEMON_RUNTIME_SERVICE_RUNNING;
+    }
+    if (peer) {
+        cbm_daemon_ipc_connection_close(peer);
+    }
+    if (client) {
+        (void)cbm_daemon_runtime_client_close(client, RUNTIME_TEST_TIMEOUT_MS);
+    }
+    cbm_daemon_runtime_service_set_ephemeral_linger_timeout_for_testing(UINT32_MAX);
+    runtime_test_fixture_finish(&fixture);
+
+    ASSERT_TRUE(started);
+    ASSERT_TRUE(peer_accepted);
+    ASSERT_TRUE(lingered);
+    ASSERT_TRUE(held_through_reconcile);
+    PASS();
+}
+
+/* Direction 2 (bounded, no hang): a peer that never commits must not wedge the
+ * lingering generation forever (the host_serving 900s hang). With the window
+ * collapsed to zero the accept loop reconcile reaches the backstop and retires
+ * even while the peer is still accepted. Removing the window backstop hangs
+ * this test. */
+TEST(daemon_runtime_ephemeral_linger_retires_within_bound) {
+    cbm_daemon_build_identity_t identity =
+        runtime_test_identity("2.4.0", runtime_test_self_build());
+    cbm_daemon_runtime_service_set_ephemeral_linger_timeout_for_testing(0);
+    runtime_test_fixture_t fixture;
+    bool started = runtime_test_fixture_start(&fixture, "storm-bound", &identity);
+    cbm_daemon_runtime_client_t *client = NULL;
+    cbm_daemon_ipc_connection_t *peer = NULL;
+    cbm_daemon_runtime_connect_result_t result = {0};
+    bool peer_accepted = false;
+    bool exited = false;
+
+    if (started) {
+        client = cbm_daemon_runtime_client_connect(fixture.endpoint, &identity,
+                                                   RUNTIME_TEST_TIMEOUT_MS, &result);
+    }
+    if (client) {
+        peer = cbm_daemon_ipc_connect(fixture.endpoint, RUNTIME_TEST_TIMEOUT_MS);
+        for (int i = 0; i < 1000 && !peer_accepted; i++) {
+            if (cbm_daemon_runtime_service_active_connections(fixture.service) >= 2) {
+                peer_accepted = true;
+                break;
+            }
+            cbm_usleep(2000);
+        }
+    }
+    if (peer_accepted) {
+        (void)cbm_daemon_runtime_client_close(client, RUNTIME_TEST_TIMEOUT_MS);
+        client = NULL;
+        /* Peer never commits + window already elapsed -> the bounded backstop in
+         * the accept loop reconcile must retire the generation, not hang. */
+        exited = cbm_daemon_runtime_service_wait_exited(fixture.service, RUNTIME_TEST_TIMEOUT_MS);
+    }
+    if (peer) {
+        cbm_daemon_ipc_connection_close(peer);
+    }
+    if (client) {
+        (void)cbm_daemon_runtime_client_close(client, RUNTIME_TEST_TIMEOUT_MS);
+    }
+    cbm_daemon_runtime_service_set_ephemeral_linger_timeout_for_testing(UINT32_MAX);
+    runtime_test_fixture_finish(&fixture);
+
+    ASSERT_TRUE(started);
+    ASSERT_TRUE(peer_accepted);
+    ASSERT_TRUE(exited);
+    PASS();
+}
+#endif
+
 TEST(daemon_runtime_authenticated_idle_connection_outlives_lease_interval) {
     cbm_daemon_build_identity_t identity =
         runtime_test_identity("2.4.0", runtime_test_self_build());
@@ -5002,6 +5122,10 @@ SUITE(daemon_runtime) {
     RUN_TEST(daemon_runtime_conflict_log_failure_uses_operation_log_fallback);
     RUN_TEST(daemon_runtime_disconnect_releases_only_connection_subscriptions);
     RUN_TEST(daemon_runtime_final_disconnect_automatically_exits_within_bound);
+#if defined(CBM_ENABLE_TEST_SEAMS)
+    RUN_TEST(daemon_runtime_ephemeral_lingers_while_peer_mid_hello);
+    RUN_TEST(daemon_runtime_ephemeral_linger_retires_within_bound);
+#endif
     RUN_TEST(daemon_runtime_authenticated_idle_connection_outlives_lease_interval);
     RUN_TEST(daemon_runtime_connection_cap_covers_slow_hello_and_stopping_is_terminal);
     RUN_TEST(daemon_runtime_rejects_forged_identity_extension);


### PR DESCRIPTION
### Problem

A burst of one-shot clients (e.g. six parallel `cli list_projects`) shares one **ephemeral** daemon generation and races to connect. The generation retired the instant its last *committed* client disconnected — even when another one-shot's connection was already **accepted and still mid-HELLO** — stranding that racer on a `STOPPING` daemon and forcing a full cold respawn (up to the 12 s daemon-claim handoff each). Under load the retire/respawn churn exhausts a client's 30 s bootstrap budget.

This is the root cause of two intermittent CI failures:
- **`test-windows-guards` → `section_cold_storm`**: *"cold-storm client failed (racing daemon spawn)"* (a `test_daemon_stability.py` regression guard).
- **POSIX `host_serving`**: a startup that never reaches "serving" (or the 900 s `cli`-suite hang).

Both are content-disjoint flakes that gate the install/memory fix queue.

### Fix

When the last committed client of an ephemeral, non-permanent generation disconnects, **linger a bounded window iff a peer connection is already accepted but has not yet passed HELLO admission** (`in_use`, connected, `!admitted`, not disconnecting — `runtime_has_pending_hello_peer_locked`). The accept loop's `reconcile_lifetime` retires the generation once that racer drains without committing **or** the bounded window (`RUNTIME_EPHEMERAL_LINGER_MS`, test-seam-overridable) elapses; a racer that commits clears the linger. With no such racer — the common single-client case — the generation retires **immediately, unchanged**.

The linger deliberately covers **only a pre-HELLO racer**, never an already-admitted **provisional** session (HELLO done, app session opening): the contract that a provisional coordinator client cannot keep a retiring generation alive is **preserved** (`daemon_runtime_final_disconnect_rejects_blocked_provisional_session` stays green).

The daemon cannot count cross-process cohort peers (advisory locks expose presence, not a holder count; Windows `LockFileEx` has no non-owning probe), so this uses the one peer signal it has locally — accepted-but-unadmitted connections. The window is bounded, so a racer that never commits cannot wedge the generation (no unbounded idle hang).

The coordinator gains a transient `linger` hold (distinct from `permanent`) so its own last-client self-transition to `STOPPING` is suppressed while the racer is outstanding; clearing it while idle retires the coordinator at once.

### Verification (macOS, sanitized build)

- daemon suites **224 passed / 0 failed / 1 skipped** (the skip is the pre-existing Linux-only userns case).
- New tests pin both directions:
  - `daemon_runtime_ephemeral_lingers_while_peer_mid_hello` — a raw accepted-but-unHELLO'd peer keeps the generation `RUNNING` after the committed client leaves.
  - `daemon_runtime_ephemeral_linger_retires_within_bound` — the bounded backstop retires even while the peer is still accepted.
- **RED on revert**: neutering the gate flips exactly `ASSERT(lingered)` (`test_daemon_runtime.c`) and nothing else.
- `clang-format` (Homebrew LLVM) + `cppcheck` + NOLINT clean.

⚠️ The Windows `section_cold_storm` guard is the integration confirmation — its VM run is the final check before merge (the arm64 VM covers the native path; x64 is CI's `test-windows-guards`).
