### PR TITLE
fix(extract): budget tree-sitter parses by thread CPU time, not wall clock

### DIFF
--- a/internal/cbm/cbm.c
+++ b/internal/cbm/cbm.c
@@ -213,9 +213,42 @@ static const char *cbm_string_read(void *payload, uint32_t byte, TSPoint point,
 
 // --- Parse timeout callback ---
 
+/* Budget for the tree-sitter progress callback. The PRIMARY gate is per-thread
+ * CPU time: a worker descheduled under CI contention burns WALL time but not
+ * CPU, so a starved-but-parseable file must NOT be abandoned merely because the
+ * 5 s budget elapsed in wall-clock against near-zero CPU. That false "parse
+ * timeout" silently dropped a file's defs and, with them, every cross-file edge
+ * those defs anchored (e.g. a Celery.send_task definition backing an ASYNC_CALLS
+ * edge). A generous WALL ceiling stays as a backstop so a genuinely
+ * stuck/spinning parse still terminates in bounded time. */
+#define CBM_PARSE_WALL_CEILING_FACTOR 12ULL /* ~60 s ceiling for the 5 s CPU budget */
+
+typedef struct {
+    uint64_t cpu_deadline_ns; // trip once this thread's CPU time passes it
+    uint64_t wall_ceiling_ns; // hard wall backstop for a spinning/stuck parse
+} CBMParseBudget;
+
+#ifdef CBM_ENABLE_TEST_SEAMS
+/* Deterministic RED-repro seam (armed by CBM_TEST_WALL_STALL_ON in
+ * cbm_extract_file_ex): when set, the timeout callback reads the WALL clock this
+ * many ns ahead of reality while CPU time is untouched — emulating a worker
+ * descheduled long enough for the old wall-only budget to elapse against
+ * near-zero CPU. With the CPU-time budget the parse still completes; a wall-only
+ * / tight-ceiling budget drops the file. Thread-local so it cannot leak across
+ * worker threads. Compiled only into seam-enabled test artifacts. */
+static CBM_TLS uint64_t tl_parse_wall_seam_offset_ns = 0;
+#endif
+
+/* tree-sitter's TSProgressCallback mandates a non-const TSParseState*; a const
+ * parameter here would not match the opts.progress_callback assignment below. */
+// cppcheck-suppress constParameterCallback
 static bool cbm_timeout_cb(TSParseState *state) {
-    uint64_t deadline = *(uint64_t *)state->payload;
-    return now_ns() > deadline;
+    const CBMParseBudget *budget = (const CBMParseBudget *)state->payload;
+    uint64_t wall = now_ns();
+#ifdef CBM_ENABLE_TEST_SEAMS
+    wall += tl_parse_wall_seam_offset_ns;
+#endif
+    return cbm_thread_cpu_time_ns() > budget->cpu_deadline_ns || wall > budget->wall_ceiling_ns;
 }
 
 // --- Thread-local parser pool ---
@@ -1620,11 +1653,26 @@ static CBMFileResult *extract_file_ex_body(const char *source, int source_len, C
     };
 
     TSParseOptions opts = {0};
-    uint64_t deadline_ns = 0; // cppcheck-suppress unreadVariable
+    CBMParseBudget budget = {0}; // cppcheck-suppress unreadVariable
     if (timeout_micros > 0) {
-        deadline_ns = t0 + ((uint64_t)timeout_micros * USEC_TO_NSEC);
-        opts.payload = &deadline_ns;
+        uint64_t budget_ns = (uint64_t)timeout_micros * USEC_TO_NSEC;
+        // Descheduling burns wall time but not CPU: gate on this thread's CPU
+        // time so a starved-but-parseable file is not abandoned, with a generous
+        // wall ceiling as a backstop against a genuinely spinning/stuck parse.
+        budget.cpu_deadline_ns = cbm_thread_cpu_time_ns() + budget_ns;
+        budget.wall_ceiling_ns = t0 + budget_ns * CBM_PARSE_WALL_CEILING_FACTOR;
+        opts.payload = &budget;
         opts.progress_callback = cbm_timeout_cb;
+#ifdef CBM_ENABLE_TEST_SEAMS
+        tl_parse_wall_seam_offset_ns = 0;
+        const char *stall_on = getenv("CBM_TEST_WALL_STALL_ON");
+        if (stall_on && stall_on[0] && rel_path && strstr(rel_path, stall_on)) {
+            // Push the wall reading past the 1x budget (the old wall-only budget
+            // trips) but well under the generous ceiling (the CPU-time budget
+            // survives): budget + 1 s, deterministic, no real timing involved.
+            tl_parse_wall_seam_offset_ns = budget_ns + NSEC_PER_SEC;
+        }
+#endif
     }
 
     TSTree *tree = ts_parser_parse_with_options(parser, NULL, ts_input, opts);

--- a/src/foundation/compat.c
+++ b/src/foundation/compat.c
@@ -316,6 +316,30 @@ int cbm_clock_gettime(int clk_id, struct timespec *tp) {
 }
 #endif
 
+/* ── Per-thread CPU time ──────────────────────────────────────── */
+
+uint64_t cbm_thread_cpu_time_ns(void) {
+#ifdef _WIN32
+    FILETIME creation, exit_time, kernel, user;
+    if (!GetThreadTimes(GetCurrentThread(), &creation, &exit_time, &kernel, &user)) {
+        return 0;
+    }
+    /* kernel/user each carry a 64-bit count of 100-ns ticks split across a
+     * FILETIME's two DWORDs; recombine, sum, and scale to nanoseconds. The
+     * shift-combine avoids casting to ULARGE_INTEGER (alignment-unsafe per
+     * MSDN, and its union members trip cppcheck's unreadVariable). */
+    uint64_t kernel_ticks = ((uint64_t)kernel.dwHighDateTime << 32) | kernel.dwLowDateTime;
+    uint64_t user_ticks = ((uint64_t)user.dwHighDateTime << 32) | user.dwLowDateTime;
+    return (kernel_ticks + user_ticks) * 100ULL;
+#else
+    struct timespec ts;
+    if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) != 0) {
+        return 0;
+    }
+    return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+#endif
+}
+
 /* ── getline (Windows lacks it) ───────────────────────────────── */
 
 #ifdef _WIN32

--- a/src/foundation/compat.h
+++ b/src/foundation/compat.h
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 /* stdlib.h declares getenv (cbm_tmpdir) and, on Windows, _putenv_s (cbm_setenv/
  * cbm_unsetenv). The x86-64 mingw toolchain pulled it in transitively, but the
@@ -98,6 +99,16 @@ static inline int cbm_nanosleep(const struct timespec *req, struct timespec *rem
 
 /* Sleeps for the full requested duration even when POSIX signals interrupt it. */
 int cbm_nanosleep_full(const struct timespec *req);
+
+/* Per-CALLING-THREAD CPU time in nanoseconds. Unlike cbm_clock_gettime — which
+ * measures WALL time on every platform (QueryPerformanceCounter on Windows) —
+ * this advances only while the calling thread is actually scheduled on a CPU, so
+ * a descheduled/starved thread accrues (almost) none. Use it to budget work
+ * against real CPU consumed rather than wall-clock, which a contended host
+ * inflates without the thread doing any work. POSIX (incl. macOS 10.12+):
+ * CLOCK_THREAD_CPUTIME_ID. Windows: GetThreadTimes kernel+user. Returns 0 if the
+ * platform clock is unavailable. Implemented in compat.c. */
+uint64_t cbm_thread_cpu_time_ns(void);
 
 /* ── gmtime_r (Windows lacks it) ─────────────────────────────── */
 #ifdef _WIN32

--- a/tests/test_edge_types_probe.c
+++ b/tests/test_edge_types_probe.c
@@ -842,6 +842,37 @@ TEST(async_calls_celery_python) {
     PASS();
 }
 
+/* RED-repro: a wall-clock / scheduling artifact must NOT drop a parseable
+ * file's defs. The CBM_TEST_WALL_STALL_ON seam forces the parse-timeout callback
+ * to read the WALL clock as (budget + 1 s) ahead while CPU time is untouched —
+ * emulating a worker descheduled under CI contention. celery/app.py DEFINES
+ * Celery.send_task; under the old wall-only 5 s budget that file is abandoned
+ * with zero defs, the "celery" QN the caller resolves against vanishes, and the
+ * ASYNC_CALLS edge count drops to 0 (the intermittent async_calls_celery_python
+ * failure). With the CPU-time budget the parse still completes (CPU under budget,
+ * wall under the generous ceiling) and the edge survives. Deterministic: the
+ * seam is a fixed offset, never real timing. Binds only under CBM_ENABLE_TEST_SEAMS
+ * (always set for the test-runner); a no-seam build exercises the plain edge. */
+TEST(async_calls_celery_wall_stall_seam) {
+    static const EtFile f[] = {
+        {"celery/app.py",
+         "class Celery:\n"
+         "    def task(self):\n        def decorator(fn): return fn\n        return decorator\n\n"
+         "    def send_task(self, name, args=None): return (name, args)\n\n"
+         "app = Celery()\n"},
+        {"tasks/order_tasks.py",
+         "from celery.app import app\n\n\n"
+         "def dispatch_order_created(order_id):\n"
+         "    return app.send_task('order_created', args=[order_id])\n\n\n"
+         "def dispatch_order_shipped(order_id):\n"
+         "    return app.send_task('order_shipped', args=[order_id])\n"}};
+    cbm_setenv("CBM_TEST_WALL_STALL_ON", "celery/app.py", 1);
+    int ok = et_edge_present(f, 2, "ASYNC_CALLS", 1);
+    cbm_unsetenv("CBM_TEST_WALL_STALL_ON");
+    ASSERT_TRUE(ok);
+    PASS();
+}
+
 /* Sidekiq (Ruby) — "Sidekiq" substring in resolved QN */
 TEST(async_calls_sidekiq_ruby) {
     static const EtFile f[] = {
@@ -1625,6 +1656,7 @@ SUITE(edge_types_probe) {
 
     /* ASYNC_CALLS — message queue dispatch (5 brokers × languages) */
     RUN_TEST(async_calls_celery_python);
+    RUN_TEST(async_calls_celery_wall_stall_seam);
     RUN_TEST(async_calls_sidekiq_ruby);
     RUN_TEST(async_calls_kafkajs_ts);
     RUN_TEST(async_calls_sqs_go);


### PR DESCRIPTION
### Problem

The per-file tree-sitter parse in extract was bounded by a **5 s WALL-CLOCK** budget. Under CI contention a worker thread can be descheduled long enough for 5 s of *wall* time to elapse against near-zero CPU, so a small, perfectly parseable file was abandoned with a false `parse timeout` and yielded **zero defs**. When that file *defines* a symbol other files resolve against (e.g. `celery.app.Celery.send_task` backing an `ASYNC_CALLS` edge, or a `userpb` gRPC client backing `GRPC_CALLS`), the cross-file service edge then failed to classify — surfacing as the intermittent `convergence_probe` / `edge_types_probe` service-edge assertions (count 0). The verdict was decided by wall-clock scheduling rather than the input — an O9 "no timeout decides a test" defect, and a real production defect (a loaded host silently under-indexes a trivial file).

(The cross-file resolution path itself is provably deterministic — a hard join barrier, content-deterministic #787 merge, sealed read-only cross-LSP registries, thread-local resolve caches — so this is not a resolution race.)

### Fix

Gate the parse on **per-thread CPU time**, with a generous **wall ceiling** as a backstop:

- New portable helper `cbm_thread_cpu_time_ns()` (`compat.c/.h`): POSIX/macOS `clock_gettime(CLOCK_THREAD_CPUTIME_ID)`, Windows `GetThreadTimes` (kernel+user, 100 ns units → ns). Returns 0 on clock failure → degrades safely to the wall ceiling. Deliberately **not** `cbm_clock_gettime` (wall on every platform; QPC on Windows).
- The progress-callback payload becomes `{cpu_deadline_ns, wall_ceiling_ns}`; it trips when this thread's CPU time passes the budget **or** wall time passes `t0 + budget × 12` (~60 s for the 5 s budget). Descheduling burns wall, not CPU, so a starved-but-parseable file survives; a CPU-spinning parse still trips the CPU deadline; a genuinely stuck parse still trips the wall ceiling (bounded — no hang).

### RED-repro (deterministic, `CBM_ENABLE_TEST_SEAMS` only)

A thread-local wall-clock offset armed by env `CBM_TEST_WALL_STALL_ON` emulates a descheduled worker (wall reads `budget + 1 s` ahead while CPU is untouched — above the old 1× wall budget, below the ceiling). `async_calls_celery_wall_stall_seam` arms it for the Celery **definition** file and asserts `ASYNC_CALLS ≥ 1`.

### Verification (macOS, sanitized ASan/UBSan)

| State | Result |
|---|---|
| **GREEN-with-fix** | `edge_types_probe` + `convergence_probe` → **107 passed / 0 failed** |
| **RED-on-revert** (budget → wall-only + 1× ceiling, seam kept) | **58 passed / 1 failed** — only `async_calls_celery_wall_stall_seam` at the `ASYNC_CALLS` assertion |
| **GREEN-restored** | **107 passed / 0 failed** |
| Regression smoke (`extraction parse_coverage pipeline lang_contract grammar_regression`) | **698 passed / 0 failed** |

`lint-ci` clean (cppcheck + clang-format Homebrew LLVM + NOLINT). The Windows `GetThreadTimes` path is compile-checked by CI (not runnable on macOS).
