### PR TITLE
fix(ci): grant the security permissions in dry-run.yml, and derive the caller list

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -58,6 +58,13 @@ jobs:
   # ── Security (independent island — does not block main pipeline) ──
   security:
     uses: ./.github/workflows/_security.yml
+    # The called job requests security-events:read to count code-scanning
+    # alerts; a reusable workflow cannot request more than its caller grants,
+    # so withholding this here fails the whole run at startup.
+    permissions:
+      contents: read
+      security-events: read
+      actions: read
     secrets: inherit
 
   # ── Lint (cppcheck + clang-format) ────────────────────────────

--- a/tests/test_security_gate_fail_closed.sh
+++ b/tests/test_security_gate_fail_closed.sh
@@ -98,8 +98,25 @@ require(
 #    downgrade, it fails the entire run with a startup_failure before a single
 #    job executes. Checking only the called workflow is how this test passed
 #    while the PR pipeline never started.
-for caller_name in ("pr.yml", "release.yml"):
-    caller = (root / ".github" / "workflows" / caller_name).read_text(encoding="utf-8")
+#    The caller list is DERIVED, never hardcoded. An earlier revision listed
+#    ("pr.yml", "release.yml") by hand and stayed green while dry-run.yml -- a
+#    third caller nobody had listed -- failed every run at startup. A test that
+#    only checks the callers you remembered cannot catch the one you forgot.
+workflow_dir = root / ".github" / "workflows"
+callers = sorted(
+    path.name
+    for path in workflow_dir.glob("*.yml")
+    if "uses: ./.github/workflows/_security.yml" in path.read_text(encoding="utf-8")
+)
+require(
+    len(callers) >= 3,
+    "expected at least 3 callers of _security.yml, found: "
+    + (", ".join(callers) or "none")
+    + " -- if a caller was deliberately removed, lower this floor on purpose",
+)
+
+for caller_name in callers:
+    caller = (workflow_dir / caller_name).read_text(encoding="utf-8")
     # The next sibling may be a comment line, not a key, so the lookahead has to
     # accept any 2-space-indented non-space -- matching only `  \w` silently
     # failed to find release.yml's job at all.


### PR DESCRIPTION
#2189 gave `codeql-gate` the `security-events: read` it needs to actually see code-scanning alerts, and granted it at the two callers I knew about — `pr.yml` and `release.yml`.

**There is a third.** `dry-run.yml` calls the same reusable workflow and was left granting only the workflow default, so every dispatch of it now fails at **startup** — before a single job runs, with no job output to explain why. Observed immediately on dispatch: run `34725401182` on `7d74337e`, `startup_failure`.

### Why the contract test missed it

It iterated a hardcoded `("pr.yml", "release.yml")`. A test that checks only the callers you remembered cannot catch the one you forgot — and it reports green while doing so. That is the same shape of false assurance as the 403-to-"0 alerts" bug this contract exists to prevent.

The caller list is now **derived**: every workflow containing `uses: ./.github/workflows/_security.yml` must grant `security-events: read` and `actions: read`, with a floor of three callers so a silent deletion is noticed too.

Reverting only `dry-run.yml`'s grant now fails the test by name:

```
- dry-run.yml must grant security-events: read to the security job
- dry-run.yml must grant actions: read to the security job
```